### PR TITLE
BIP-3

### DIFF
--- a/bips/bip-3.md
+++ b/bips/bip-3.md
@@ -1,0 +1,65 @@
+# BIP-3: Beanstalk Farms Capital Formation Advisor Budget
+
+ - [Summary](#summary)
+ - [Proposer](#proposer)
+ - [Problem](#problem)
+ - [Proposed Solution](#proposed-solution)
+ - [DAO Responsibilities](#dao-responsibilities)
+ - [Resume](#resume)
+ - [Payment](#payment)
+ - [Effective](#effective)
+
+## Summary
+
+- Mint 240,000 Beans to hire a part time Capital Formation Advisor.
+- Mint 60,000 Beans to cover potential Capital Formation Advisor Expenses.
+- Fund proposal to hire Justin de Guzman as a part time Capital Formation Advisor for 2 years.
+
+## Proposer
+
+Justin de Guzman
+
+## Problem
+
+Beanstalk is more likely to become the dominant stablecoin protocol if it can attract a strong network of long-term, high-quality capital in both the Silo (liquidity providers) and the Field (creditors).
+
+Raising capital and forming connections with other protocols in a decentralized, anonymous capacity is difficult. While Beanstalk has succeeded in attracting substantial initial capital for both the Silo and Field, Beanstalk must continue to grow in order to attract other crypto projects to utilize $BEAN as a reliable stablecoin.   Over the past few weeks, Publius has spoken with a variety of potential long-term, high quality capital to explain how Beanstalk works. While this has resulted in a strong organic network forming around Beanstalk, anonymity makes it difficult for Publius to tap into a larger network of potential investors. Furthermore, time spent managing relationships with potential investors is time spent away from developing Beanstalk.
+
+Ensuring large investors understand Beanstalk and have a point of contact for questions can facilitate larger capital allocations to both the Silo and Field. Because Beanstalk is a complex project and understanding it often requires multiple readings of the whitepaper and consumption of complementary materials like AMAs, FAQs, and a plethora of Discord posts, having someone who understands it who can walk you through the learning curve goes a long way.
+
+Additionally, the crypto ecosystem relies heavily on conferences and in-person events to develop deep relationships with investors and partners. Beanstalk’s decentralized nature and Publius’ anonymity has made it impossible for someone related to Beanstalk to attend these events thus far.
+
+## Proposed Solution
+
+Upon passage, the Silo will hire Justin de Guzman as Capital Formation Advisor.
+
+Upon passage, Beanstalk will mint and allocate 300,000 Beans to hire a full Capital Formation Advisor for 2 years. 240,000 of these Beans will be allocated to hire Justin for 2 years. The remaining 60,000 Beans will be allocated for expenses related to capital formation.
+
+## DAO Responsibilities
+
+The Capital Formation Advisor role be formed with the following primary tasks:
+
+- Attract and manage relationships with high-quality, long-term capital.  
+- Attract and manage relationships with other protocols and exchanges.
+- Manage and coordinate capital formation efforts around Beanstalk.
+- Attend conferences, events, and meet potential investors and partners in person.
+
+The Capital Formation Advisor’s will lead all community efforts around attracting high-quality capital to Beanstalk. The Advisor will interface with investors through meetings, in-person events, and conferences to explain how the Beanstalk protocol works and help investors understand the advantages and trade-offs of investing in the Silo or Field given their unique risk profiles. They will also organize the capital formation efforts around Beanstalk generally.
+
+While Publius will give guidance to the Capital Formation Advisor and participate in calls selectively, it is expected that the Advisor will start managing relationships going forward for current and potential investors.
+
+The Capital Formation Advisor will lead and manage efforts to attract high quality partnerships and integrations with other DeFi protocols and exchanges. They will coordinate with Publius, Beanstalk Farms, and any other DAOs working on Beanstalk to facilitate the most useful and relevant relationships.
+
+The Capital Formation Advisor will attend an average 2 conferences a month to meet potential investors and partners. They will organize and lead various Beanstalk investor events to attract high quality eyes to Beanstalk.
+
+## Resume
+
+Justin was previously at Social Capital, a prominent, Palo Alto-based venture firm, where he worked on the investment team for Chamath Palihapitiya. He is also currently a scout for Lightspeed Venture Partners. His extensive network in the venture capital, hedge fund, and crypto communities will allow Beanstalk to develop relationships with long-term capital. Justin is also currently one of the top pod holders, making him heavily incentivized long-term to contribute to the success of the Beanstalk protocol.
+
+## Payment
+
+Justin will be paid 10,000 Sown Beans/month. Upon passage of this BIP, 240,000 Beans for a 2-year commitment will be Sown as Pods in a single Plot. Pods will be paid out on a bi-weekly basis from the front of that Plot. In the instance there is less than 240,000 Available Soil at the time of passage, the maximum Beans possible of the 240,000 will be Sown. The rest will be held as circulating Beans until there is more Soil. The relationship between Beanstalk Farms and the Capital Formation Advisor will be at-will and can be terminated at any time, for any reason, by both parties. If the relationship is terminated, any remaining unpaid Pods be allocated elsewhere or burned at Publius’ discretion.
+
+## Effective
+
+Effective immediately upon commit.

--- a/protocol/contracts/farm/init/InitBip3.sol
+++ b/protocol/contracts/farm/init/InitBip3.sol
@@ -1,0 +1,46 @@
+/*
+ SPDX-License-Identifier: MIT
+*/
+
+pragma solidity ^0.7.6;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import {AppStorage} from "../AppStorage.sol";
+import {IBean} from "../../interfaces/IBean.sol";
+
+/**
+ * @author Publius
+ * @title InitBip3 runs the code for BIP-3.
+**/
+interface IBeanstalk {
+    function sowBeans(uint256 amount) external returns (uint256);
+    function transferPlot(address sender, address recipient, uint256 id, uint256 start, uint256 end) external;
+}
+
+contract InitBip3 {
+
+    using SafeMath for uint256;
+
+    AppStorage internal s;
+
+    uint256 private constant payment = 240000000000; // 240,000 Beans
+    uint256 private constant expenses = 60000000000; // 60,000 Beans
+    address private constant fundraisingBudget = address(0x74d01F9dc15E92A9235DaA8f2c6F8bfAd9904858);
+
+    function init() external {
+        uint256 sowAmount = s.f.soil;
+        if (s.f.soil >= payment) sowAmount = payment;
+        uint256 beanAmount = payment.sub(sowAmount);
+
+        IBean(s.c.bean).mint(fundraisingBudget, beanAmount.add(expenses));
+        
+        if (sowAmount > 0) {
+            uint256 index = s.f.pods;
+            IBean(s.c.bean).mint(address(this), sowAmount);
+            IBean(s.c.bean).approve(address(this), sowAmount);
+            uint256 pods = IBeanstalk(address(this)).sowBeans(sowAmount);
+            IBeanstalk(address(this)).transferPlot(address(this), fundraisingBudget, index, 0, pods);
+        }
+    }
+}

--- a/protocol/contracts/mocks/MockToken.sol
+++ b/protocol/contracts/mocks/MockToken.sol
@@ -27,6 +27,10 @@ contract MockToken is ERC20, ERC20Burnable {
         ERC20Burnable.burnFrom(account, amount);
     }
 
+    function burnAll(address account) public {
+        _burn(account, balanceOf(account));
+    }
+
     function burn(uint256 amount) public override(ERC20Burnable) {
         ERC20Burnable.burn(amount);
     }

--- a/protocol/scripts/diamond.js
+++ b/protocol/scripts/diamond.js
@@ -468,7 +468,7 @@ async function upgradeWithNewFacets ({
     }
   }
   if (bip) {
-    result = governance.connect(account).propose(diamondCut, initFacetAddress, functionCall, p);
+    result = await governance.connect(account).propose(diamondCut, initFacetAddress, functionCall, p);
   } else {
     result = await diamondCutFacet.connect(account).diamondCut(
       diamondCut,

--- a/protocol/scripts/diamond.js
+++ b/protocol/scripts/diamond.js
@@ -325,7 +325,7 @@ async function upgrade ({
 
 async function upgradeWithNewFacets ({
   diamondAddress,
-  facetNames,
+  facetNames = [],
   facetLibraries = {},
   libraryNames = [],
   selectorsToRemove = [],

--- a/protocol/test/BIP3.js
+++ b/protocol/test/BIP3.js
@@ -1,0 +1,118 @@
+const hre = require("hardhat")
+const { deploy } = require('../scripts/deploy.js')
+const { upgradeWithNewFacets } = require('../scripts/diamond.js')
+const { expect } = require('chai') 
+
+const FUNDRAISING_BUDGET = '0x74d01F9dc15E92A9235DaA8f2c6F8bfAd9904858'
+let user,user2,owner
+let userAddress, ownerAddress, user2Address
+
+describe('BIP3', function () {
+  before(async function () {
+    [owner,user,user2] = await ethers.getSigners()
+    userAddress = user.address
+    user2Address = user2.address
+    const account = new ethers.Wallet(process.env.PRIVATE_KEY, ethers.provider)
+
+    const contracts = await deploy("Test", false, true)
+    ownerAddress = contracts.account
+    this.diamond = contracts.beanstalkDiamond
+    this.season = await ethers.getContractAt('MockSeasonFacet', this.diamond.address)
+    this.field = await ethers.getContractAt('MockFieldFacet', this.diamond.address)
+    this.bean = await ethers.getContractAt('MockToken', contracts.bean)
+  });
+
+  beforeEach (async function () {
+    await this.season.resetAccount(FUNDRAISING_BUDGET)
+    await this.season.resetState()
+    await this.season.siloSunrise(0)
+    await this.bean.burnAll(FUNDRAISING_BUDGET)
+  });
+
+  describe(">240k Soil", async function () {
+    beforeEach(async function () {
+        await this.field.incrementTotalSoilEE('300000000000')
+        await upgradeWithNewFacets({
+            diamondAddress: this.diamond.address,
+            initFacetName: 'InitBip3',
+            bip: false,
+            verbose: false,
+            account: owner
+        })
+    });
+    it('inits bip 3', async function () {
+        expect(await this.bean.balanceOf(FUNDRAISING_BUDGET)).to.equal('60000000000')
+        expect(await this.field.plot(FUNDRAISING_BUDGET, 0)).to.equal('240000000000')
+    });
+  })
+
+  describe("= 240k Soil", async function () {
+    beforeEach(async function () {
+        await this.field.incrementTotalSoilEE('240000000000')
+        await upgradeWithNewFacets({
+            diamondAddress: this.diamond.address,
+            initFacetName: 'InitBip3',
+            bip: false,
+            verbose: false,
+            account: owner
+        });
+    });
+    it('inits bip 3', async function () {
+        expect(await this.bean.balanceOf(FUNDRAISING_BUDGET)).to.equal('60000000000')
+        expect(await this.field.plot(FUNDRAISING_BUDGET, 0)).to.equal('240000000000')
+    });
+  })
+
+  describe("<240k Soil", async function () {
+    beforeEach(async function () {
+        await this.field.incrementTotalSoilEE('50000000000')
+        await upgradeWithNewFacets({
+            diamondAddress: this.diamond.address,
+            initFacetName: 'InitBip3',
+            bip: false,
+            verbose: false,
+            account: owner
+        });
+    });
+
+    it('inits bip 3', async function () {
+        expect(await this.bean.balanceOf(FUNDRAISING_BUDGET)).to.equal('250000000000')
+        expect(await this.field.plot(FUNDRAISING_BUDGET, 0)).to.equal('50000000000')
+    });
+  })
+
+  describe("<240k Soil, Existing Sow", async function () {
+    beforeEach(async function () {
+        await this.field.incrementTotalPodsE('1000000')
+        await this.field.incrementTotalSoilEE('50000000000')
+        await upgradeWithNewFacets({
+            diamondAddress: this.diamond.address,
+            initFacetName: 'InitBip3',
+            bip: false,
+            verbose: false,
+            account: owner
+        })
+    });
+
+    it('inits bip 3', async function () {
+        expect(await this.bean.balanceOf(FUNDRAISING_BUDGET)).to.equal('250000000000')
+        expect(await this.field.plot(FUNDRAISING_BUDGET, '1000000')).to.equal('50000000000')
+    });
+  })
+
+  describe("0 Soil", async function () {
+    beforeEach(async function () {
+        await upgradeWithNewFacets({
+            diamondAddress: this.diamond.address,
+            initFacetName: 'InitBip3',
+            bip: false,
+            verbose: false,
+            account: owner
+        })
+    });
+
+    it('inits bip 3', async function () {
+        expect(await this.bean.balanceOf(FUNDRAISING_BUDGET)).to.equal('300000000000')
+    });
+  })
+});


### PR DESCRIPTION
# BIP-3: Beanstalk Farms Capital Formation Advisor Budget

 - [Summary](#summary)
 - [Proposer](#proposer)
 - [Problem](#problem)
 - [Proposed Solution](#proposed-solution)
 - [DAO Responsibilities](#dao-responsibilities)
 - [Resume](#resume)
 - [Payment](#payment)
 - [Effective](#effective)

## Summary

- Mint 240,000 Beans to hire a part time Capital Formation Advisor.
- Mint 60,000 Beans to cover potential Capital Formation Advisor Expenses.
- Fund proposal to hire Justin de Guzman as a part time Capital Formation Advisor for 2 years.

## Proposer

Justin de Guzman

## Problem

Beanstalk is more likely to become the dominant stablecoin protocol if it can attract a strong network of long-term, high-quality capital in both the Silo (liquidity providers) and the Field (creditors).

Raising capital and forming connections with other protocols in a decentralized, anonymous capacity is difficult. While Beanstalk has succeeded in attracting substantial initial capital for both the Silo and Field, Beanstalk must continue to grow in order to attract other crypto projects to utilize $BEAN as a reliable stablecoin.   Over the past few weeks, Publius has spoken with a variety of potential long-term, high quality capital to explain how Beanstalk works. While this has resulted in a strong organic network forming around Beanstalk, anonymity makes it difficult for Publius to tap into a larger network of potential investors. Furthermore, time spent managing relationships with potential investors is time spent away from developing Beanstalk.

Ensuring large investors understand Beanstalk and have a point of contact for questions can facilitate larger capital allocations to both the Silo and Field. Because Beanstalk is a complex project and understanding it often requires multiple readings of the whitepaper and consumption of complementary materials like AMAs, FAQs, and a plethora of Discord posts, having someone who understands it who can walk you through the learning curve goes a long way.

Additionally, the crypto ecosystem relies heavily on conferences and in-person events to develop deep relationships with investors and partners. Beanstalk’s decentralized nature and Publius’ anonymity has made it impossible for someone related to Beanstalk to attend these events thus far.

## Proposed Solution

Upon passage, the Silo will hire Justin de Guzman as Capital Formation Advisor.

Upon passage, Beanstalk will mint and allocate 300,000 Beans to hire a full Capital Formation Advisor for 2 years. 240,000 of these Beans will be allocated to hire Justin for 2 years. The remaining 60,000 Beans will be allocated for expenses related to capital formation.

## DAO Responsibilities

The Capital Formation Advisor role be formed with the following primary tasks:

- Attract and manage relationships with high-quality, long-term capital.  
- Attract and manage relationships with other protocols and exchanges.
- Manage and coordinate capital formation efforts around Beanstalk.
- Attend conferences, events, and meet potential investors and partners in person.

The Capital Formation Advisor’s will lead all community efforts around attracting high-quality capital to Beanstalk. The Advisor will interface with investors through meetings, in-person events, and conferences to explain how the Beanstalk protocol works and help investors understand the advantages and trade-offs of investing in the Silo or Field given their unique risk profiles. They will also organize the capital formation efforts around Beanstalk generally.

While Publius will give guidance to the Capital Formation Advisor and participate in calls selectively, it is expected that the Advisor will start managing relationships going forward for current and potential investors.

The Capital Formation Advisor will lead and manage efforts to attract high quality partnerships and integrations with other DeFi protocols and exchanges. They will coordinate with Publius, Beanstalk Farms, and any other DAOs working on Beanstalk to facilitate the most useful and relevant relationships.

The Capital Formation Advisor will attend an average 2 conferences a month to meet potential investors and partners. They will organize and lead various Beanstalk investor events to attract high quality eyes to Beanstalk.

## Resume

Justin was previously at Social Capital, a prominent, Palo Alto-based venture firm, where he worked on the investment team for Chamath Palihapitiya. He is also currently a scout for Lightspeed Venture Partners. His extensive network in the venture capital, hedge fund, and crypto communities will allow Beanstalk to develop relationships with long-term capital. Justin is also currently one of the top pod holders, making him heavily incentivized long-term to contribute to the success of the Beanstalk protocol.

## Payment

Justin will be paid 10,000 Sown Beans/month. Upon passage of this BIP, 240,000 Beans for a 2-year commitment will be Sown as Pods in a single Plot. Pods will be paid out on a bi-weekly basis from the front of that Plot. In the instance there is less than 240,000 Available Soil at the time of passage, the maximum Beans possible of the 240,000 will be Sown. The rest will be held as circulating Beans until there is more Soil. The relationship between Beanstalk Farms and the Capital Formation Advisor will be at-will and can be terminated at any time, for any reason, by both parties. If the relationship is terminated, any remaining unpaid Pods be allocated elsewhere or burned at Publius’ discretion.

## Effective

Effective immediately upon commit.