### PR TITLE
BIP-X: Fungible Deposits + Bean/LP Silo V2

### DIFF
--- a/protocol/contracts/farm/facets/SiloFacet/BeanSilo.sol
+++ b/protocol/contracts/farm/facets/SiloFacet/BeanSilo.sol
@@ -68,6 +68,12 @@ contract BeanSilo is LPSilo {
         LibCheck.beanBalanceCheck();
     }
 
+    function _transferBeans(uint32[] calldata crates, uint256[] calldata amounts, address transferTo)
+        internal
+    {
+
+    }
+
     function removeBeanDeposits(uint32[] calldata crates, uint256[] calldata amounts)
         private
         returns (uint256 beansRemoved, uint256 stalkRemoved)

--- a/protocol/contracts/farm/facets/SiloFacet/BeanSilo.sol
+++ b/protocol/contracts/farm/facets/SiloFacet/BeanSilo.sol
@@ -18,15 +18,15 @@ contract BeanSilo is LPSilo {
 
     event BeanDeposit(address indexed account, uint256 season, uint256 beans);
     event BeanRemove(address indexed account, uint32[] crates, uint256[] crateBeans, uint256 beans);
-    event BeanWithdraw(address indexed account, uint256 season, uint256 beans);
+	event BeanWithdraw(address indexed account, uint256 season, uint256 beans);
 
-    /**
-     * Getters
-    **/
+	/**
+	 * Getters
+	 **/
 
-    function totalDepositedBeans() public view returns (uint256) {
+	function totalDepositedBeans() public view returns (uint256) {
 		return s.bean.deposited;
-    }
+	}
 
     function totalWithdrawnBeans() public view returns (uint256) {
 		return s.bean.withdrawn;

--- a/protocol/contracts/farm/facets/SiloFacet/BeanSilo.sol
+++ b/protocol/contracts/farm/facets/SiloFacet/BeanSilo.sol
@@ -25,11 +25,11 @@ contract BeanSilo is LPSilo {
     **/
 
     function totalDepositedBeans() public view returns (uint256) {
-            return s.bean.deposited;
+		return s.bean.deposited;
     }
 
     function totalWithdrawnBeans() public view returns (uint256) {
-            return s.bean.withdrawn;
+		return s.bean.withdrawn;
     }
 
     function beanDeposit(address account, uint32 id) public view returns (uint256) {
@@ -37,7 +37,7 @@ contract BeanSilo is LPSilo {
     }
 
     function beanWithdrawal(address account, uint32 i) public view returns (uint256) {
-            return s.a[account].bean.withdrawals[i];
+		return s.a[account].bean.withdrawals[i];
     }
 
     /**

--- a/protocol/contracts/farm/facets/SiloFacet/LPSilo.sol
+++ b/protocol/contracts/farm/facets/SiloFacet/LPSilo.sol
@@ -26,11 +26,11 @@ contract LPSilo is UpdateSilo {
     **/
 
     function totalDepositedLP() public view returns (uint256) {
-            return s.lp.deposited;
+		return s.lp.deposited;
     }
 
     function totalWithdrawnLP() public view returns (uint256) {
-            return s.lp.withdrawn;
+		return s.lp.withdrawn;
     }
 
     function lpDeposit(address account, uint32 id) public view returns (uint256, uint256) {

--- a/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
@@ -50,6 +50,9 @@ contract SiloV2Facet is TokenSilo {
 		if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
 			console.log("Bean Balance (SiloV2Facet): ", IERC20(token).balanceOf(address(this)));
 		}
+		if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
+			console.log("LP Balance (SiloV2Facet): ", IERC20(token).balanceOf(address(this)));
+		}
         _deposit(token, amount);
     }
 

--- a/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
@@ -152,6 +152,7 @@ contract SiloV2Facet is TokenSilo {
         LibInternal.updateSilo(msg.sender);
         _transferDeposit(token, season, amount, transferTo);
         LibSilo.updateBalanceOfRainStalk(msg.sender);
+        LibSilo.updateBalanceOfRainStalk(transferTo);
     }
 
     function transferTokenBySeasons(
@@ -164,6 +165,7 @@ contract SiloV2Facet is TokenSilo {
         LibInternal.updateSilo(msg.sender);
         _transferDeposits(token, seasons, amounts, transferTo);
         LibSilo.updateBalanceOfRainStalk(msg.sender);
+        LibSilo.updateBalanceOfRainStalk(transferTo);
     }
 
     function transferTokensBySeason(WithdrawSeason[] calldata withdraws, address transferTo)
@@ -180,6 +182,7 @@ contract SiloV2Facet is TokenSilo {
             );
         }
         LibSilo.updateBalanceOfRainStalk(msg.sender);
+        LibSilo.updateBalanceOfRainStalk(transferTo);
     }
 
     function transferTokensBySeasons(WithdrawSeasons[] calldata withdraws, address transferTo)
@@ -196,6 +199,7 @@ contract SiloV2Facet is TokenSilo {
             );
         }
         LibSilo.updateBalanceOfRainStalk(msg.sender);
+        LibSilo.updateBalanceOfRainStalk(transferTo);
     }
 
     /*

--- a/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
@@ -47,12 +47,6 @@ contract SiloV2Facet is TokenSilo {
 
     function deposit(address token, uint256 amount) external {
         IERC20(token).transferFrom(msg.sender, address(this), amount);
-		if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
-			console.log("Bean Balance (SiloV2Facet): ", IERC20(token).balanceOf(address(this)));
-		}
-		if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
-			console.log("LP Balance (SiloV2Facet): ", IERC20(token).balanceOf(address(this)));
-		}
         _deposit(token, amount);
     }
 

--- a/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
-*/
+ */
 
 pragma solidity ^0.7.6;
 pragma experimental ABIEncoderV2;
@@ -11,9 +11,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /*
  * @author Publius
  * @title SiloV2Facet handles depositing, withdrawing and claiming whitelisted Silo tokens.
-*/
+ */
 contract SiloV2Facet is TokenSilo {
-
     event BeanAllocation(address indexed account, uint256 beans);
 
     using SafeMath for uint256;
@@ -54,30 +53,50 @@ contract SiloV2Facet is TokenSilo {
      * Withdraw
      */
 
-    function withdrawTokenBySeason(address token, uint32 season, uint256 amount) external {
+    function withdrawTokenBySeason(
+        address token,
+        uint32 season,
+        uint256 amount
+    ) external {
         LibInternal.updateSilo(msg.sender);
         _withdrawDeposit(token, season, amount);
         LibSilo.updateBalanceOfRainStalk(msg.sender);
     }
 
-    function withdrawTokenBySeasons(address token, uint32[] calldata seasons, uint256[] calldata amounts) external {
+    function withdrawTokenBySeasons(
+        address token,
+        uint32[] calldata seasons,
+        uint256[] calldata amounts
+    ) external {
         LibInternal.updateSilo(msg.sender);
         _withdrawDeposits(token, seasons, amounts);
         LibSilo.updateBalanceOfRainStalk(msg.sender);
     }
 
-    function withdrawTokensBySeason(WithdrawSeason[] calldata withdraws) external {
+    function withdrawTokensBySeason(WithdrawSeason[] calldata withdraws)
+        external
+    {
         LibInternal.updateSilo(msg.sender);
         for (uint256 i = 0; i < withdraws.length; i++) {
-            _withdrawDeposit(withdraws[i].token, withdraws[i].season, withdraws[i].amount);
+            _withdrawDeposit(
+                withdraws[i].token,
+                withdraws[i].season,
+                withdraws[i].amount
+            );
         }
         LibSilo.updateBalanceOfRainStalk(msg.sender);
     }
 
-    function withdrawTokensBySeasons(WithdrawSeasons[] calldata withdraws) external {
+    function withdrawTokensBySeasons(WithdrawSeasons[] calldata withdraws)
+        external
+    {
         LibInternal.updateSilo(msg.sender);
         for (uint256 i = 0; i < withdraws.length; i++) {
-            _withdrawDeposits(withdraws[i].token, withdraws[i].seasons, withdraws[i].amounts);
+            _withdrawDeposits(
+                withdraws[i].token,
+                withdraws[i].seasons,
+                withdraws[i].amounts
+            );
         }
         LibSilo.updateBalanceOfRainStalk(msg.sender);
     }
@@ -92,7 +111,9 @@ contract SiloV2Facet is TokenSilo {
         emit ClaimSeason(msg.sender, token, season, amount);
     }
 
-    function claimTokenBySeasons(address token, uint32[] calldata seasons) public {
+    function claimTokenBySeasons(address token, uint32[] calldata seasons)
+        public
+    {
         uint256 amount = removeTokenWithdrawals(msg.sender, token, seasons);
         IERC20(token).transfer(msg.sender, amount);
         emit ClaimSeasons(msg.sender, token, seasons, amount);
@@ -111,17 +132,87 @@ contract SiloV2Facet is TokenSilo {
     }
 
     /*
+     * Transfer
+     */
+
+    function transferTokenBySeason(
+        address token,
+        uint32 season,
+        uint256 amount,
+        address transferTo
+    ) external {
+        require(msg.sender != transferTo, "Can't transfer to yourself");
+        LibInternal.updateSilo(msg.sender);
+        _transferDeposit(token, season, amount, transferTo);
+        LibSilo.updateBalanceOfRainStalk(msg.sender);
+    }
+
+    function transferTokenBySeasons(
+        address token,
+        uint32[] calldata seasons,
+        uint256[] calldata amounts,
+        address transferTo
+    ) external {
+        require(msg.sender != transferTo, "Can't transfer to yourself");
+        LibInternal.updateSilo(msg.sender);
+        _transferDeposits(token, seasons, amounts, transferTo);
+        LibSilo.updateBalanceOfRainStalk(msg.sender);
+    }
+
+    function transferTokensBySeason(WithdrawSeason[] calldata withdraws, address transferTo)
+        external
+    {
+        LibInternal.updateSilo(msg.sender);
+        for (uint256 i = 0; i < withdraws.length; i++) {
+            _transferDeposit(
+                withdraws[i].token,
+                withdraws[i].season,
+                withdraws[i].amount,
+                transferTo
+            );
+        }
+        LibSilo.updateBalanceOfRainStalk(msg.sender);
+    }
+
+    function transferTokensBySeasons(WithdrawSeasons[] calldata withdraws, address transferTo)
+        external
+    {
+        LibInternal.updateSilo(msg.sender);
+        for (uint256 i = 0; i < withdraws.length; i++) {
+            _transferDeposits(
+                withdraws[i].token,
+                withdraws[i].seasons,
+                withdraws[i].amounts,
+                transferTo
+            );
+        }
+        LibSilo.updateBalanceOfRainStalk(msg.sender);
+    }
+
+    /*
      * Whitelist
      */
 
-    function whitelistToken(address token, bytes4 selector, uint32 stalk, uint32 seeds) external {
-        require(msg.sender == address(this), "Silo: Only Beanstalk can whitelist tokens.");
+    function whitelistToken(
+        address token,
+        bytes4 selector,
+        uint32 stalk,
+        uint32 seeds
+    ) external {
+        require(
+            msg.sender == address(this),
+            "Silo: Only Beanstalk can whitelist tokens."
+        );
         s.ss[token].selector = selector;
         s.ss[token].stalk = stalk;
         s.ss[token].seeds = seeds;
     }
 
-    function tokenSettings(address token) external view returns (Storage.SiloSettings memory) {
+    function tokenSettings(address token)
+        external
+        view
+        returns (Storage.SiloSettings memory)
+    {
         return s.ss[token];
     }
 }

--- a/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
@@ -7,6 +7,7 @@ pragma experimental ABIEncoderV2;
 
 import "./TokenSilo.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "hardhat/console.sol";
 
 /*
  * @author Publius
@@ -46,6 +47,9 @@ contract SiloV2Facet is TokenSilo {
 
     function deposit(address token, uint256 amount) external {
         IERC20(token).transferFrom(msg.sender, address(this), amount);
+		if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
+			console.log("Bean Balance (SiloV2Facet): ", IERC20(token).balanceOf(address(this)));
+		}
         _deposit(token, amount);
     }
 

--- a/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/SiloV2Facet.sol
@@ -162,6 +162,7 @@ contract SiloV2Facet is TokenSilo {
     function transferTokensBySeason(WithdrawSeason[] calldata withdraws, address transferTo)
         external
     {
+        require(msg.sender != transferTo, "Can't transfer to yourself");
         LibInternal.updateSilo(msg.sender);
         for (uint256 i = 0; i < withdraws.length; i++) {
             _transferDeposit(
@@ -177,6 +178,7 @@ contract SiloV2Facet is TokenSilo {
     function transferTokensBySeasons(WithdrawSeasons[] calldata withdraws, address transferTo)
         external
     {
+        require(msg.sender != transferTo, "Can't transfer to yourself");
         LibInternal.updateSilo(msg.sender);
         for (uint256 i = 0; i < withdraws.length; i++) {
             _transferDeposits(

--- a/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
@@ -4,12 +4,10 @@
 
 pragma solidity ^0.7.6;
 pragma experimental ABIEncoderV2;
-
 import "../../../libraries/Silo/LibTokenSilo.sol";
 import "../../../libraries/Silo/LibSilo.sol";
 import "../../../libraries/LibInternal.sol";
 import "../SiloFacet/BeanSilo.sol";
-
 import "hardhat/console.sol";
 
 /**
@@ -17,30 +15,29 @@ import "hardhat/console.sol";
  * @title Token Silo
 **/
 contract TokenSilo {
-
+	
 	AppStorage internal s;
-
-    uint32 private constant ASSET_PADDING = 100;
-
-    using SafeMath for uint256;
-    using SafeMath for uint32;
-
-    event Deposit(address indexed account, address indexed token, uint256 season, uint256 amount, uint256 bdv);
+    
+	uint32 private constant ASSET_PADDING = 100;
+    
+	using SafeMath for uint256;
+	using SafeMath for uint32;
+    
+	event Deposit(address indexed account, address indexed token, uint256 season, uint256 amount, uint256 bdv);
     event RemoveSeasons(address indexed account, address indexed token, uint32[] seasons, uint256[] amounts, uint256 amount);
-    event RemoveSeason(address indexed account, address indexed token, uint32 season, uint256 amount);
-
+    event ReoveSeason(address indexed account, address indexed token, uint32 season, uint256 amount);
     event Withdraw(address indexed account, address indexed token, uint32 season, uint256 amount);
     event ClaimSeasons(address indexed account, address indexed token, uint32[] seasons, uint256 amount);
     event ClaimSeason(address indexed account, address indexed token, uint32 season, uint256 amount);
-
-    struct AssetsRemoved {
+    
+	struct AssetsRemoved {
         uint256 tokensRemoved;
         uint256 stalkRemoved;
         uint256 seedsRemoved;
         uint256 bdvRemoved;
     }
-
-    /**
+    
+	/**
      * Getters
     **/
 
@@ -117,6 +114,7 @@ contract TokenSilo {
         if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
 			LibInternal.updateSilo(msg.sender);
 			(uint256 beansRemoved, uint256 stalkRemoved) = LibBeanSilo.removeBeanDeposits(seasons, amounts);
+			addBeanWithdrawal(msg.sender, season()+s.season.withdrawSeasons, beansRemoved);
 			LibBeanSilo.addBeanWithdrawal(msg.sender, _season()+s.season.withdrawSeasons, beansRemoved);
 			LibBeanSilo.decrementDepositedBeans(beansRemoved);
 			LibSilo.withdrawSiloAssets(msg.sender, beansRemoved.mul(C.getSeedsPerBean()), stalkRemoved);
@@ -129,6 +127,8 @@ contract TokenSilo {
 				uint256 stalkRemoved,
 				uint256 seedsRemoved
 			) = LibLPSilo.removeLPDeposits(seasons, amounts);
+			uint32 arrivalSeason = season() + s.season.withdrawSeasons;
+			addLPWithdrawal(msg.sender, arrivalSeason, lpRemoved);
 			uint32 arrivalSeason = _season() + s.season.withdrawSeasons;
 			LibLPSilo.addLPWithdrawal(msg.sender, arrivalSeason, lpRemoved);
 			LibLPSilo.decrementDepositedLP(lpRemoved);

--- a/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
@@ -117,7 +117,7 @@ contract TokenSilo {
         if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
 			LibInternal.updateSilo(msg.sender);
 			(uint256 beansRemoved, uint256 stalkRemoved) = LibBeanSilo.removeBeanDeposits(seasons, amounts);
-			addBeanWithdrawal(msg.sender, season()+s.season.withdrawSeasons, beansRemoved);
+			LibBeanSilo.addBeanWithdrawal(msg.sender, _season()+s.season.withdrawSeasons, beansRemoved);
 			LibBeanSilo.decrementDepositedBeans(beansRemoved);
 			LibSilo.withdrawSiloAssets(msg.sender, beansRemoved.mul(C.getSeedsPerBean()), stalkRemoved);
 			LibSilo.updateBalanceOfRainStalk(msg.sender);
@@ -129,8 +129,8 @@ contract TokenSilo {
 				uint256 stalkRemoved,
 				uint256 seedsRemoved
 			) = LibLPSilo.removeLPDeposits(seasons, amounts);
-			uint32 arrivalSeason = season() + s.season.withdrawSeasons;
-			addLPWithdrawal(msg.sender, arrivalSeason, lpRemoved);
+			uint32 arrivalSeason = _season() + s.season.withdrawSeasons;
+			LibLPSilo.addLPWithdrawal(msg.sender, arrivalSeason, lpRemoved);
 			LibLPSilo.decrementDepositedLP(lpRemoved);
 			LibSilo.withdrawSiloAssets(msg.sender, seedsRemoved, stalkRemoved);
 			LibSilo.updateBalanceOfRainStalk(msg.sender);

--- a/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
@@ -9,7 +9,6 @@ import "../../../libraries/Silo/LibSilo.sol";
 import "../../../libraries/LibInternal.sol";
 import "../SiloFacet/BeanSilo.sol";
 import "hardhat/console.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /**
  * @author Publius
@@ -98,6 +97,8 @@ contract TokenSilo {
         } else if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
 			uint32 _s = _season();
 			uint256 lpb = LibLPSilo.lpToLPBeans(amount);
+			console.log("amount", amount);
+			console.log("lpb", lpb);
 			require(lpb > 0, "Silo: No Beans under LP.");
 			LibLPSilo.incrementDepositedLP(amount);
 			uint256 seeds = lpb.mul(C.getSeedsPerLPBean());

--- a/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
@@ -9,6 +9,7 @@ import "../../../libraries/Silo/LibSilo.sol";
 import "../../../libraries/LibInternal.sol";
 import "../SiloFacet/BeanSilo.sol";
 import "hardhat/console.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /**
  * @author Publius
@@ -89,6 +90,7 @@ contract TokenSilo {
     function _deposit(address token, uint256 amount) internal {
 		LibInternal.updateSilo(msg.sender);
         if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
+			console.log("Bean Balance (TokenSilo _deposit): ", IERC20(token).balanceOf(address(this)));
 			require(amount > 0, "Silo: No beans.");
 			LibBeanSilo.incrementDepositedBeans(amount);
 			LibSilo.depositSiloAssets(msg.sender, amount.mul(C.getSeedsPerBean()), amount.mul(C.getStalkPerBean()));
@@ -112,12 +114,14 @@ contract TokenSilo {
     function _withdrawDeposits(address token, uint32[] calldata seasons, uint256[] calldata amounts) internal {
         require(seasons.length == amounts.length, "Silo: Crates, amounts are diff lengths.");
         if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
+			console.log("Bean Balance (TokenSilo _withdrawDeposits 1): ", IERC20(token).balanceOf(address(this)));
 			LibInternal.updateSilo(msg.sender);
 			(uint256 beansRemoved, uint256 stalkRemoved) = LibBeanSilo.removeBeanDeposits(seasons, amounts);
 			LibBeanSilo.addBeanWithdrawal(msg.sender, _season()+s.season.withdrawSeasons, beansRemoved);
 			LibBeanSilo.decrementDepositedBeans(beansRemoved);
 			LibSilo.withdrawSiloAssets(msg.sender, beansRemoved.mul(C.getSeedsPerBean()), stalkRemoved);
 			LibSilo.updateBalanceOfRainStalk(msg.sender);
+			console.log("Bean Balance (TokenSilo _withdrawDeposits 2): ", IERC20(token).balanceOf(address(this)));
 			LibCheck.beanBalanceCheck();
         } else if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
 			LibInternal.updateSilo(msg.sender);

--- a/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
@@ -116,7 +116,7 @@ contract TokenSilo {
         require(seasons.length == amounts.length, "Silo: Crates, amounts are diff lengths.");
         if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
 			LibInternal.updateSilo(msg.sender);
-			(uint256 beansRemoved, uint256 stalkRemoved) = removeBeanDeposits(seasons, amounts);
+			(uint256 beansRemoved, uint256 stalkRemoved) = LibBeanSilo.removeBeanDeposits(seasons, amounts);
 			addBeanWithdrawal(msg.sender, season()+s.season.withdrawSeasons, beansRemoved);
 			LibBeanSilo.decrementDepositedBeans(beansRemoved);
 			LibSilo.withdrawSiloAssets(msg.sender, beansRemoved.mul(C.getSeedsPerBean()), stalkRemoved);
@@ -128,7 +128,7 @@ contract TokenSilo {
 				uint256 lpRemoved,
 				uint256 stalkRemoved,
 				uint256 seedsRemoved
-			) = removeLPDeposits(seasons, amounts);
+			) = LibLPSilo.removeLPDeposits(seasons, amounts);
 			uint32 arrivalSeason = season() + s.season.withdrawSeasons;
 			addLPWithdrawal(msg.sender, arrivalSeason, lpRemoved);
 			LibLPSilo.decrementDepositedLP(lpRemoved);

--- a/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
@@ -113,8 +113,8 @@ contract TokenSilo {
 
     function _withdrawDeposits(address token, uint32[] calldata seasons, uint256[] calldata amounts) internal {
         require(seasons.length == amounts.length, "Silo: Crates, amounts are diff lengths.");
-			LibInternal.updateSilo(msg.sender);
         if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
+			LibInternal.updateSilo(msg.sender);
 			(uint256 beansRemoved, uint256 stalkRemoved) = LibBeanSilo.removeBeanDeposits(seasons, amounts);
 			LibBeanSilo.addBeanWithdrawal(msg.sender, _season()+s.season.withdrawSeasons, beansRemoved);
 			LibBeanSilo.decrementDepositedBeans(beansRemoved);
@@ -139,7 +139,6 @@ contract TokenSilo {
 			LibTokenSilo.decrementDepositedToken(token, ar.tokensRemoved);
 			LibSilo.withdrawSiloAssets(msg.sender, ar.seedsRemoved, ar.stalkRemoved);
 		}
-		LibSilo.updateBalanceOfRainStalk(msg.sender);
     }
 
     function _withdrawDeposit(address token, uint32 season, uint256 amount) internal {
@@ -159,7 +158,6 @@ contract TokenSilo {
     function _transferDeposits(address token, uint32[] calldata seasons, uint256[] calldata amounts, address transferTo) internal {
         require(seasons.length == amounts.length, "Silo: Crates, amounts are diff lengths.");
         if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
-			LibInternal.updateSilo(msg.sender);
 			(uint256 beansRemoved, uint256 stalkRemoved) = LibBeanSilo.removeBeanDeposits(seasons, amounts);
 			LibSilo.withdrawSiloAssets(msg.sender, beansRemoved.mul(C.getSeedsPerBean()), stalkRemoved);
 			for (uint256 i = 0; i < seasons.length; i++) {
@@ -169,7 +167,6 @@ contract TokenSilo {
 			LibSilo.updateBalanceOfRainStalk(msg.sender);
 			LibCheck.beanBalanceCheck();
         } else if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
-			LibInternal.updateSilo(msg.sender);
 			LibLPSilo.transferLPDeposits(seasons, amounts, transferTo);
 			LibSilo.updateBalanceOfRainStalk(msg.sender);
 			LibCheck.lpBalanceCheck();

--- a/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
@@ -170,16 +170,7 @@ contract TokenSilo {
 			LibCheck.beanBalanceCheck();
         } else if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
 			LibInternal.updateSilo(msg.sender);
-			(
-				uint256 lpRemoved,
-				uint256 stalkRemoved,
-				uint256 seedsRemoved
-			) = LibLPSilo.removeLPDeposits(seasons, amounts);
-			LibSilo.withdrawSiloAssets(msg.sender, seedsRemoved, stalkRemoved);
-			for (uint256 i = 0; i < seasons.length; i++) {
-				LibLPSilo.addLPDeposit(transferTo, seasons[i], amounts[i]);
-			}
-			LibSilo.depositSiloAssets(transferTo, seedsRemoved, stalkRemoved);
+			LibLPSilo.transferLPDeposits(seasons, amounts, transferTo);
 			LibSilo.updateBalanceOfRainStalk(msg.sender);
 			LibCheck.lpBalanceCheck();
         } else {

--- a/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
@@ -163,12 +163,12 @@ contract TokenSilo {
 			for (uint256 i = 0; i < seasons.length; i++) {
 				LibBeanSilo.addBeanDeposit(transferTo, seasons[i], amounts[i]);
 			}
-			LibSilo.depositSiloAssets(msg.sender, beansRemoved.mul(C.getSeedsPerBean()), stalkRemoved);
-			LibSilo.updateBalanceOfRainStalk(msg.sender);
+			LibSilo.depositSiloAssets(transferTo, beansRemoved.mul(C.getSeedsPerBean()), stalkRemoved);
+			LibSilo.updateBalanceOfRainStalk(transferTo);
 			LibCheck.beanBalanceCheck();
         } else if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
 			LibLPSilo.transferLPDeposits(seasons, amounts, transferTo);
-			LibSilo.updateBalanceOfRainStalk(msg.sender);
+			LibSilo.updateBalanceOfRainStalk(transferTo);
 			LibCheck.lpBalanceCheck();
         } else {
 			AssetsRemoved memory ar;

--- a/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
@@ -8,6 +8,7 @@ pragma experimental ABIEncoderV2;
 import "../../../libraries/Silo/LibTokenSilo.sol";
 import "../../../libraries/Silo/LibSilo.sol";
 import "../../../libraries/LibInternal.sol";
+import "../SiloFacet/BeanSilo.sol";
 
 import "hardhat/console.sol";
 
@@ -15,7 +16,7 @@ import "hardhat/console.sol";
  * @author Publius
  * @title Token Silo
 **/
-contract TokenSilo {
+contract TokenSilo is BeanSilo {
 
     uint32 private constant ASSET_PADDING = 100;
 
@@ -43,20 +44,54 @@ contract TokenSilo {
      * Getters
     **/
 
+    /**
+    if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
+
+    } else if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
+
+    } else {
+
+    }
+     */
+
     function getDeposit(address account, address token, uint32 season) external view returns (uint256, uint256) {
-        return LibTokenSilo.tokenDeposit(account, token, season);
+        if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
+            return beanDeposit(account, season);
+        } else if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
+            return lpDeposit(account, season);
+        } else {
+            return LibTokenSilo.tokenDeposit(account, token, season);
+        }
     }
 
     function getWithdrawal(address account, address token, uint32 season) external view returns (uint256) {
-        return LibTokenSilo.tokenWithdrawal(account, token, season);
+        if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
+            beanWithdrawal(account, season);
+        } else if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
+            lpWithdrawal(account, season);
+        } else {
+            return LibTokenSilo.tokenWithdrawal(account, token, season);
+        }
     }
 
     function getTotalDeposited(address token) external view returns (uint256) {
-        return s.siloBalances[token].deposited;
+        if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
+            return totalDepositedBeans();
+        } else if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
+            return totalDepositedLP();
+        } else {
+            return s.siloBalances[token].deposited;
+        }
     }
 
     function getTotalWithdrawn(address token) external view returns (uint256) {
-        return s.siloBalances[token].withdrawn;
+        if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
+            return totalWithdrawnBeans();
+        } else if (token == address(0x87898263B6C5BABe34b4ec53F22d98430b91e371)) {
+            return totalWithdrawnLP();
+        } else {
+            return s.siloBalances[token].withdrawn;
+        }
     }
 
     /**

--- a/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
+++ b/protocol/contracts/farm/facets/SiloV2Facet/TokenSilo.sol
@@ -25,7 +25,7 @@ contract TokenSilo {
     
 	event Deposit(address indexed account, address indexed token, uint256 season, uint256 amount, uint256 bdv);
     event RemoveSeasons(address indexed account, address indexed token, uint32[] seasons, uint256[] amounts, uint256 amount);
-    event ReoveSeason(address indexed account, address indexed token, uint32 season, uint256 amount);
+    event RemoveSeason(address indexed account, address indexed token, uint32 season, uint256 amount);
     event Withdraw(address indexed account, address indexed token, uint32 season, uint256 amount);
     event ClaimSeasons(address indexed account, address indexed token, uint32[] seasons, uint256 amount);
     event ClaimSeason(address indexed account, address indexed token, uint32 season, uint256 amount);
@@ -114,7 +114,6 @@ contract TokenSilo {
         if (token == address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db)) {
 			LibInternal.updateSilo(msg.sender);
 			(uint256 beansRemoved, uint256 stalkRemoved) = LibBeanSilo.removeBeanDeposits(seasons, amounts);
-			addBeanWithdrawal(msg.sender, season()+s.season.withdrawSeasons, beansRemoved);
 			LibBeanSilo.addBeanWithdrawal(msg.sender, _season()+s.season.withdrawSeasons, beansRemoved);
 			LibBeanSilo.decrementDepositedBeans(beansRemoved);
 			LibSilo.withdrawSiloAssets(msg.sender, beansRemoved.mul(C.getSeedsPerBean()), stalkRemoved);
@@ -127,8 +126,6 @@ contract TokenSilo {
 				uint256 stalkRemoved,
 				uint256 seedsRemoved
 			) = LibLPSilo.removeLPDeposits(seasons, amounts);
-			uint32 arrivalSeason = season() + s.season.withdrawSeasons;
-			addLPWithdrawal(msg.sender, arrivalSeason, lpRemoved);
 			uint32 arrivalSeason = _season() + s.season.withdrawSeasons;
 			LibLPSilo.addLPWithdrawal(msg.sender, arrivalSeason, lpRemoved);
 			LibLPSilo.decrementDepositedLP(lpRemoved);

--- a/protocol/contracts/farm/init/InitDiamond.sol
+++ b/protocol/contracts/farm/init/InitDiamond.sol
@@ -43,10 +43,15 @@ contract InitDiamond {
         ds.supportedInterfaces[type(IDiamondLoupe).interfaceId] = true;
         ds.supportedInterfaces[type(IERC173).interfaceId] = true;
 
-        s.c.bean = address(new Bean());
         s.c.weth = IUniswapV2Router02(UNISWAP_ROUTER).WETH();
-        s.c.pair = address(IUniswapV2Factory(UNISWAP_FACTORY).createPair(s.c.bean, s.c.weth));
         s.c.pegPair = PEG_PAIR;
+		// comment out these if testing
+        // s.c.bean = address(new Bean());
+        // s.c.pair = address(IUniswapV2Factory(UNISWAP_FACTORY).createPair(s.c.bean, s.c.weth));
+		
+		// comment in these if testing
+        s.c.bean = address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db);
+        s.c.pair = address(0x87898263B6C5BABe34b4ec53F22d98430b91e371);
 
         IBean(s.c.bean).approve(UNISWAP_ROUTER, uint256(-1));
         IUniswapV2Pair(s.c.pair).approve(UNISWAP_ROUTER, uint256(-1));

--- a/protocol/contracts/libraries/LibCheck.sol
+++ b/protocol/contracts/libraries/LibCheck.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 import "./LibAppStorage.sol";
 import "../interfaces/IBean.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "hardhat/console.sol";
 
@@ -22,7 +23,9 @@ library LibCheck {
 
     function beanBalanceCheck() internal view {
         AppStorage storage s = LibAppStorage.diamondStorage();
+		console.log("IERC20(s.c.bean).balanceOf(address(this))", IERC20(s.c.bean).balanceOf(address(this))); 
 		console.log("IBean(s.c.bean).balanceOf(address(this))", IBean(s.c.bean).balanceOf(address(this))); 
+		console.log("Bean Address: ", s.c.bean);
 		console.log("s.f.harvestable", s.f.harvestable); 
 		console.log("s.f.harvested", s.f.harvested); 
 		console.log("s.bean.deposited", s.bean.deposited); 
@@ -36,6 +39,7 @@ library LibCheck {
 
     function lpBalanceCheck() internal view {
         AppStorage storage s = LibAppStorage.diamondStorage();
+		console.log("IERC20(s.c.pair).balanceOf(address(this))", IERC20(s.c.pair).balanceOf(address(this))); 
 		console.log("IBean(s.c.pair).balanceOf(address(this))", IBean(s.c.pair).balanceOf(address(this))); 
 		console.log("s.lp.deposited", s.lp.deposited); 
 		console.log("s.lp.withdrawn", s.lp.withdrawn); 

--- a/protocol/contracts/libraries/LibCheck.sol
+++ b/protocol/contracts/libraries/LibCheck.sol
@@ -10,6 +10,8 @@ import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 import "./LibAppStorage.sol";
 import "../interfaces/IBean.sol";
 
+import "hardhat/console.sol";
+
 /**
  * @author Publius
  * @title Check Library verifies Beanstalk's balances are correct.
@@ -20,6 +22,11 @@ library LibCheck {
 
     function beanBalanceCheck() internal view {
         AppStorage storage s = LibAppStorage.diamondStorage();
+		console.log("IBean(s.c.bean).balanceOf(address(this))", IBean(s.c.bean).balanceOf(address(this))); 
+		console.log("s.f.harvestable", s.f.harvestable); 
+		console.log("s.f.harvested", s.f.harvested); 
+		console.log("s.bean.deposited", s.bean.deposited); 
+		console.log("s.bean.withdrawn", s.bean.withdrawn); 
         require(
             IBean(s.c.bean).balanceOf(address(this)) >=
                 s.f.harvestable.sub(s.f.harvested).add(s.bean.deposited).add(s.bean.withdrawn),
@@ -29,6 +36,9 @@ library LibCheck {
 
     function lpBalanceCheck() internal view {
         AppStorage storage s = LibAppStorage.diamondStorage();
+		console.log("IBean(s.c.pair).balanceOf(address(this))", IBean(s.c.pair).balanceOf(address(this))); 
+		console.log("s.lp.deposited", s.lp.deposited); 
+		console.log("s.lp.withdrawn", s.lp.withdrawn); 
         require(
             IUniswapV2Pair(s.c.pair).balanceOf(address(this)) >= s.lp.deposited.add(s.lp.withdrawn),
             "Check: LP balance fail."

--- a/protocol/contracts/libraries/LibCheck.sol
+++ b/protocol/contracts/libraries/LibCheck.sol
@@ -9,7 +9,6 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 import "./LibAppStorage.sol";
 import "../interfaces/IBean.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "hardhat/console.sol";
 
@@ -23,13 +22,6 @@ library LibCheck {
 
     function beanBalanceCheck() internal view {
         AppStorage storage s = LibAppStorage.diamondStorage();
-		console.log("IERC20(s.c.bean).balanceOf(address(this))", IERC20(s.c.bean).balanceOf(address(this))); 
-		console.log("IBean(s.c.bean).balanceOf(address(this))", IBean(s.c.bean).balanceOf(address(this))); 
-		console.log("Bean Address: ", s.c.bean);
-		console.log("s.f.harvestable", s.f.harvestable); 
-		console.log("s.f.harvested", s.f.harvested); 
-		console.log("s.bean.deposited", s.bean.deposited); 
-		console.log("s.bean.withdrawn", s.bean.withdrawn); 
         require(
             IBean(s.c.bean).balanceOf(address(this)) >=
                 s.f.harvestable.sub(s.f.harvested).add(s.bean.deposited).add(s.bean.withdrawn),
@@ -39,7 +31,6 @@ library LibCheck {
 
     function lpBalanceCheck() internal view {
         AppStorage storage s = LibAppStorage.diamondStorage();
-		console.log("IERC20(s.c.pair).balanceOf(address(this))", IERC20(s.c.pair).balanceOf(address(this))); 
 		console.log("IBean(s.c.pair).balanceOf(address(this))", IBean(s.c.pair).balanceOf(address(this))); 
 		console.log("s.lp.deposited", s.lp.deposited); 
 		console.log("s.lp.withdrawn", s.lp.withdrawn); 

--- a/protocol/contracts/libraries/Silo/LibBeanSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibBeanSilo.sol
@@ -41,20 +41,20 @@ library LibBeanSilo {
         return amount;
     }
 
-    function removeBeanDeposits(uint32[] calldata crates, uint256[] calldata amounts)
+
+    function transferBeanDeposits(uint32[] calldata crates, uint256[] calldata amounts, address transferTo)
         internal
-        returns (uint256 beansRemoved, uint256 stalkRemoved)
     {
+        uint256 beansRemoved;
         AppStorage storage s = LibAppStorage.diamondStorage();
         for (uint256 i = 0; i < crates.length; i++) {
             uint256 crateBeans = LibBeanSilo.removeBeanDeposit(msg.sender, crates[i], amounts[i]);
             beansRemoved = beansRemoved.add(crateBeans);
-            stalkRemoved = stalkRemoved.add(crateBeans.mul(C.getStalkPerBean()).add(
-                LibSilo.stalkReward(crateBeans.mul(C.getSeedsPerBean()), s.season.current-crates[i]))
-            );
+			LibSilo.withd
         }
         emit BeanRemove(msg.sender, crates, amounts, beansRemoved);
     }
+
 
     function addBeanWithdrawal(address account, uint32 arrivalSeason, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();

--- a/protocol/contracts/libraries/Silo/LibBeanSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibBeanSilo.sol
@@ -41,20 +41,20 @@ library LibBeanSilo {
         return amount;
     }
 
-
-    function transferBeanDeposits(uint32[] calldata crates, uint256[] calldata amounts, address transferTo)
+    function removeBeanDeposits(uint32[] calldata crates, uint256[] calldata amounts)
         internal
+        returns (uint256 beansRemoved, uint256 stalkRemoved)
     {
-        uint256 beansRemoved;
         AppStorage storage s = LibAppStorage.diamondStorage();
         for (uint256 i = 0; i < crates.length; i++) {
             uint256 crateBeans = LibBeanSilo.removeBeanDeposit(msg.sender, crates[i], amounts[i]);
             beansRemoved = beansRemoved.add(crateBeans);
-			LibSilo.withd
+            stalkRemoved = stalkRemoved.add(crateBeans.mul(C.getStalkPerBean()).add(
+                LibSilo.stalkReward(crateBeans.mul(C.getSeedsPerBean()), s.season.current-crates[i]))
+            );
         }
         emit BeanRemove(msg.sender, crates, amounts, beansRemoved);
     }
-
 
     function addBeanWithdrawal(address account, uint32 arrivalSeason, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();

--- a/protocol/contracts/libraries/Silo/LibLPSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLPSilo.sol
@@ -10,7 +10,6 @@ import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 import "../LibAppStorage.sol";
 import "../../C.sol";
 import "./LibSilo.sol";
-import "hardhat/console.sol";
 
 /**
  * @author Publius
@@ -100,8 +99,6 @@ library LibLPSilo {
                 LibSilo.stalkReward(crateSeeds, s.season.current-crates[i])));
         }
 
-		
-		
         emit LPRemove(msg.sender, crates, amounts, lpRemoved);
     }
 
@@ -123,12 +120,6 @@ library LibLPSilo {
         (uint112 reserve0, uint112 reserve1,) = IUniswapV2Pair(s.c.pair).getReserves();
 
         uint256 beanReserve = s.index == 0 ? reserve0 : reserve1;
-
-        console.log("amount", amount); // 1000 
-        console.log("reserve0", reserve0); // 2000
-        console.log("reserve1", reserve1); // 2
-        console.log("beanReserve", beanReserve); // 2
-        console.log("IUniswapV2Pair(s.c.pair).totalSupply()", IUniswapV2Pair(s.c.pair).totalSupply()); // 10000
 
         return amount.mul(beanReserve).mul(2).div(IUniswapV2Pair(s.c.pair).totalSupply()); // 0
     }

--- a/protocol/contracts/libraries/Silo/LibLPSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLPSilo.sol
@@ -10,6 +10,7 @@ import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 import "../LibAppStorage.sol";
 import "../../C.sol";
 import "./LibSilo.sol";
+import "hardhat/console.sol";
 
 /**
  * @author Publius
@@ -97,6 +98,13 @@ library LibLPSilo {
         (uint112 reserve0, uint112 reserve1,) = IUniswapV2Pair(s.c.pair).getReserves();
 
         uint256 beanReserve = s.index == 0 ? reserve0 : reserve1;
-        return amount.mul(beanReserve).mul(2).div(IUniswapV2Pair(s.c.pair).totalSupply());
+
+        console.log("amount", amount); // 1000 
+        console.log("reserve0", reserve0); // 2000
+        console.log("reserve1", reserve1); // 2
+        console.log("beanReserve", beanReserve); // 2
+        console.log("IUniswapV2Pair(s.c.pair).totalSupply()", IUniswapV2Pair(s.c.pair).totalSupply()); // 10000
+
+        return amount.mul(beanReserve).mul(2).div(IUniswapV2Pair(s.c.pair).totalSupply()); // 0
     }
 }

--- a/protocol/contracts/libraries/Silo/LibLPSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLPSilo.sol
@@ -81,6 +81,31 @@ library LibLPSilo {
         emit LPRemove(msg.sender, crates, amounts, lpRemoved);
     }
 
+    function transferLPDeposits(uint32[] calldata crates, uint256[] calldata amounts, address transferTo)
+        internal 
+    {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+		uint256 lpRemoved;
+        for (uint256 i = 0; i < crates.length; i++) {
+            (uint256 crateBeans, uint256 crateSeeds) = removeLPDeposit(
+                msg.sender,
+                crates[i],
+                amounts[i]
+            );
+            lpRemoved = lpRemoved.add(crateBeans);
+			LibSilo.withdrawSiloAssets(msg.sender, crateSeeds, crateSeeds.mul(C.getStalkPerLPSeed()).add(
+                LibSilo.stalkReward(crateSeeds, s.season.current-crates[i])));
+			addLPDeposit(transferTo, crates[i], amounts[i], crateSeeds);
+			LibSilo.depositSiloAssets(transferTo, crateSeeds, crateSeeds.mul(C.getStalkPerLPSeed()).add(
+                LibSilo.stalkReward(crateSeeds, s.season.current-crates[i])));
+        }
+
+		
+		
+        emit LPRemove(msg.sender, crates, amounts, lpRemoved);
+    }
+
+
     function addLPWithdrawal(address account, uint32 arrivalSeason, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.a[account].lp.withdrawals[arrivalSeason] = s.a[account].lp.withdrawals[arrivalSeason].add(amount);

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -25,7 +25,7 @@ library LibSilo {
     **/
 
     function depositSiloAssets(address account, uint256 seeds, uint256 stalk) internal {
-        incrementBalanceOfStalk(account, stalk);
+		incrementBalanceOfStalk(account, stalk);
         incrementBalanceOfSeeds(account, seeds);
     }
 

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -1,11 +1,11 @@
 /**
  * SPDX-License-Identifier: MIT
-**/
+ **/
 
 pragma solidity ^0.7.6;
 pragma experimental ABIEncoderV2;
 
-import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
 import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 import "../LibAppStorage.sol";
 import "../../C.sol";
@@ -13,23 +13,39 @@ import "../../C.sol";
 /**
  * @author Publius
  * @title Lib Token Silo
-**/
+ **/
 library LibTokenSilo {
-
     using SafeMath for uint256;
 
-    event Deposit(address indexed account, address indexed token, uint256 season, uint256 amount, uint256 bdv);
+    event Deposit(
+        address indexed account,
+        address indexed token,
+        uint256 season,
+        uint256 amount,
+        uint256 bdv
+    );
 
     /*
      * Deposit
      */
 
-    function deposit(address account, address token, uint32 _s, uint256 amount) internal returns (uint256, uint256) {
+    function deposit(
+        address account,
+        address token,
+        uint32 _s,
+        uint256 amount
+    ) internal returns (uint256, uint256) {
         uint256 bdv = beanDenominatedValue(token, amount);
         return depositWithBDV(account, token, _s, amount, bdv);
     }
 
-    function depositWithBDV(address account, address token, uint32 _s, uint256 amount, uint256 bdv) internal returns (uint256, uint256) {
+    function depositWithBDV(
+        address account,
+        address token,
+        uint32 _s,
+        uint256 amount,
+        uint256 bdv
+    ) internal returns (uint256, uint256) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         require(bdv > 0, "Silo: No Beans under Token.");
         incrementDepositedToken(token, amount);
@@ -37,12 +53,33 @@ library LibTokenSilo {
         return (bdv.mul(s.ss[token].seeds), bdv.mul(s.ss[token].stalk));
     }
 
-    function incrementDepositedToken(address token, uint256 amount) private {
+    function transferWithBDV(
+        address account,
+        address token,
+        uint32 _s,
+        uint256 amount,
+        uint256 bdv
+    ) internal returns (uint256, uint256) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        s.siloBalances[token].deposited = s.siloBalances[token].deposited.add(amount);
+        require(bdv > 0, "Silo: No Beans under Token.");
+        addDeposit(account, token, _s, amount, bdv);
+        return (bdv.mul(s.ss[token].seeds), bdv.mul(s.ss[token].stalk));
     }
 
-    function addDeposit(address account, address token, uint32 _s, uint256 amount, uint256 bdv) internal {
+    function incrementDepositedToken(address token, uint256 amount) private {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        s.siloBalances[token].deposited = s.siloBalances[token].deposited.add(
+            amount
+        );
+    }
+
+    function addDeposit(
+        address account,
+        address token,
+        uint32 _s,
+        uint256 amount,
+        uint256 bdv
+    ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.a[account].deposits[token][_s].amount += uint128(amount);
         s.a[account].deposits[token][_s].bdv += uint128(bdv);
@@ -51,25 +88,39 @@ library LibTokenSilo {
 
     function decrementDepositedToken(address token, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        s.siloBalances[token].deposited = s.siloBalances[token].deposited.sub(amount);
+        s.siloBalances[token].deposited = s.siloBalances[token].deposited.sub(
+            amount
+        );
     }
 
     /*
      * Remove
      */
 
-    function removeDeposit(address account, address token, uint32 id, uint256 amount)
-        internal
-        returns (uint256, uint256) 
-    {
+    function removeDeposit(
+        address account,
+        address token,
+        uint32 id,
+        uint256 amount
+    ) internal returns (uint256, uint256) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        (uint256 crateAmount, uint256 crateBase) = tokenDeposit(account, token, id);
+        (uint256 crateAmount, uint256 crateBase) = tokenDeposit(
+            account,
+            token,
+            id
+        );
         require(crateAmount >= amount, "Silo: Crate balance too low.");
         if (amount < crateAmount) {
             uint256 base = amount.mul(crateBase).div(crateAmount);
-            uint256 newBase = uint256(s.a[account].deposits[token][id].bdv).sub(base);
-            uint256 newAmount = uint256(s.a[account].deposits[token][id].amount).sub(amount);
-            require(newBase <= uint128(-1) && newAmount <= uint128(-1), 'Silo: uint128 overflow.');
+            uint256 newBase = uint256(s.a[account].deposits[token][id].bdv).sub(
+                base
+            );
+            uint256 newAmount = uint256(s.a[account].deposits[token][id].amount)
+                .sub(amount);
+            require(
+                newBase <= uint128(-1) && newAmount <= uint128(-1),
+                "Silo: uint128 overflow."
+            );
             s.a[account].deposits[token][id].amount = uint128(newAmount);
             s.a[account].deposits[token][id].bdv = uint128(newBase);
             return (amount, base);
@@ -83,20 +134,42 @@ library LibTokenSilo {
      * Getters
      */
 
-    function tokenDeposit(address account, address token, uint32 id) internal view returns (uint256, uint256) {
+    // returns token amount and token bdv
+    function tokenDeposit(
+        address account,
+        address token,
+        uint32 id
+    ) internal view returns (uint256, uint256) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        return (s.a[account].deposits[token][id].amount, s.a[account].deposits[token][id].bdv);
+        return (
+            s.a[account].deposits[token][id].amount,
+            s.a[account].deposits[token][id].bdv
+        );
     }
 
-    function beanDenominatedValue(address token, uint256 amount) private returns (uint256 bdv) {
+    function beanDenominatedValue(address token, uint256 amount)
+        private
+        returns (uint256 bdv)
+    {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        bytes memory myFunctionCall = abi.encodeWithSelector(s.ss[token].selector, amount);
-        (bool success, bytes memory data) = address(this).delegatecall(myFunctionCall);
+        bytes memory myFunctionCall = abi.encodeWithSelector(
+            s.ss[token].selector,
+            amount
+        );
+        (bool success, bytes memory data) = address(this).delegatecall(
+            myFunctionCall
+        );
         require(success, "Silo: Bean denominated value failed.");
-        assembly { bdv := mload(add(data, add(0x20, 0))) }
+        assembly {
+            bdv := mload(add(data, add(0x20, 0)))
+        }
     }
 
-    function tokenWithdrawal(address account, address token, uint32 id) internal view returns (uint256) {
+    function tokenWithdrawal(
+        address account,
+        address token,
+        uint32 id
+    ) internal view returns (uint256) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return s.a[account].withdrawals[token][id];
     }

--- a/protocol/contracts/mocks/MockInitDiamond.sol
+++ b/protocol/contracts/mocks/MockInitDiamond.sol
@@ -26,11 +26,16 @@ contract MockInitDiamond {
     AppStorage internal s;
 
     function init(address mockRouter) external {
-        s.c.bean = address(new MockToken("BEAN", "Beanstalk"));
-        s.c.pair = address(new MockUniswapV2Pair(s.c.bean));
         s.c.pegPair = address(new MockUniswapV2Pair(s.c.weth));
         MockUniswapV2Router(mockRouter).setPair(s.c.pair);
         s.c.weth = IUniswapV2Router02(mockRouter).WETH();
+		// comment out these if testing
+        // s.c.bean = address(new MockToken("BEAN", "Beanstalk"));
+        // s.c.pair = address(new MockUniswapV2Pair(s.c.bean));
+		
+		// comment in these if testing
+        s.c.bean = address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db);
+        s.c.pair = address(0x87898263B6C5BABe34b4ec53F22d98430b91e371);
 
         IBean(s.c.bean).approve(mockRouter, uint256(-1));
         IUniswapV2Pair(s.c.pair).approve(mockRouter, uint256(-1));

--- a/protocol/contracts/mocks/MockInitDiamond.sol
+++ b/protocol/contracts/mocks/MockInitDiamond.sol
@@ -27,7 +27,6 @@ contract MockInitDiamond {
 
     function init(address mockRouter) external {
         s.c.pegPair = address(new MockUniswapV2Pair(s.c.weth));
-        MockUniswapV2Router(mockRouter).setPair(s.c.pair);
         s.c.weth = IUniswapV2Router02(mockRouter).WETH();
 		// comment out these if testing
         // s.c.bean = address(new MockToken("BEAN", "Beanstalk"));
@@ -37,6 +36,7 @@ contract MockInitDiamond {
         s.c.bean = address(0xDC59ac4FeFa32293A95889Dc396682858d52e5Db);
         s.c.pair = address(0x87898263B6C5BABe34b4ec53F22d98430b91e371);
 
+        MockUniswapV2Router(mockRouter).setPair(s.c.pair);
         IBean(s.c.bean).approve(mockRouter, uint256(-1));
         IUniswapV2Pair(s.c.pair).approve(mockRouter, uint256(-1));
         IWETH(s.c.weth).approve(mockRouter, uint256(-1));

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -20,7 +20,7 @@
     "csvtojson": "^2.0.10",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.2",
-    "hardhat": "^2.4.3",
+    "hardhat": "^2.9.2",
     "hardhat-contract-sizer": "^2.0.3",
     "hardhat-gas-reporter": "^1.0.4",
     "json-bigint": "^1.0.0",

--- a/protocol/scripts/deploy.js
+++ b/protocol/scripts/deploy.js
@@ -1,64 +1,71 @@
-const MAX_INT = '115792089237316195423570985008687907853269984665640564039457584007913129639935'
+const MAX_INT =
+  "115792089237316195423570985008687907853269984665640564039457584007913129639935";
 
-const diamond = require('./diamond.js')
-const { impersonateCurve } = require('./impersonate.js')
+const diamond = require("./diamond.js");
+const {
+  impersonateCurve,
+  impersonateRouter,
+  impersonateBean,
+  impersonatePool,
+} = require("./impersonate.js");
 function addCommas(nStr) {
-  nStr += ''
-  const x = nStr.split('.')
-  let x1 = x[0]
-  const x2 = x.length > 1 ? '.' + x[1] : ''
-  var rgx = /(\d+)(\d{3})/
+  nStr += "";
+  const x = nStr.split(".");
+  let x1 = x[0];
+  const x2 = x.length > 1 ? "." + x[1] : "";
+  var rgx = /(\d+)(\d{3})/;
   while (rgx.test(x1)) {
-    x1 = x1.replace(rgx, '$1' + ',' + '$2')
+    x1 = x1.replace(rgx, "$1" + "," + "$2");
   }
-  return x1 + x2
+  return x1 + x2;
 }
 
 function strDisplay(str) {
-  return addCommas(str.toString())
+  return addCommas(str.toString());
 }
 
 async function main(scriptName, verbose = true, mock = false) {
   if (verbose) {
-    console.log('SCRIPT NAME: ', scriptName)
-    console.log('MOCKS ENABLED: ', mock)
+    console.log("SCRIPT NAME: ", scriptName);
+    console.log("MOCKS ENABLED: ", mock);
   }
 
-  const accounts = await ethers.getSigners()
-  const account = await accounts[0].getAddress()
+  const accounts = await ethers.getSigners();
+  const account = await accounts[0].getAddress();
   if (verbose) {
-    console.log('Account: ' + account)
-    console.log('---')
+    console.log("Account: " + account);
+    console.log("---");
   }
-  let tx
-  let totalGasUsed = ethers.BigNumber.from('0')
-  let receipt
-  const name = 'Beanstalk'
+  let tx;
+  let totalGasUsed = ethers.BigNumber.from("0");
+  let receipt;
+  const name = "Beanstalk";
 
-
-  async function deployFacets(verbose,
+  async function deployFacets(
+    verbose,
     facets,
     libraryNames = [],
-    facetLibraries = {},
+    facetLibraries = {}
   ) {
-    const instances = []
-    const libraries = {}
+    const instances = [];
+    const libraries = {};
 
     for (const name of libraryNames) {
-      if (verbose) console.log(`Deploying: ${name}`)
-      let libraryFactory = await ethers.getContractFactory(name)
-      libraryFactory = await libraryFactory.deploy()
-      await libraryFactory.deployed()
-      const receipt = await libraryFactory.deployTransaction.wait()
-      if (verbose) console.log(`${name} deploy gas used: ` + strDisplay(receipt.gasUsed))
-      if (verbose) console.log(`Deployed at ${libraryFactory.address}`)
-      libraries[name] = libraryFactory.address
+      if (verbose) console.log(`Deploying: ${name}`);
+      let libraryFactory = await ethers.getContractFactory(name);
+      libraryFactory = await libraryFactory.deploy();
+      await libraryFactory.deployed();
+      const receipt = await libraryFactory.deployTransaction.wait();
+      if (verbose)
+        console.log(`${name} deploy gas used: ` + strDisplay(receipt.gasUsed));
+      if (verbose) console.log(`Deployed at ${libraryFactory.address}`);
+      libraries[name] = libraryFactory.address;
     }
 
     for (let facet of facets) {
-      let constructorArgs = []
+      let constructorArgs = [];
       if (Array.isArray(facet)) {
-        ;[facet, constructorArgs] = facet
+        [facet, constructorArgs] = facet;
       }
       let factory;
       if (facetLibraries[facet] !== undefined) {
@@ -67,21 +74,21 @@ async function main(scriptName, verbose = true, mock = false) {
           return acc;
         }, {});
         factory = await ethers.getContractFactory(facet, {
-          libraries: facetLibrary
-        },
-        );
+          libraries: facetLibrary,
+        });
       } else {
-        factory = await ethers.getContractFactory(facet)
+        factory = await ethers.getContractFactory(facet);
       }
-      const facetInstance = await factory.deploy(...constructorArgs)
-      await facetInstance.deployed()
-      const tx = facetInstance.deployTransaction
-      const receipt = await tx.wait()
-      if (verbose) console.log(`${facet} deploy gas used: ` + strDisplay(receipt.gasUsed))
-      totalGasUsed = totalGasUsed.add(receipt.gasUsed)
-      instances.push(facetInstance)
+      const facetInstance = await factory.deploy(...constructorArgs);
+      await facetInstance.deployed();
+      const tx = facetInstance.deployTransaction;
+      const receipt = await tx.wait();
+      if (verbose)
+        console.log(`${facet} deploy gas used: ` + strDisplay(receipt.gasUsed));
+      totalGasUsed = totalGasUsed.add(receipt.gasUsed);
+      instances.push(facetInstance);
     }
-    return instances
+    return instances;
   }
   let [
     seasonFacet,
@@ -95,111 +102,137 @@ async function main(scriptName, verbose = true, mock = false) {
     marketplaceFacet,
     fundraiserFacet,
     convertFacet,
-    budgetFacet
-  ] = mock ? await deployFacets(
-    verbose,
-    ['MockSeasonFacet',
-      'MockOracleFacet',
-      'MockFieldFacet',
-      'MockSiloFacet',
-      'MockSiloV2Facet',
-      'CurveBDVFacet',
-      'MockGovernanceFacet',
-      'MockClaimFacet',
-      'MockMarketplaceFacet',
-      'MockFundraiserFacet',
-      'ConvertFacet',
-      'MockBudgetFacet'],
-    ["LibClaim"],
-    {
-      "MockMarketplaceFacet": ["LibClaim"],
-      "MockSiloFacet": ["LibClaim"],
-      "MockFieldFacet": ["LibClaim"],
-      "MockClaimFacet": ["LibClaim"],
-      "ConvertFacet": ["LibClaim"]
-    },
-  ) : await deployFacets(
-    verbose,
-    ['SeasonFacet',
-      'OracleFacet',
-      'FieldFacet',
-      'SiloFacet',
-      'SiloV2Facet',
-      'CurveBDVFacet',
-      'GovernanceFacet',
-      'ClaimFacet',
-      'MarketplaceFacet',
-      'FundraiserFacet',
-      'ConvertFacet',
-      'BudgetFacet'],
-    ["LibClaim"],
-    {
-      "SiloFacet": ["LibClaim"],
-      "FieldFacet": ["LibClaim"],
-      "ClaimFacet": ["LibClaim"],
-      "ConvertFacet": ["LibClaim"],
-      "MarketplaceFacet": ["LibClaim"]
-    },
-  )
-  const initDiamondArg = mock ? 'contracts/mocks/MockInitDiamond.sol:MockInitDiamond' : 'contracts/farm/InitDiamond.sol:InitDiamond'
+    budgetFacet,
+  ] = mock
+    ? await deployFacets(
+        verbose,
+        [
+          "MockSeasonFacet",
+          "MockOracleFacet",
+          "MockFieldFacet",
+          "MockSiloFacet",
+          "MockSiloV2Facet",
+          "CurveBDVFacet",
+          "MockGovernanceFacet",
+          "MockClaimFacet",
+          "MockMarketplaceFacet",
+          "MockFundraiserFacet",
+          "ConvertFacet",
+          "MockBudgetFacet",
+        ],
+        ["LibClaim"],
+        {
+          MockMarketplaceFacet: ["LibClaim"],
+          MockSiloFacet: ["LibClaim"],
+          MockFieldFacet: ["LibClaim"],
+          MockClaimFacet: ["LibClaim"],
+          ConvertFacet: ["LibClaim"],
+        }
+      )
+    : await deployFacets(
+        verbose,
+        [
+          "SeasonFacet",
+          "OracleFacet",
+          "FieldFacet",
+          "SiloFacet",
+          "SiloV2Facet",
+          "CurveBDVFacet",
+          "GovernanceFacet",
+          "ClaimFacet",
+          "MarketplaceFacet",
+          "FundraiserFacet",
+          "ConvertFacet",
+          "BudgetFacet",
+        ],
+        ["LibClaim"],
+        {
+          SiloFacet: ["LibClaim"],
+          FieldFacet: ["LibClaim"],
+          ClaimFacet: ["LibClaim"],
+          ConvertFacet: ["LibClaim"],
+          MarketplaceFacet: ["LibClaim"],
+        }
+      );
+  const initDiamondArg = mock
+    ? "contracts/mocks/MockInitDiamond.sol:MockInitDiamond"
+    : "contracts/farm/InitDiamond.sol:InitDiamond";
   // eslint-disable-next-line no-unused-vars
 
-  let args = []
+  let args = [];
   if (mock) {
-    await impersonateCurve()
-    const MockUniswapV2Router = await ethers.getContractFactory("MockUniswapV2Router");
+    await impersonateCurve();
+    await impersonateRouter();
+    await impersonateBean();
+    await impersonatePool();
+    const MockUniswapV2Router = await ethers.getContractFactory(
+      "MockUniswapV2Router"
+    );
     mockRouter = await MockUniswapV2Router.deploy();
-    args.push(mockRouter.address)
+    args.push(mockRouter.address);
   }
 
   const [beanstalkDiamond, diamondCut] = await diamond.deploy({
-    diamondName: 'BeanstalkDiamond',
+    diamondName: "BeanstalkDiamond",
     initDiamond: initDiamondArg,
     facets: [
-      ['SeasonFacet', seasonFacet],
-      ['OracleFacet', oracleFacet],
-      ['FieldFacet', fieldFacet],
-      ['SiloFacet', siloFacet],
-      ['SiloV2Facet', siloV2Facet],
-      ['CurveBDVFacet', curveBDVFacet],
-      ['GovernanceFacet', governanceFacet],
-      ['ClaimFacet', claimFacet],
-      ['MarketplaceFacet', marketplaceFacet],
-      ['FundraiserFacet', fundraiserFacet],
-      ['ConvertFacet', convertFacet],
-      ['BudgetFacet', budgetFacet]
+      ["SeasonFacet", seasonFacet],
+      ["OracleFacet", oracleFacet],
+      ["FieldFacet", fieldFacet],
+      ["SiloFacet", siloFacet],
+      ["SiloV2Facet", siloV2Facet],
+      ["CurveBDVFacet", curveBDVFacet],
+      ["GovernanceFacet", governanceFacet],
+      ["ClaimFacet", claimFacet],
+      ["MarketplaceFacet", marketplaceFacet],
+      ["FundraiserFacet", fundraiserFacet],
+      ["ConvertFacet", convertFacet],
+      ["BudgetFacet", budgetFacet],
     ],
     owner: account,
     args: args,
-    verbose: verbose
+    verbose: verbose,
   });
 
-  tx = beanstalkDiamond.deployTransaction
-  receipt = await tx.wait()
-  if (verbose) console.log('BeanStalk diamond deploy gas used: ' + strDisplay(receipt.gasUsed))
-  if (verbose) console.log('BeanStalk diamond cut gas used: ' + strDisplay(diamondCut.gasUsed))
-  totalGasUsed = totalGasUsed.add(receipt.gasUsed).add(diamondCut.gasUsed)
+  tx = beanstalkDiamond.deployTransaction;
+  receipt = await tx.wait();
+  if (verbose)
+    console.log(
+      "BeanStalk diamond deploy gas used: " + strDisplay(receipt.gasUsed)
+    );
+  if (verbose)
+    console.log(
+      "BeanStalk diamond cut gas used: " + strDisplay(diamondCut.gasUsed)
+    );
+  totalGasUsed = totalGasUsed.add(receipt.gasUsed).add(diamondCut.gasUsed);
 
-
-  const season = await ethers.getContractAt('SeasonFacet', beanstalkDiamond.address);
+  const season = await ethers.getContractAt(
+    "SeasonFacet",
+    beanstalkDiamond.address
+  );
   const bean = await season.bean();
   const pair = await season.pair();
   const pegPair = await season.pegPair();
-  const silo = await ethers.getContractAt('SiloFacet', beanstalkDiamond.address);
+  const silo = await ethers.getContractAt(
+    "SiloFacet",
+    beanstalkDiamond.address
+  );
   const weth = await silo.weth();
 
   if (verbose) {
     console.log("--");
-    console.log('Beanstalk diamond address:' + beanstalkDiamond.address)
-    console.log('Bean address:' + bean)
-    console.log('Uniswap Pair address:' + pair)
+    console.log("Beanstalk diamond address:" + beanstalkDiamond.address);
+    console.log("Bean address:" + bean);
+    console.log("Uniswap Pair address:" + pair);
     console.log("--");
   }
 
-  const diamondLoupeFacet = await ethers.getContractAt('DiamondLoupeFacet', beanstalkDiamond.address)
+  const diamondLoupeFacet = await ethers.getContractAt(
+    "DiamondLoupeFacet",
+    beanstalkDiamond.address
+  );
 
-
-  if (verbose) console.log('Total gas used: ' + strDisplay(totalGasUsed))
+  if (verbose) console.log("Total gas used: " + strDisplay(totalGasUsed));
   return {
     account: account,
     beanstalkDiamond: beanstalkDiamond,
@@ -218,7 +251,7 @@ async function main(scriptName, verbose = true, mock = false) {
     pegPair: pegPair,
     weth: weth,
     bean: bean,
-  }
+  };
 }
 
 // We recommend this pattern to be able to use async/await everywhere
@@ -227,8 +260,8 @@ if (require.main === module) {
   main()
     .then(() => process.exit(0))
     .catch((error) => {
-      console.error(error)
-      process.exit(1)
-    })
+      console.error(error);
+      process.exit(1);
+    });
 }
-exports.deploy = main
+exports.deploy = main;

--- a/protocol/scripts/impersonate.js
+++ b/protocol/scripts/impersonate.js
@@ -1,22 +1,70 @@
-var fs = require('fs');
-
+var fs = require("fs");
 
 const THREE_CURVE = "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7";
 const BEAN_3_CURVE = "0x3a70DfA7d2262988064A2D051dd47521E43c9BdD";
+const UNISWAP_V2_ROUTER = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D";
+const UNISWAP_V2_PAIR = "0x87898263B6C5BABe34b4ec53F22d98430b91e371";
+const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const BEAN = "0xDC59ac4FeFa32293A95889Dc396682858d52e5Db";
 
 async function curve() {
-    let threeCurveJson = fs.readFileSync(`./artifacts/contracts/mocks/curve/Mock3Curve.sol/Mock3Curve.json`);
-    await network.provider.send("hardhat_setCode", [
-      THREE_CURVE,
-      JSON.parse(threeCurveJson).deployedBytecode,
-    ]);
+  let threeCurveJson = fs.readFileSync(
+    `./artifacts/contracts/mocks/curve/Mock3Curve.sol/Mock3Curve.json`
+  );
+  await network.provider.send("hardhat_setCode", [
+    THREE_CURVE,
+    JSON.parse(threeCurveJson).deployedBytecode,
+  ]);
 
-
-    let bean3CurveJson = fs.readFileSync(`./artifacts/contracts/mocks/curve/MockBean3Curve.sol/MockBean3Curve.json`);
-    await network.provider.send("hardhat_setCode", [
-      BEAN_3_CURVE,
-      JSON.parse(bean3CurveJson).deployedBytecode,
-    ]);
+  let bean3CurveJson = fs.readFileSync(
+    `./artifacts/contracts/mocks/curve/MockBean3Curve.sol/MockBean3Curve.json`
+  );
+  await network.provider.send("hardhat_setCode", [
+    BEAN_3_CURVE,
+    JSON.parse(bean3CurveJson).deployedBytecode,
+  ]);
 }
 
-exports.impersonateCurve = curve
+async function router() {
+  let routerJson = fs.readFileSync(
+    `./artifacts/contracts/mocks/MockUniswapV2Router.sol/MockUniswapV2Router.json`
+  );
+  await network.provider.send("hardhat_setCode", [
+    UNISWAP_V2_ROUTER,
+    JSON.parse(routerJson).deployedBytecode,
+  ]);
+
+  let tokenJson = fs.readFileSync(
+    `./artifacts/contracts/mocks/MockWETH.sol/MockWETH.json`
+  );
+  await network.provider.send("hardhat_setCode", [
+    WETH,
+    JSON.parse(tokenJson).deployedBytecode,
+  ]);
+}
+
+async function pool() {
+  let tokenJson = fs.readFileSync(
+    `./artifacts/contracts/mocks/MockUniswapV2Pair.sol/MockUniswapV2Pair.json`
+  );
+  await network.provider.send("hardhat_setCode", [
+    UNISWAP_V2_PAIR,
+    JSON.parse(tokenJson).deployedBytecode,
+  ]);
+}
+
+async function bean() {
+  let tokenJson = fs.readFileSync(
+    `./artifacts/contracts/mocks/MockToken.sol/MockToken.json`
+  );
+
+  await network.provider.send("hardhat_setCode", [
+    BEAN,
+    JSON.parse(tokenJson).deployedBytecode,
+  ]);
+}
+
+exports.impersonateRouter = router;
+exports.impersonateBean = bean;
+exports.impersonateCurve = curve;
+exports.impersonatePool = pool;

--- a/protocol/test/SiloV2.test.js
+++ b/protocol/test/SiloV2.test.js
@@ -1395,20 +1395,13 @@ describe("Silo", function () {
     });
 
 	it("properly transfers beans", async function () {
-	  console.log(await this.silo.balanceOfStalk(userAddress));
-	  console.log(await this.silo.balanceOfSeeds(userAddress));
-	  console.log(await this.silo.balanceOfStalk(user2Address));
-	  console.log(await this.silo.balanceOfSeeds(user2Address));
-	   
 	  await this.silo2.connect(user).transferTokenBySeasons(this.bean.address, [3], [1000], user2Address);
-
-	  console.log(await this.silo.balanceOfStalk(userAddress));
-	  console.log(await this.silo.balanceOfSeeds(userAddress));
-	  console.log(await this.silo.balanceOfStalk(user2Address));
-	  console.log(await this.silo.balanceOfSeeds(user2Address));
-
       expect(await this.silo2.getTotalDeposited(this.bean.address)).to.eq("1000");
       expect(await this.silo2.getTotalWithdrawn(this.bean.address)).to.eq("0");
+	  expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
+	  expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+	  expect(await this.silo.balanceOfStalk(user2Address)).to.eq("10000000");
+	  expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("2000");
     });
   });
 
@@ -1432,20 +1425,13 @@ describe("Silo", function () {
     });
 
 	it("properly transfers LP", async function () {
-	  console.log(await this.silo.balanceOfStalk(userAddress));
-	  console.log(await this.silo.balanceOfSeeds(userAddress));
-	  console.log(await this.silo.balanceOfStalk(user2Address));
-	  console.log(await this.silo.balanceOfSeeds(user2Address));
-	   
 	  await this.silo2.connect(user).transferTokenBySeasons(this.pair.address, [3], [1000], user2Address);
-
-	  console.log(await this.silo.balanceOfStalk(userAddress));
-	  console.log(await this.silo.balanceOfSeeds(userAddress));
-	  console.log(await this.silo.balanceOfStalk(user2Address));
-	  console.log(await this.silo.balanceOfSeeds(user2Address));
-
       expect(await this.silo2.getTotalDeposited(this.pair.address)).to.eq("1000");
       expect(await this.silo2.getTotalWithdrawn(this.pair.address)).to.eq("0");
+	  expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
+	  expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+	  expect(await this.silo.balanceOfStalk(user2Address)).to.eq("2000000");
+	  expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("800");
     });
   });
 });

--- a/protocol/test/SiloV2.test.js
+++ b/protocol/test/SiloV2.test.js
@@ -1393,6 +1393,20 @@ describe("Silo", function () {
       expect(await this.silo2.getTotalDeposited(this.bean.address)).to.eq("0");
       expect(await this.silo2.getTotalWithdrawn(this.bean.address)).to.eq("1000");
     });
+
+	it("properly transfers beans", async function () {
+	  console.log(await this.silo.balanceOfStalk(userAddress));
+	  console.log(await this.silo.balanceOfSeeds(userAddress));
+	  console.log(await this.silo.balanceOfStalk(user2Address));
+	  console.log(await this.silo.balanceOfSeeds(user2Address));
+	   
+	  await this.silo2.connect(user).transferTokenBySeasons(this.bean.address, [3], [1000], user2Address);
+	  console.log(await this.silo.balanceOfStalk(userAddress));
+	  console.log(await this.silo.balanceOfSeeds(userAddress));
+	  console.log(await this.silo.balanceOfStalk(user2Address));
+	  console.log(await this.silo.balanceOfSeeds(user2Address));
+      expect(await this.silo2.getTotalDeposited(this.bean.address)).to.eq("1000");
+      expect(await this.silo2.getTotalWithdrawn(this.bean.address)).to.eq("0");
   });
 
   describe("LP deposit and withdraw", async function () {

--- a/protocol/test/SiloV2.test.js
+++ b/protocol/test/SiloV2.test.js
@@ -1414,5 +1414,12 @@ describe("Silo", function () {
     //     .withdrawTokenBySeason(this.pair.address, 3, "1000");
     //   expect(await this.LPSilo.totalDepositedLP()).to.eq("0");
     // });
+    it("properly withdraws LP", async function () {
+      await this.silo2
+        .connect(user)
+        .withdrawTokenBySeasons(this.pair.address, [3], ["1000"]);
+      expect(await this.silo2.getTotalDeposited(this.pair.address)).to.eq("0");
+      expect(await this.silo2.getTotalWithdrawn(this.pair.address)).to.eq("1000");
+    });
   });
 });

--- a/protocol/test/SiloV2.test.js
+++ b/protocol/test/SiloV2.test.js
@@ -1401,20 +1401,21 @@ describe("Silo", function () {
 	  console.log(await this.silo.balanceOfSeeds(user2Address));
 	   
 	  await this.silo2.connect(user).transferTokenBySeasons(this.bean.address, [3], [1000], user2Address);
+
 	  console.log(await this.silo.balanceOfStalk(userAddress));
 	  console.log(await this.silo.balanceOfSeeds(userAddress));
 	  console.log(await this.silo.balanceOfStalk(user2Address));
 	  console.log(await this.silo.balanceOfSeeds(user2Address));
+
       expect(await this.silo2.getTotalDeposited(this.bean.address)).to.eq("1000");
       expect(await this.silo2.getTotalWithdrawn(this.bean.address)).to.eq("0");
+    });
   });
 
   describe("LP deposit and withdraw", async function () {
     beforeEach(async function () {
       await this.season.siloSunrise(0);
-	  console.log(await this.pair.balanceOf(userAddress));
       await this.pair.faucet(userAddress, "10000");
-	  console.log(await this.pair.balanceOf(userAddress));
       await this.silo2.connect(user).deposit(this.pair.address, "1000");
     });
 
@@ -1428,6 +1429,23 @@ describe("Silo", function () {
         .withdrawTokenBySeasons(this.pair.address, [3], ["1000"]);
       expect(await this.silo2.getTotalDeposited(this.pair.address)).to.eq("0");
       expect(await this.silo2.getTotalWithdrawn(this.pair.address)).to.eq("1000");
+    });
+
+	it("properly transfers LP", async function () {
+	  console.log(await this.silo.balanceOfStalk(userAddress));
+	  console.log(await this.silo.balanceOfSeeds(userAddress));
+	  console.log(await this.silo.balanceOfStalk(user2Address));
+	  console.log(await this.silo.balanceOfSeeds(user2Address));
+	   
+	  await this.silo2.connect(user).transferTokenBySeasons(this.pair.address, [3], [1000], user2Address);
+
+	  console.log(await this.silo.balanceOfStalk(userAddress));
+	  console.log(await this.silo.balanceOfSeeds(userAddress));
+	  console.log(await this.silo.balanceOfStalk(user2Address));
+	  console.log(await this.silo.balanceOfSeeds(user2Address));
+
+      expect(await this.silo2.getTotalDeposited(this.pair.address)).to.eq("1000");
+      expect(await this.silo2.getTotalWithdrawn(this.pair.address)).to.eq("0");
     });
   });
 });

--- a/protocol/test/SiloV2.test.js
+++ b/protocol/test/SiloV2.test.js
@@ -1408,12 +1408,6 @@ describe("Silo", function () {
       expect(await this.silo2.getTotalDeposited(this.pair.address)).to.eq("1000");
     });
 
-    // it("properly withdraws LP", async function () {
-    //   await this.silo2
-    //     .connect(user)
-    //     .withdrawTokenBySeason(this.pair.address, 3, "1000");
-    //   expect(await this.LPSilo.totalDepositedLP()).to.eq("0");
-    // });
     it("properly withdraws LP", async function () {
       await this.silo2
         .connect(user)

--- a/protocol/test/SiloV2.test.js
+++ b/protocol/test/SiloV2.test.js
@@ -1,58 +1,84 @@
-const { expect } = require('chai');
-const { deploy } = require('../scripts/deploy.js')
-let user,user2,owner;
+const { expect } = require("chai");
+const { deploy } = require("../scripts/deploy.js");
+let user, user2, owner;
 let userAddress, ownerAddress, user2Address;
 
 const THREE_CURVE = "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7";
 const BEAN_3_CURVE = "0x3a70DfA7d2262988064A2D051dd47521E43c9BdD";
 
-const BN_ZERO = ethers.utils.parseEther('0');
+const BN_ZERO = ethers.utils.parseEther("0");
 
-describe('Silo', function () {
+describe("Silo", function () {
   before(async function () {
-    [owner,user,user2] = await ethers.getSigners();
+    [owner, user, user2] = await ethers.getSigners();
     userAddress = user.address;
     user2Address = user2.address;
     const contracts = await deploy("Test", false, true);
     ownerAddress = contracts.account;
     this.diamond = contracts.beanstalkDiamond;
-    this.season = await ethers.getContractAt('MockSeasonFacet', this.diamond.address);
-    this.diamondLoupeFacet = await ethers.getContractAt('DiamondLoupeFacet', this.diamond.address)
-    this.silo = await ethers.getContractAt('MockSiloFacet', this.diamond.address);
-    this.silo2 = await ethers.getContractAt('MockSiloV2Facet', this.diamond.address);
-    this.convert = await ethers.getContractAt('ConvertFacet', this.diamond.address);
-    this.pair = await ethers.getContractAt('MockUniswapV2Pair', contracts.pair);
-    this.pegPair = await ethers.getContractAt('MockUniswapV2Pair', contracts.pegPair);
-    this.bean = await ethers.getContractAt('MockToken', contracts.bean);
-    this.claim = await ethers.getContractAt('MockClaimFacet', this.diamond.address)
+    this.season = await ethers.getContractAt(
+      "MockSeasonFacet",
+      this.diamond.address
+    );
+    this.diamondLoupeFacet = await ethers.getContractAt(
+      "DiamondLoupeFacet",
+      this.diamond.address
+    );
+    this.silo = await ethers.getContractAt(
+      "MockSiloFacet",
+      this.diamond.address
+    );
+    this.silo2 = await ethers.getContractAt(
+      "MockSiloV2Facet",
+      this.diamond.address
+    );
+    this.convert = await ethers.getContractAt(
+      "ConvertFacet",
+      this.diamond.address
+    );
+    this.pair = await ethers.getContractAt("MockUniswapV2Pair", contracts.pair);
+    this.pegPair = await ethers.getContractAt(
+      "MockUniswapV2Pair",
+      contracts.pegPair
+    );
+    this.bean = await ethers.getContractAt("MockToken", contracts.bean);
+    this.claim = await ethers.getContractAt(
+      "MockClaimFacet",
+      this.diamond.address
+    );
 
     this.siloToken = await ethers.getContractFactory("MockToken");
-    this.siloToken = await this.siloToken.deploy("Silo", "SILO")
-    await this.siloToken.deployed()
+    this.siloToken = await this.siloToken.deploy("Silo", "SILO");
+    await this.siloToken.deployed();
 
     await this.silo2.mockWhitelistToken(
-      this.siloToken.address, 
-      this.silo2.interface.getSighash("mockBDV(uint256 amount)"), 
-      '10000', 
-      '1');
+      this.siloToken.address,
+      this.silo2.interface.getSighash("mockBDV(uint256 amount)"),
+      "10000",
+      "1"
+    );
 
-    await this.pair.simulateTrade('2000', '2');
+    await this.pair.simulateTrade("2000", "2");
     await this.season.siloSunrise(0);
-    await this.pair.faucet(userAddress, '1');
-    await this.bean.mint(userAddress, '1000000000');
-    await this.bean.mint(user2Address, '1000000000');
-    await this.pair.connect(user).approve(this.silo.address, '100000000000');
-    await this.pair.connect(user2).approve(this.silo.address, '100000000000');
-    await this.siloToken.connect(user).approve(this.silo.address, '100000000000');
-    await this.siloToken.connect(user2).approve(this.silo.address, '100000000000');
-    await this.bean.connect(user).approve(this.silo.address, '100000000000');
-    await this.bean.connect(user2).approve(this.silo.address, '100000000000'); 
+    await this.pair.faucet(userAddress, "1");
+    await this.bean.mint(userAddress, "1000000000");
+    await this.bean.mint(user2Address, "1000000000");
+    await this.pair.connect(user).approve(this.silo.address, "100000000000");
+    await this.pair.connect(user2).approve(this.silo.address, "100000000000");
+    await this.siloToken
+      .connect(user)
+      .approve(this.silo.address, "100000000000");
+    await this.siloToken
+      .connect(user2)
+      .approve(this.silo.address, "100000000000");
+    await this.bean.connect(user).approve(this.silo.address, "100000000000");
+    await this.bean.connect(user2).approve(this.silo.address, "100000000000");
   });
 
-  beforeEach (async function () {
-    await this.season.resetAccount(userAddress)
-    await this.season.resetAccount(user2Address)
-    await this.season.resetAccount(ownerAddress)
+  beforeEach(async function () {
+    await this.season.resetAccount(userAddress);
+    await this.season.resetAccount(user2Address);
+    await this.season.resetAccount(ownerAddress);
     await this.season.resetAccountToken(userAddress, this.siloToken.address);
     await this.season.resetAccountToken(user2Address, this.siloToken.address);
     await this.pair.burnAllLP(this.silo.address);
@@ -61,489 +87,1289 @@ describe('Silo', function () {
     await this.pair.burnAllLP(ownerAddress);
     await this.season.resetState();
     await this.season.siloSunrise(0);
-    await this.siloToken.mint(userAddress, '10000');
-    await this.siloToken.mint(user2Address, '10000');
+    await this.siloToken.mint(userAddress, "10000");
+    await this.siloToken.mint(user2Address, "10000");
   });
 
-  describe('reverts', function () {
-    it('reverts not Beanstalk tries to whitelist ', async function () {
-      await expect(this.silo2.connect(user).whitelistToken(
-        this.siloToken.address, 
-        this.silo2.interface.getSighash("mockBDV(uint256 amount)"), 
-        '10000', 
-        '1')).to.revertedWith('Silo: Only Beanstalk can whitelist tokens.');
-    });
-  });
-
-  describe('deposit', function () {
-    describe('reverts', function () {
-      it('reverts if BDV is 0', async function () {
-        await expect(this.silo2.connect(user).deposit(this.siloToken.address, '0')).to.revertedWith('Silo: No Beans under Token.');
-      });
-
-      it('reverts if deposits a non whitelisted token', async function () {
-        await expect(this.silo2.connect(user).deposit(this.bean.address, '0')).to.revertedWith('Silo: Bean denominated value failed.');
-      });
-    });
-
-    describe('single deposit', function () {
-      beforeEach(async function () {
-        this.result = await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-      });
-  
-      it('properly updates the total balances', async function () {
-        expect(await this.silo2.getTotalDeposited(this.siloToken.address)).to.eq('1000');
-        expect(await this.silo.totalSeeds()).to.eq('1000');
-        expect(await this.silo.totalStalk()).to.eq('10000000');
-      });
-  
-      it('properly updates the user balance', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('1000');
-        expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10000000');
-      });
-  
-      it('properly adds the crate', async function () {
-        const deposit = await this.silo2.getDeposit(userAddress, this.siloToken.address, 2);
-        expect(deposit[0]).to.eq('1000');
-        expect(deposit[1]).to.eq('1000');
-      })
-
-      it('emits Deposit event', async function () {
-        await expect(this.result).to.emit(this.silo2, 'Deposit').withArgs(userAddress, this.siloToken.address, 2, '1000', '1000');
-      });
-    });
-  
-    describe('2 deposits same season', function () {
-      beforeEach(async function () {
-        this.result = await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-        this.result = await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-      });
-  
-      it('properly updates the total balances', async function () {
-        expect(await this.silo2.getTotalDeposited(this.siloToken.address)).to.eq('2000');
-        expect(await this.silo.totalSeeds()).to.eq('2000');
-        expect(await this.silo.totalStalk()).to.eq('20000000');
-      });
-  
-      it('properly updates the user balance', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('2000');
-        expect(await this.silo.balanceOfStalk(userAddress)).to.eq('20000000');
-      });
-  
-      it('properly adds the crate', async function () {
-        const deposit = await this.silo2.getDeposit(userAddress, this.siloToken.address, 2);
-        expect(deposit[0]).to.eq('2000');
-        expect(deposit[1]).to.eq('2000');
-      })
-    });
-  
-    describe('2 deposits 2 users', function () {
-      beforeEach(async function () {
-        this.result = await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-        this.result = await this.silo2.connect(user2).deposit(this.siloToken.address, '1000');
-      });
-  
-      it('properly updates the total balances', async function () {
-        expect(await this.silo2.getTotalDeposited(this.siloToken.address)).to.eq('2000');
-        expect(await this.silo.totalSeeds()).to.eq('2000');
-        expect(await this.silo.totalStalk()).to.eq('20000000');
-      });
-  
-      it('properly updates the user balance', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('1000');
-        expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10000000');
-      });
-      it('properly updates the user2 balance', async function () {
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.eq('1000');
-        expect(await this.silo.balanceOfStalk(user2Address)).to.eq('10000000');
-      });
-  
-      it('properly adds the crate', async function () {
-        let deposit = await this.silo2.getDeposit(userAddress, this.siloToken.address, 2);
-        expect(deposit[0]).to.eq('1000');
-        expect(deposit[1]).to.eq('1000');
-        deposit = await this.silo2.getDeposit(user2Address, this.siloToken.address, 2);
-        expect(deposit[0]).to.eq('1000');
-        expect(deposit[1]).to.eq('1000');
-      });
+  describe("reverts", function () {
+    it("reverts not Beanstalk tries to whitelist ", async function () {
+      await expect(
+        this.silo2
+          .connect(user)
+          .whitelistToken(
+            this.siloToken.address,
+            this.silo2.interface.getSighash("mockBDV(uint256 amount)"),
+            "10000",
+            "1"
+          )
+      ).to.revertedWith("Silo: Only Beanstalk can whitelist tokens.");
     });
   });
 
-  describe('withdraw', function () {
+  describe("deposit", function () {
+    describe("reverts", function () {
+      it("reverts if BDV is 0", async function () {
+        await expect(
+          this.silo2.connect(user).deposit(this.siloToken.address, "0")
+        ).to.revertedWith("Silo: No Beans under Token.");
+      });
+
+      it("reverts if deposits a non whitelisted token", async function () {
+        await expect(
+          this.silo2.connect(user).deposit(this.bean.address, "0")
+        ).to.revertedWith("Silo: Bean denominated value failed.");
+      });
+    });
+
+    describe("single deposit", function () {
+      beforeEach(async function () {
+        this.result = await this.silo2
+          .connect(user)
+          .deposit(this.siloToken.address, "1000");
+      });
+
+      it("properly updates the total balances", async function () {
+        expect(
+          await this.silo2.getTotalDeposited(this.siloToken.address)
+        ).to.eq("1000");
+        expect(await this.silo.totalSeeds()).to.eq("1000");
+        expect(await this.silo.totalStalk()).to.eq("10000000");
+      });
+
+      it("properly updates the user balance", async function () {
+        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+        expect(await this.silo.balanceOfStalk(userAddress)).to.eq("10000000");
+      });
+
+      it("properly adds the crate", async function () {
+        const deposit = await this.silo2.getDeposit(
+          userAddress,
+          this.siloToken.address,
+          2
+        );
+        expect(deposit[0]).to.eq("1000");
+        expect(deposit[1]).to.eq("1000");
+      });
+
+      it("emits Deposit event", async function () {
+        await expect(this.result)
+          .to.emit(this.silo2, "Deposit")
+          .withArgs(userAddress, this.siloToken.address, 2, "1000", "1000");
+      });
+    });
+
+    describe("2 deposits same season", function () {
+      beforeEach(async function () {
+        this.result = await this.silo2
+          .connect(user)
+          .deposit(this.siloToken.address, "1000");
+        this.result = await this.silo2
+          .connect(user)
+          .deposit(this.siloToken.address, "1000");
+      });
+
+      it("properly updates the total balances", async function () {
+        expect(
+          await this.silo2.getTotalDeposited(this.siloToken.address)
+        ).to.eq("2000");
+        expect(await this.silo.totalSeeds()).to.eq("2000");
+        expect(await this.silo.totalStalk()).to.eq("20000000");
+      });
+
+      it("properly updates the user balance", async function () {
+        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("2000");
+        expect(await this.silo.balanceOfStalk(userAddress)).to.eq("20000000");
+      });
+
+      it("properly adds the crate", async function () {
+        const deposit = await this.silo2.getDeposit(
+          userAddress,
+          this.siloToken.address,
+          2
+        );
+        expect(deposit[0]).to.eq("2000");
+        expect(deposit[1]).to.eq("2000");
+      });
+    });
+
+    describe("2 deposits 2 users", function () {
+      beforeEach(async function () {
+        this.result = await this.silo2
+          .connect(user)
+          .deposit(this.siloToken.address, "1000");
+        this.result = await this.silo2
+          .connect(user2)
+          .deposit(this.siloToken.address, "1000");
+      });
+
+      it("properly updates the total balances", async function () {
+        expect(
+          await this.silo2.getTotalDeposited(this.siloToken.address)
+        ).to.eq("2000");
+        expect(await this.silo.totalSeeds()).to.eq("2000");
+        expect(await this.silo.totalStalk()).to.eq("20000000");
+      });
+
+      it("properly updates the user balance", async function () {
+        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+        expect(await this.silo.balanceOfStalk(userAddress)).to.eq("10000000");
+      });
+      it("properly updates the user2 balance", async function () {
+        expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("1000");
+        expect(await this.silo.balanceOfStalk(user2Address)).to.eq("10000000");
+      });
+
+      it("properly adds the crate", async function () {
+        let deposit = await this.silo2.getDeposit(
+          userAddress,
+          this.siloToken.address,
+          2
+        );
+        expect(deposit[0]).to.eq("1000");
+        expect(deposit[1]).to.eq("1000");
+        deposit = await this.silo2.getDeposit(
+          user2Address,
+          this.siloToken.address,
+          2
+        );
+        expect(deposit[0]).to.eq("1000");
+        expect(deposit[1]).to.eq("1000");
+      });
+    });
+  });
+
+  describe("withdraw", function () {
     beforeEach(async function () {
-      await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-    })
-    describe('reverts', function () {
-      it('reverts if amount is 0', async function () {
-        await expect(this.silo2.connect(user).withdrawTokenBySeason(this.siloToken.address, '2', '1001')).to.revertedWith('Silo: Crate balance too low.');
+      await this.silo2.connect(user).deposit(this.siloToken.address, "1000");
+    });
+    describe("reverts", function () {
+      it("reverts if amount is 0", async function () {
+        await expect(
+          this.silo2
+            .connect(user)
+            .withdrawTokenBySeason(this.siloToken.address, "2", "1001")
+        ).to.revertedWith("Silo: Crate balance too low.");
       });
 
-      it('reverts if deposits + withdrawals is a different length', async function () {
-        await expect(this.silo2.connect(user).withdrawTokenBySeasons(this.siloToken.address, ['2', '3'], ['1001'])).to.revertedWith('Silo: Crates, amounts are diff lengths.');
+      it("reverts if deposits + withdrawals is a different length", async function () {
+        await expect(
+          this.silo2
+            .connect(user)
+            .withdrawTokenBySeasons(
+              this.siloToken.address,
+              ["2", "3"],
+              ["1001"]
+            )
+        ).to.revertedWith("Silo: Crates, amounts are diff lengths.");
       });
     });
 
-    describe('withdraw token by season', async function () {
-      describe('withdraw 1 Bean crate', async function () {
+    describe("withdraw token by season", async function () {
+      describe("withdraw 1 Bean crate", async function () {
         beforeEach(async function () {
-          this.result = await this.silo2.connect(user).withdrawTokenBySeason(this.siloToken.address, 2, '1000');
-        });
-    
-        it('properly updates the total balances', async function () {
-          expect(await this.silo2.getTotalDeposited(this.siloToken.address)).to.eq('0');
-          expect(await this.silo.totalStalk()).to.eq('0');
-          expect(await this.silo.totalSeeds()).to.eq('0');
-          expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('1000');
-        });
-        it('properly updates the user balance', async function () {
-          expect(await this.silo.balanceOfStalk(userAddress)).to.eq('0');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('0');
+          this.result = await this.silo2
+            .connect(user)
+            .withdrawTokenBySeason(this.siloToken.address, 2, "1000");
         });
 
-        it('properly removes the deposit', async function () {
-          const deposit = await this.silo2.getDeposit(userAddress, this.siloToken.address, 2);
-          expect(deposit[0]).to.eq('0');
-          expect(deposit[1]).to.eq('0');
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("0");
+          expect(await this.silo.totalStalk()).to.eq("0");
+          expect(await this.silo.totalSeeds()).to.eq("0");
+          expect(
+            await this.silo2.getTotalWithdrawn(this.siloToken.address)
+          ).to.eq("1000");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
         });
 
-        it('properly adds the withdrawal', async function () {
-          expect(await this.silo2.getWithdrawal(userAddress, this.siloToken.address, 27)).to.eq('1000');
+        it("properly removes the deposit", async function () {
+          const deposit = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(deposit[0]).to.eq("0");
+          expect(deposit[1]).to.eq("0");
         });
-    
-        it('emits Remove and Withdrawal event', async function () {
-          await expect(this.result).to.emit(this.silo2, 'RemoveSeason').withArgs(userAddress, this.siloToken.address, 2, '1000');
-          await expect(this.result).to.emit(this.silo2, 'Withdraw').withArgs(userAddress, this.siloToken.address, 27, '1000');
+
+        it("properly adds the withdrawal", async function () {
+          expect(
+            await this.silo2.getWithdrawal(
+              userAddress,
+              this.siloToken.address,
+              27
+            )
+          ).to.eq("1000");
+        });
+
+        it("emits Remove and Withdrawal event", async function () {
+          await expect(this.result)
+            .to.emit(this.silo2, "RemoveSeason")
+            .withArgs(userAddress, this.siloToken.address, 2, "1000");
+          await expect(this.result)
+            .to.emit(this.silo2, "Withdraw")
+            .withArgs(userAddress, this.siloToken.address, 27, "1000");
         });
       });
-      
-      describe('withdraw part of a bean crate', function () {
+
+      describe("withdraw part of a bean crate", function () {
         beforeEach(async function () {
-          this.result = await this.silo2.connect(user).withdrawTokenBySeason(this.siloToken.address, 2, '500');
-        });
-    
-        it('properly updates the total balances', async function () {
-          expect(await this.silo2.getTotalDeposited(this.siloToken.address)).to.eq('500');
-          expect(await this.silo.totalStalk()).to.eq('5000000');
-          expect(await this.silo.totalSeeds()).to.eq('500');
-          expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('500');
-        });
-        it('properly updates the user balance', async function () {
-          expect(await this.silo.balanceOfStalk(userAddress)).to.eq('5000000');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('500');
+          this.result = await this.silo2
+            .connect(user)
+            .withdrawTokenBySeason(this.siloToken.address, 2, "500");
         });
 
-        it('properly removes the deposit', async function () {
-          const deposit = await this.silo2.getDeposit(userAddress, this.siloToken.address, 2);
-          expect(deposit[0]).to.eq('500');
-          expect(deposit[1]).to.eq('500');
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("500");
+          expect(await this.silo.totalStalk()).to.eq("5000000");
+          expect(await this.silo.totalSeeds()).to.eq("500");
+          expect(
+            await this.silo2.getTotalWithdrawn(this.siloToken.address)
+          ).to.eq("500");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("5000000");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("500");
         });
 
-        it('properly adds the withdrawal', async function () {
-          expect(await this.silo2.getWithdrawal(userAddress, this.siloToken.address, 27)).to.eq('500');
+        it("properly removes the deposit", async function () {
+          const deposit = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(deposit[0]).to.eq("500");
+          expect(deposit[1]).to.eq("500");
         });
 
-        it('emits Remove and Withdrawal event', async function () {
-          await expect(this.result).to.emit(this.silo2, 'RemoveSeason').withArgs(userAddress, this.siloToken.address, 2, '500');
-          await expect(this.result).to.emit(this.silo2, 'Withdraw').withArgs(userAddress, this.siloToken.address, 27, '500');
+        it("properly adds the withdrawal", async function () {
+          expect(
+            await this.silo2.getWithdrawal(
+              userAddress,
+              this.siloToken.address,
+              27
+            )
+          ).to.eq("500");
         });
-      });
-    });
 
-    describe("withdraw token by seasons", async function (){
-      describe('1 full and 1 partial token crates', function () {
-        beforeEach(async function () {
-          await this.season.siloSunrise(0);
-          await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-          this.result = await this.silo2.connect(user).withdrawTokenBySeasons(this.siloToken.address, [2,3],['500','1000']);
-        });
-    
-        it('properly updates the total balances', async function () {
-          expect(await this.silo2.getTotalDeposited(this.siloToken.address)).to.eq('500');
-          expect(await this.silo.totalStalk()).to.eq('5000500');
-          expect(await this.silo.totalSeeds()).to.eq('500');
-          expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('1500');
-        });
-        it('properly updates the user balance', async function () {
-          expect(await this.silo.balanceOfStalk(userAddress)).to.eq('5000500');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('500');
-        });
-        it('properly removes the crate', async function () {
-          let dep = await this.silo2.getDeposit(userAddress, this.siloToken.address, 2);
-          expect(dep[0]).to.equal('500')
-          expect(dep[1]).to.equal('500')
-          dep = await this.silo2.getDeposit(userAddress, this.siloToken.address, 3);
-          expect(dep[0]).to.equal('0')
-          expect(dep[1]).to.equal('0')
-        });
-        it('emits Remove and Withdrawal event', async function () {
-          await expect(this.result).to.emit(this.silo2, 'RemoveSeasons').withArgs(userAddress, this.siloToken.address, [2,3], ['500', '1000'], '1500');
-          await expect(this.result).to.emit(this.silo2, 'Withdraw').withArgs(userAddress, this.siloToken.address, 28, '1500');
-        });
-      });
-      describe('2 token crates', function () {
-        beforeEach(async function () {
-          await this.season.siloSunrise(0);
-          await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-          this.result = await this.silo2.connect(user).withdrawTokenBySeasons(this.siloToken.address, [2,3],['1000','1000']);
-        });
-    
-        it('properly updates the total balances', async function () {
-          expect(await this.silo2.getTotalDeposited(this.siloToken.address)).to.eq('0');
-          expect(await this.silo.totalStalk()).to.eq('0');
-          expect(await this.silo.totalSeeds()).to.eq('0');
-          expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('2000');
-        });
-        it('properly updates the user balance', async function () {
-          expect(await this.silo.balanceOfStalk(userAddress)).to.eq('0');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('0');
-        });
-        it('properly removes the crate', async function () {
-          let dep = await this.silo2.getDeposit(userAddress, this.siloToken.address, 2);
-          expect(dep[0]).to.equal('0')
-          expect(dep[1]).to.equal('0')
-          dep = await this.silo2.getDeposit(userAddress, this.siloToken.address, 3);
-          expect(dep[0]).to.equal('0')
-          expect(dep[1]).to.equal('0')
-        });
-        it('emits Remove and Withdrawal event', async function () {
-          await expect(this.result).to.emit(this.silo2, 'RemoveSeasons').withArgs(userAddress, this.siloToken.address, [2,3], ['1000', '1000'], '2000');
-          await expect(this.result).to.emit(this.silo2, 'Withdraw').withArgs(userAddress, this.siloToken.address, 28, '2000');
+        it("emits Remove and Withdrawal event", async function () {
+          await expect(this.result)
+            .to.emit(this.silo2, "RemoveSeason")
+            .withArgs(userAddress, this.siloToken.address, 2, "500");
+          await expect(this.result)
+            .to.emit(this.silo2, "Withdraw")
+            .withArgs(userAddress, this.siloToken.address, 27, "500");
         });
       });
     });
-    describe("withdraw tokens by season", async function (){
-      describe('1 full and 1 partial token crates', function () {
+
+    describe("withdraw token by seasons", async function () {
+      describe("1 full and 1 partial token crates", function () {
         beforeEach(async function () {
           await this.season.siloSunrise(0);
-          await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-          this.result = await this.silo2.connect(user).withdrawTokensBySeason([[this.siloToken.address, 2, '500'],[this.siloToken.address, 3, '1000']]);
+          await this.silo2
+            .connect(user)
+            .deposit(this.siloToken.address, "1000");
+          this.result = await this.silo2
+            .connect(user)
+            .withdrawTokenBySeasons(
+              this.siloToken.address,
+              [2, 3],
+              ["500", "1000"]
+            );
         });
-    
-        it('properly updates the total balances', async function () {
-          expect(await this.silo2.getTotalDeposited(this.siloToken.address)).to.eq('500');
-          expect(await this.silo.totalStalk()).to.eq('5000500');
-          expect(await this.silo.totalSeeds()).to.eq('500');
-          expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('1500');
+
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("500");
+          expect(await this.silo.totalStalk()).to.eq("5000500");
+          expect(await this.silo.totalSeeds()).to.eq("500");
+          expect(
+            await this.silo2.getTotalWithdrawn(this.siloToken.address)
+          ).to.eq("1500");
         });
-        it('properly updates the user balance', async function () {
-          expect(await this.silo.balanceOfStalk(userAddress)).to.eq('5000500');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('500');
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("5000500");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("500");
         });
-        it('properly removes the crate', async function () {
-          let dep = await this.silo2.getDeposit(userAddress, this.siloToken.address, 2);
-          expect(dep[0]).to.equal('500')
-          expect(dep[1]).to.equal('500')
-          dep = await this.silo2.getDeposit(userAddress, this.siloToken.address, 3);
-          expect(dep[0]).to.equal('0')
-          expect(dep[1]).to.equal('0')
+        it("properly removes the crate", async function () {
+          let dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("500");
+          expect(dep[1]).to.equal("500");
+          dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
         });
-        it('emits Remove and Withdrawal event', async function () {
-          await expect(this.result).to.emit(this.silo2, 'RemoveSeason').withArgs(userAddress, this.siloToken.address, 2, '500');
-          await expect(this.result).to.emit(this.silo2, 'RemoveSeason').withArgs(userAddress, this.siloToken.address, 3, '1000');
-          await expect(this.result).to.emit(this.silo2, 'Withdraw').withArgs(userAddress, this.siloToken.address, 28, '500');
-          await expect(this.result).to.emit(this.silo2, 'Withdraw').withArgs(userAddress, this.siloToken.address, 28, '1000');
+        it("emits Remove and Withdrawal event", async function () {
+          await expect(this.result)
+            .to.emit(this.silo2, "RemoveSeasons")
+            .withArgs(
+              userAddress,
+              this.siloToken.address,
+              [2, 3],
+              ["500", "1000"],
+              "1500"
+            );
+          await expect(this.result)
+            .to.emit(this.silo2, "Withdraw")
+            .withArgs(userAddress, this.siloToken.address, 28, "1500");
         });
       });
-      describe('2 token crates', function () {
+      describe("2 token crates", function () {
         beforeEach(async function () {
           await this.season.siloSunrise(0);
-          await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-          this.result = await this.silo2.connect(user).withdrawTokensBySeason([[this.siloToken.address, 2, '1000'],[this.siloToken.address, 3, '1000']]);
+          await this.silo2
+            .connect(user)
+            .deposit(this.siloToken.address, "1000");
+          this.result = await this.silo2
+            .connect(user)
+            .withdrawTokenBySeasons(
+              this.siloToken.address,
+              [2, 3],
+              ["1000", "1000"]
+            );
         });
-    
-        it('properly updates the total balances', async function () {
-          expect(await this.silo2.getTotalDeposited(this.siloToken.address)).to.eq('0');
-          expect(await this.silo.totalStalk()).to.eq('0');
-          expect(await this.silo.totalSeeds()).to.eq('0');
-          expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('2000');
+
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("0");
+          expect(await this.silo.totalStalk()).to.eq("0");
+          expect(await this.silo.totalSeeds()).to.eq("0");
+          expect(
+            await this.silo2.getTotalWithdrawn(this.siloToken.address)
+          ).to.eq("2000");
         });
-        it('properly updates the user balance', async function () {
-          expect(await this.silo.balanceOfStalk(userAddress)).to.eq('0');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('0');
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
         });
-        it('properly removes the crate', async function () {
-          let dep = await this.silo2.getDeposit(userAddress, this.siloToken.address, 2);
-          expect(dep[0]).to.equal('0')
-          expect(dep[1]).to.equal('0')
-          dep = await this.silo2.getDeposit(userAddress, this.siloToken.address, 3);
-          expect(dep[0]).to.equal('0')
-          expect(dep[1]).to.equal('0')
+        it("properly removes the crate", async function () {
+          let dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+          dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
         });
-        it('emits Remove and Withdrawal event', async function () {
-          await expect(this.result).to.emit(this.silo2, 'RemoveSeason').withArgs(userAddress, this.siloToken.address, 2, '1000');
-          await expect(this.result).to.emit(this.silo2, 'RemoveSeason').withArgs(userAddress, this.siloToken.address, 3, '1000');
-          await expect(this.result).to.emit(this.silo2, 'Withdraw').withArgs(userAddress, this.siloToken.address, 28, '1000');
+        it("emits Remove and Withdrawal event", async function () {
+          await expect(this.result)
+            .to.emit(this.silo2, "RemoveSeasons")
+            .withArgs(
+              userAddress,
+              this.siloToken.address,
+              [2, 3],
+              ["1000", "1000"],
+              "2000"
+            );
+          await expect(this.result)
+            .to.emit(this.silo2, "Withdraw")
+            .withArgs(userAddress, this.siloToken.address, 28, "2000");
         });
       });
     });
-    describe("withdraw tokens by seasons", async function (){
-      describe('2 token crates in 2 withdrawals', function () {
+    describe("withdraw tokens by season", async function () {
+      describe("1 full and 1 partial token crates", function () {
         beforeEach(async function () {
           await this.season.siloSunrise(0);
-          await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-          this.result = await this.silo2.connect(user).withdrawTokensBySeasons([[this.siloToken.address, [2,3], ['750', '500']],[this.siloToken.address, [2,3], ['250', '250']]]);
+          await this.silo2
+            .connect(user)
+            .deposit(this.siloToken.address, "1000");
+          this.result = await this.silo2.connect(user).withdrawTokensBySeason([
+            [this.siloToken.address, 2, "500"],
+            [this.siloToken.address, 3, "1000"],
+          ]);
         });
-    
-        it('properly updates the total balances', async function () {
-          expect(await this.silo2.getTotalDeposited(this.siloToken.address)).to.eq('250');
-          expect(await this.silo.totalStalk()).to.eq('2500000');
-          expect(await this.silo.totalSeeds()).to.eq('250');
-          expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('1750');
+
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("500");
+          expect(await this.silo.totalStalk()).to.eq("5000500");
+          expect(await this.silo.totalSeeds()).to.eq("500");
+          expect(
+            await this.silo2.getTotalWithdrawn(this.siloToken.address)
+          ).to.eq("1500");
         });
-        it('properly updates the user balance', async function () {
-          expect(await this.silo.balanceOfStalk(userAddress)).to.eq('2500000');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('250');
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("5000500");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("500");
         });
-        it('properly removes the crate', async function () {
-          let dep = await this.silo2.getDeposit(userAddress, this.siloToken.address, 2);
-          expect(dep[0]).to.equal('0')
-          expect(dep[1]).to.equal('0')
-          dep = await this.silo2.getDeposit(userAddress, this.siloToken.address, 3);
-          expect(dep[0]).to.equal('250')
-          expect(dep[1]).to.equal('250')
+        it("properly removes the crate", async function () {
+          let dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("500");
+          expect(dep[1]).to.equal("500");
+          dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
         });
-        it('emits Remove and Withdrawal event', async function () {
-          await expect(this.result).to.emit(this.silo2, 'RemoveSeasons').withArgs(userAddress, this.siloToken.address, [2,3], ['750', '500'], '1250');
-          await expect(this.result).to.emit(this.silo2, 'RemoveSeasons').withArgs(userAddress, this.siloToken.address, [2,3], ['250', '250'], '500');
-          await expect(this.result).to.emit(this.silo2, 'Withdraw').withArgs(userAddress, this.siloToken.address, 28, '1250');
-          await expect(this.result).to.emit(this.silo2, 'Withdraw').withArgs(userAddress, this.siloToken.address, 28, '500');
+        it("emits Remove and Withdrawal event", async function () {
+          await expect(this.result)
+            .to.emit(this.silo2, "RemoveSeason")
+            .withArgs(userAddress, this.siloToken.address, 2, "500");
+          await expect(this.result)
+            .to.emit(this.silo2, "RemoveSeason")
+            .withArgs(userAddress, this.siloToken.address, 3, "1000");
+          await expect(this.result)
+            .to.emit(this.silo2, "Withdraw")
+            .withArgs(userAddress, this.siloToken.address, 28, "500");
+          await expect(this.result)
+            .to.emit(this.silo2, "Withdraw")
+            .withArgs(userAddress, this.siloToken.address, 28, "1000");
+        });
+      });
+      describe("2 token crates", function () {
+        beforeEach(async function () {
+          await this.season.siloSunrise(0);
+          await this.silo2
+            .connect(user)
+            .deposit(this.siloToken.address, "1000");
+          this.result = await this.silo2.connect(user).withdrawTokensBySeason([
+            [this.siloToken.address, 2, "1000"],
+            [this.siloToken.address, 3, "1000"],
+          ]);
+        });
+
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("0");
+          expect(await this.silo.totalStalk()).to.eq("0");
+          expect(await this.silo.totalSeeds()).to.eq("0");
+          expect(
+            await this.silo2.getTotalWithdrawn(this.siloToken.address)
+          ).to.eq("2000");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+        });
+        it("properly removes the crate", async function () {
+          let dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+          dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+        });
+        it("emits Remove and Withdrawal event", async function () {
+          await expect(this.result)
+            .to.emit(this.silo2, "RemoveSeason")
+            .withArgs(userAddress, this.siloToken.address, 2, "1000");
+          await expect(this.result)
+            .to.emit(this.silo2, "RemoveSeason")
+            .withArgs(userAddress, this.siloToken.address, 3, "1000");
+          await expect(this.result)
+            .to.emit(this.silo2, "Withdraw")
+            .withArgs(userAddress, this.siloToken.address, 28, "1000");
+        });
+      });
+    });
+    describe("withdraw tokens by seasons", async function () {
+      describe("2 token crates in 2 withdrawals", function () {
+        beforeEach(async function () {
+          await this.season.siloSunrise(0);
+          await this.silo2
+            .connect(user)
+            .deposit(this.siloToken.address, "1000");
+          this.result = await this.silo2.connect(user).withdrawTokensBySeasons([
+            [this.siloToken.address, [2, 3], ["750", "500"]],
+            [this.siloToken.address, [2, 3], ["250", "250"]],
+          ]);
+        });
+
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("250");
+          expect(await this.silo.totalStalk()).to.eq("2500000");
+          expect(await this.silo.totalSeeds()).to.eq("250");
+          expect(
+            await this.silo2.getTotalWithdrawn(this.siloToken.address)
+          ).to.eq("1750");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("2500000");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("250");
+        });
+        it("properly removes the crate", async function () {
+          let dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+          dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("250");
+          expect(dep[1]).to.equal("250");
+        });
+        it("emits Remove and Withdrawal event", async function () {
+          await expect(this.result)
+            .to.emit(this.silo2, "RemoveSeasons")
+            .withArgs(
+              userAddress,
+              this.siloToken.address,
+              [2, 3],
+              ["750", "500"],
+              "1250"
+            );
+          await expect(this.result)
+            .to.emit(this.silo2, "RemoveSeasons")
+            .withArgs(
+              userAddress,
+              this.siloToken.address,
+              [2, 3],
+              ["250", "250"],
+              "500"
+            );
+          await expect(this.result)
+            .to.emit(this.silo2, "Withdraw")
+            .withArgs(userAddress, this.siloToken.address, 28, "1250");
+          await expect(this.result)
+            .to.emit(this.silo2, "Withdraw")
+            .withArgs(userAddress, this.siloToken.address, 28, "500");
         });
       });
     });
   });
 
-  describe('claim', function () {
+  //--------------------------------------
+
+  describe("transfer", function () {
     beforeEach(async function () {
-      await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-      await this.silo2.connect(user).withdrawTokenBySeason(this.siloToken.address, '2', '1000');
+      await this.silo2.connect(user).deposit(this.siloToken.address, "1000");
+    });
+    describe("reverts", function () {
+      it("reverts if amount is 0", async function () {
+        await expect(
+          this.silo2
+            .connect(user)
+            .transferTokenBySeason(
+              this.siloToken.address,
+              "2",
+              "1001",
+              user2Address
+            )
+        ).to.revertedWith("Silo: Crate balance too low.");
+      });
+
+      it("reverts if deposits + transfer is a different length", async function () {
+        await expect(
+          this.silo2
+            .connect(user)
+            .transferTokenBySeasons(
+              this.siloToken.address,
+              ["2", "3"],
+              ["1001"],
+              user2Address
+            )
+        ).to.revertedWith("Silo: Crates, amounts are diff lengths.");
+      });
+    });
+
+    describe("transfer deposit by season", async function () {
+      describe("transfer 1 Bean crate", async function () {
+        beforeEach(async function () {
+          this.result = await this.silo2
+            .connect(user)
+            .transferTokenBySeason(
+              this.siloToken.address,
+              2,
+              "1000",
+              user2Address
+            );
+        });
+
+        it("properly updates the total balances (stays the same)", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("1000");
+          expect(
+            await this.silo2.getTotalWithdrawn(this.siloToken.address)
+          ).to.eq("0");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+        });
+        it("properly updates the transferTo user balance", async function () {
+          expect(await this.silo.balanceOfStalk(user2Address)).to.eq(
+            "10000000"
+          );
+          expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("1000");
+        });
+
+        it("properly removes the deposit", async function () {
+          const deposit = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(deposit[0]).to.eq("0");
+          expect(deposit[1]).to.eq("0");
+        });
+
+        it("properly adds the deposit to transferTo user", async function () {
+          const deposit = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            2
+          );
+          expect(deposit[0]).to.eq("1000");
+          expect(deposit[1]).to.eq("1000");
+        });
+      });
+
+      describe("transfer part of a bean crate", function () {
+        beforeEach(async function () {
+          this.result = await this.silo2
+            .connect(user)
+            .transferTokenBySeason(
+              this.siloToken.address,
+              2,
+              "500",
+              user2Address
+            );
+        });
+
+        it("doesn't update the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("1000");
+          expect(await this.silo.totalStalk()).to.eq("10000000");
+          expect(await this.silo.totalSeeds()).to.eq("1000");
+          expect(
+            await this.silo2.getTotalWithdrawn(this.siloToken.address)
+          ).to.eq("0");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("5000000");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("500");
+        });
+        it("properly updates the trasnferTo user balance", async function () {
+          expect(await this.silo.balanceOfStalk(user2Address)).to.eq("5000000");
+          expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("500");
+        });
+
+        it("properly removes the deposit", async function () {
+          const deposit = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(deposit[0]).to.eq("500");
+          expect(deposit[1]).to.eq("500");
+        });
+      });
+    });
+
+    describe("transfer token by seasons", async function () {
+      describe("1 full and 1 partial token crates", function () {
+        beforeEach(async function () {
+          await this.season.siloSunrise(0);
+          await this.silo2
+            .connect(user)
+            .deposit(this.siloToken.address, "1000");
+          this.result = await this.silo2
+            .connect(user)
+            .transferTokenBySeasons(
+              this.siloToken.address,
+              [2, 3],
+              ["500", "1000"],
+              user2Address
+            );
+        });
+
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("2000");
+          expect(await this.silo.totalStalk()).to.eq("20001000");
+          expect(await this.silo.totalSeeds()).to.eq("2000");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("5000500");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("500");
+        });
+        it("properly updates the user2 balance", async function () {
+          expect(await this.silo.balanceOfStalk(user2Address)).to.eq(
+            "15000500"
+          );
+          expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("1500");
+        });
+        it("properly removes the crate for user1", async function () {
+          let dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("500");
+          expect(dep[1]).to.equal("500");
+          dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+        });
+        it("properly adds the crates for user2", async function () {
+          let dep = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("500");
+          expect(dep[1]).to.equal("500");
+          dep = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("1000");
+          expect(dep[1]).to.equal("1000");
+        });
+      });
+
+      describe("2 token crates", function () {
+        beforeEach(async function () {
+          await this.season.siloSunrise(0);
+          await this.silo2
+            .connect(user)
+            .deposit(this.siloToken.address, "1000");
+          this.result = await this.silo2
+            .connect(user)
+            .transferTokenBySeasons(
+              this.siloToken.address,
+              [2, 3],
+              ["1000", "1000"],
+              user2Address
+            );
+        });
+
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("2000");
+          expect(await this.silo.totalStalk()).to.eq("20001000");
+          expect(await this.silo.totalSeeds()).to.eq("2000");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+        });
+        it("properly updates user2 balance", async function () {
+          expect(await this.silo.balanceOfStalk(user2Address)).to.eq(
+            "20001000"
+          );
+          expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("2000");
+        });
+        it("properly removes the crates", async function () {
+          let dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+          dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+        });
+        it("properly adds the crates", async function () {
+          let dep = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("1000");
+          expect(dep[1]).to.equal("1000");
+          dep = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("1000");
+          expect(dep[1]).to.equal("1000");
+        });
+      });
+    });
+
+    describe("transfer tokens by season", async function () {
+      describe("1 full and 1 partial token crates", function () {
+        beforeEach(async function () {
+          await this.season.siloSunrise(0);
+          await this.silo2
+            .connect(user)
+            .deposit(this.siloToken.address, "1000");
+          this.result = await this.silo2.connect(user).transferTokensBySeason(
+            [
+              [this.siloToken.address, 2, "500"],
+              [this.siloToken.address, 3, "1000"],
+            ],
+            user2Address
+          );
+        });
+
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("2000");
+          expect(await this.silo.totalStalk()).to.eq("20001000");
+          expect(await this.silo.totalSeeds()).to.eq("2000");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("5000500");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("500");
+        });
+        it("properly updates user2 balance", async function () {
+          expect(await this.silo.balanceOfStalk(user2Address)).to.eq(
+            "15000500"
+          );
+          expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("1500");
+        });
+        it("properly removes the crates", async function () {
+          let dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("500");
+          expect(dep[1]).to.equal("500");
+          dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+        });
+        it("properly adds the crates", async function () {
+          let dep = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("500");
+          expect(dep[1]).to.equal("500");
+          dep = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("1000");
+          expect(dep[1]).to.equal("1000");
+        });
+      });
+      let dep;
+      describe("2 token crates", function () {
+        beforeEach(async function () {
+          await this.season.siloSunrise(0);
+          await this.silo2
+            .connect(user)
+            .deposit(this.siloToken.address, "1000");
+          this.result = await this.silo2.connect(user).transferTokensBySeason(
+            [
+              [this.siloToken.address, 2, "1000"],
+              [this.siloToken.address, 3, "1000"],
+            ],
+            user2Address
+          );
+          // dep = await this.silo2.getTotalDeposited(this.siloToken.address);
+          // console.log(
+          //   "Total deposited",
+          //   await this.silo2.getTotalDeposited(this.siloToken.address),
+          //   dep
+          // );
+          // console.log("Total Stalk", await this.silo.totalStalk());
+          // console.log("Total Seeds", await this.silo.totalSeeds());
+        });
+
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("2000");
+          expect(await this.silo.totalStalk()).to.eq("20001000");
+          expect(await this.silo.totalSeeds()).to.eq("2000");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+        });
+        it("properly updates user2 balance", async function () {
+          expect(await this.silo.balanceOfStalk(user2Address)).to.eq(
+            "20001000"
+          );
+          expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("2000");
+        });
+        it("properly removes the crate", async function () {
+          let dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+          dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+        });
+        it("properly adds the crates", async function () {
+          let dep = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("1000");
+          expect(dep[1]).to.equal("1000");
+          dep = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("1000");
+          expect(dep[1]).to.equal("1000");
+        });
+      });
+    });
+
+    describe("transfer tokens by seasons", async function () {
+      describe("2 token crates in 2 transfers", function () {
+        beforeEach(async function () {
+          await this.season.siloSunrise(0);
+          await this.silo2
+            .connect(user)
+            .deposit(this.siloToken.address, "1000");
+          this.result = await this.silo2.connect(user).transferTokensBySeasons(
+            [
+              [this.siloToken.address, [2, 3], ["750", "500"]],
+              [this.siloToken.address, [2, 3], ["250", "250"]],
+            ],
+            user2Address
+          );
+        });
+
+        it("properly updates the total balances", async function () {
+          expect(
+            await this.silo2.getTotalDeposited(this.siloToken.address)
+          ).to.eq("2000");
+          expect(await this.silo.totalStalk()).to.eq("20001000");
+          expect(await this.silo.totalSeeds()).to.eq("2000");
+        });
+        it("properly updates the user balance", async function () {
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq("2500000");
+          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("250");
+        });
+        it("properly updates user2 balance", async function () {
+          expect(await this.silo.balanceOfStalk(user2Address)).to.eq(
+            "17501000"
+          );
+          expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("1750");
+        });
+        it("properly removes the crates", async function () {
+          let dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("0");
+          expect(dep[1]).to.equal("0");
+          dep = await this.silo2.getDeposit(
+            userAddress,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("250");
+          expect(dep[1]).to.equal("250");
+        });
+        it("properly adds the crates", async function () {
+          let dep = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            2
+          );
+          expect(dep[0]).to.equal("1000");
+          expect(dep[1]).to.equal("1000");
+          dep = await this.silo2.getDeposit(
+            user2Address,
+            this.siloToken.address,
+            3
+          );
+          expect(dep[0]).to.equal("750");
+          expect(dep[1]).to.equal("750");
+        });
+      });
+    });
+  });
+
+  describe("claim", function () {
+    beforeEach(async function () {
+      await this.silo2.connect(user).deposit(this.siloToken.address, "1000");
+      await this.silo2
+        .connect(user)
+        .withdrawTokenBySeason(this.siloToken.address, "2", "1000");
       await this.season.siloSunrises(25);
-    })
+    });
 
-    describe('claim token by season', function () {
+    describe("claim token by season", function () {
       beforeEach(async function () {
         const userTokensBefore = await this.siloToken.balanceOf(userAddress);
-        this.result = await this.silo2.connect(user).claimTokenBySeason(this.siloToken.address, 27);
-        this.deltaBeans = (await this.siloToken.balanceOf(userAddress)).sub(userTokensBefore);
+        this.result = await this.silo2
+          .connect(user)
+          .claimTokenBySeason(this.siloToken.address, 27);
+        this.deltaBeans = (await this.siloToken.balanceOf(userAddress)).sub(
+          userTokensBefore
+        );
       });
 
-      it('properly updates the total balances', async function () {
-        expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('0');
-        expect(this.deltaBeans).to.equal('1000');
+      it("properly updates the total balances", async function () {
+        expect(
+          await this.silo2.getTotalWithdrawn(this.siloToken.address)
+        ).to.eq("0");
+        expect(this.deltaBeans).to.equal("1000");
       });
 
-      it('properly removes the withdrawal', async function () {
-        expect(await this.silo2.getWithdrawal(userAddress, this.siloToken.address, 27)).to.eq('0');
+      it("properly removes the withdrawal", async function () {
+        expect(
+          await this.silo2.getWithdrawal(
+            userAddress,
+            this.siloToken.address,
+            27
+          )
+        ).to.eq("0");
       });
 
-      it('emits a claim ', async function () {
-        await expect(this.result).to.emit(this.silo2, 'ClaimSeason').withArgs(userAddress, this.siloToken.address, 27, '1000');
-      });
-    });
-
-    describe('claim token by seasons', function () {
-      beforeEach(async function () {
-        await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-        await this.silo2.connect(user).withdrawTokenBySeason(this.siloToken.address, '27', '1000');
-        await this.season.siloSunrises(25);
-
-      const userTokensBefore = await this.siloToken.balanceOf(userAddress);
-        this.result = await this.silo2.connect(user).claimTokenBySeasons(this.siloToken.address, [27, 52]);
-        this.deltaBeans = (await this.siloToken.balanceOf(userAddress)).sub(userTokensBefore);
-      });
-
-      it('properly updates the total balances', async function () {
-        expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('0');
-        expect(this.deltaBeans).to.equal('2000');
-      });
-
-      it('properly removes the withdrawal', async function () {
-        expect(await this.silo2.getWithdrawal(userAddress, this.siloToken.address, 27)).to.eq('0');
-      });
-
-      it('emits a claim ', async function () {
-        await expect(this.result).to.emit(this.silo2, 'ClaimSeasons').withArgs(userAddress, this.siloToken.address, [27, 52], '2000');
+      it("emits a claim ", async function () {
+        await expect(this.result)
+          .to.emit(this.silo2, "ClaimSeason")
+          .withArgs(userAddress, this.siloToken.address, 27, "1000");
       });
     });
 
-    describe('claim tokens by season', function () {
+    describe("claim token by seasons", function () {
       beforeEach(async function () {
-        await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-        await this.silo2.connect(user).withdrawTokenBySeason(this.siloToken.address, '27', '1000');
-        await this.season.siloSunrises(25);
-
-      const userTokensBefore = await this.siloToken.balanceOf(userAddress);
-        this.result = await this.silo2.connect(user).claimTokensBySeason([[this.siloToken.address, 27], [this.siloToken.address, 52]]);
-        this.deltaBeans = (await this.siloToken.balanceOf(userAddress)).sub(userTokensBefore);
-      });
-  
-      it('properly updates the total balances', async function () {
-        expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('0');
-        expect(this.deltaBeans).to.equal('2000');
-      });
-
-      it('properly removes the withdrawal', async function () {
-        expect(await this.silo2.getWithdrawal(userAddress, this.siloToken.address, 27)).to.eq('0');
-      });
-
-      it('emits a claim ', async function () {
-        await expect(this.result).to.emit(this.silo2, 'ClaimSeason').withArgs(userAddress, this.siloToken.address, 27, '1000');
-        await expect(this.result).to.emit(this.silo2, 'ClaimSeason').withArgs(userAddress, this.siloToken.address, 52, '1000');
-      });
-    });
-
-    describe('claim tokens by season', function () {
-      beforeEach(async function () {
-        await this.silo2.connect(user).deposit(this.siloToken.address, '1000');
-        await this.silo2.connect(user).withdrawTokenBySeason(this.siloToken.address, '27', '500');
-        await this.season.siloSunrise(0);
-        await this.silo2.connect(user).withdrawTokenBySeason(this.siloToken.address, '27', '250');
-        await this.season.siloSunrise(0);
-        await this.silo2.connect(user).withdrawTokenBySeason(this.siloToken.address, '27', '250');
+        await this.silo2.connect(user).deposit(this.siloToken.address, "1000");
+        await this.silo2
+          .connect(user)
+          .withdrawTokenBySeason(this.siloToken.address, "27", "1000");
         await this.season.siloSunrises(25);
 
         const userTokensBefore = await this.siloToken.balanceOf(userAddress);
-        this.result = await this.silo2.connect(user).claimTokensBySeasons([[this.siloToken.address, [27, 52]], [this.siloToken.address, [53, 54]]]);
-        this.deltaBeans = (await this.siloToken.balanceOf(userAddress)).sub(userTokensBefore);
-      });
-  
-      it('properly updates the total balances', async function () {
-        expect(await this.silo2.getTotalWithdrawn(this.siloToken.address)).to.eq('0');
-        expect(this.deltaBeans).to.equal('2000');
-      });
-
-      it('properly removes the withdrawal', async function () {
-        expect(await this.silo2.getWithdrawal(userAddress, this.siloToken.address, 27)).to.eq('0');
+        this.result = await this.silo2
+          .connect(user)
+          .claimTokenBySeasons(this.siloToken.address, [27, 52]);
+        this.deltaBeans = (await this.siloToken.balanceOf(userAddress)).sub(
+          userTokensBefore
+        );
       });
 
-      it('emits a claim ', async function () {
-        await expect(this.result).to.emit(this.silo2, 'ClaimSeasons').withArgs(userAddress, this.siloToken.address, [27, 52], '1500');
-        await expect(this.result).to.emit(this.silo2, 'ClaimSeasons').withArgs(userAddress, this.siloToken.address, [53, 54], '500');
+      it("properly updates the total balances", async function () {
+        expect(
+          await this.silo2.getTotalWithdrawn(this.siloToken.address)
+        ).to.eq("0");
+        expect(this.deltaBeans).to.equal("2000");
+      });
+
+      it("properly removes the withdrawal", async function () {
+        expect(
+          await this.silo2.getWithdrawal(
+            userAddress,
+            this.siloToken.address,
+            27
+          )
+        ).to.eq("0");
+      });
+
+      it("emits a claim ", async function () {
+        await expect(this.result)
+          .to.emit(this.silo2, "ClaimSeasons")
+          .withArgs(userAddress, this.siloToken.address, [27, 52], "2000");
+      });
+    });
+
+    describe("claim tokens by season", function () {
+      beforeEach(async function () {
+        await this.silo2.connect(user).deposit(this.siloToken.address, "1000");
+        await this.silo2
+          .connect(user)
+          .withdrawTokenBySeason(this.siloToken.address, "27", "1000");
+        await this.season.siloSunrises(25);
+
+        const userTokensBefore = await this.siloToken.balanceOf(userAddress);
+        this.result = await this.silo2.connect(user).claimTokensBySeason([
+          [this.siloToken.address, 27],
+          [this.siloToken.address, 52],
+        ]);
+        this.deltaBeans = (await this.siloToken.balanceOf(userAddress)).sub(
+          userTokensBefore
+        );
+      });
+
+      it("properly updates the total balances", async function () {
+        expect(
+          await this.silo2.getTotalWithdrawn(this.siloToken.address)
+        ).to.eq("0");
+        expect(this.deltaBeans).to.equal("2000");
+      });
+
+      it("properly removes the withdrawal", async function () {
+        expect(
+          await this.silo2.getWithdrawal(
+            userAddress,
+            this.siloToken.address,
+            27
+          )
+        ).to.eq("0");
+      });
+
+      it("emits a claim ", async function () {
+        await expect(this.result)
+          .to.emit(this.silo2, "ClaimSeason")
+          .withArgs(userAddress, this.siloToken.address, 27, "1000");
+        await expect(this.result)
+          .to.emit(this.silo2, "ClaimSeason")
+          .withArgs(userAddress, this.siloToken.address, 52, "1000");
+      });
+    });
+
+    describe("claim tokens by season", function () {
+      beforeEach(async function () {
+        await this.silo2.connect(user).deposit(this.siloToken.address, "1000");
+        await this.silo2
+          .connect(user)
+          .withdrawTokenBySeason(this.siloToken.address, "27", "500");
+        await this.season.siloSunrise(0);
+        await this.silo2
+          .connect(user)
+          .withdrawTokenBySeason(this.siloToken.address, "27", "250");
+        await this.season.siloSunrise(0);
+        await this.silo2
+          .connect(user)
+          .withdrawTokenBySeason(this.siloToken.address, "27", "250");
+        await this.season.siloSunrises(25);
+
+        const userTokensBefore = await this.siloToken.balanceOf(userAddress);
+        this.result = await this.silo2.connect(user).claimTokensBySeasons([
+          [this.siloToken.address, [27, 52]],
+          [this.siloToken.address, [53, 54]],
+        ]);
+        this.deltaBeans = (await this.siloToken.balanceOf(userAddress)).sub(
+          userTokensBefore
+        );
+      });
+
+      it("properly updates the total balances", async function () {
+        expect(
+          await this.silo2.getTotalWithdrawn(this.siloToken.address)
+        ).to.eq("0");
+        expect(this.deltaBeans).to.equal("2000");
+      });
+
+      it("properly removes the withdrawal", async function () {
+        expect(
+          await this.silo2.getWithdrawal(
+            userAddress,
+            this.siloToken.address,
+            27
+          )
+        ).to.eq("0");
+      });
+
+      it("emits a claim ", async function () {
+        await expect(this.result)
+          .to.emit(this.silo2, "ClaimSeasons")
+          .withArgs(userAddress, this.siloToken.address, [27, 52], "1500");
+        await expect(this.result)
+          .to.emit(this.silo2, "ClaimSeasons")
+          .withArgs(userAddress, this.siloToken.address, [53, 54], "500");
       });
     });
   });
 
   describe("Curve BDV", async function () {
     before(async function () {
-      this.threeCurve = await ethers.getContractAt('Mock3Curve', THREE_CURVE);
-      await this.threeCurve.set_virtual_price(ethers.utils.parseEther('1'));
-      this.beanThreeCurve = await ethers.getContractAt('MockBean3Curve', BEAN_3_CURVE);
-      await this.beanThreeCurve.set_supply('100000');
-      await this.beanThreeCurve.set_A_precise('1000');
+      this.threeCurve = await ethers.getContractAt("Mock3Curve", THREE_CURVE);
+      await this.threeCurve.set_virtual_price(ethers.utils.parseEther("1"));
+      this.beanThreeCurve = await ethers.getContractAt(
+        "MockBean3Curve",
+        BEAN_3_CURVE
+      );
+      await this.beanThreeCurve.set_supply("100000");
+      await this.beanThreeCurve.set_A_precise("1000");
       await this.beanThreeCurve.set_balances([
-        ethers.utils.parseUnits('1000000',6),
-        ethers.utils.parseEther('1000000')
+        ethers.utils.parseUnits("1000000", 6),
+        ethers.utils.parseEther("1000000"),
       ]);
     });
 
     it("properly checks bdv", async function () {
-      this.curveBDV = await ethers.getContractAt('CurveBDVFacet', this.diamond.address);
-      expect(await this.curveBDV.curveToBDV('100')).to.equal('2000000000');
-    })
+      this.curveBDV = await ethers.getContractAt(
+        "CurveBDVFacet",
+        this.diamond.address
+      );
+      expect(await this.curveBDV.curveToBDV("100")).to.equal("2000000000");
+    });
 
     it("properly checks bdv", async function () {
-      await this.threeCurve.set_virtual_price(ethers.utils.parseEther('1.02'));
-      this.curveBDV = await ethers.getContractAt('CurveBDVFacet', this.diamond.address);
-      expect(await this.curveBDV.curveToBDV('1')).to.equal('20181651');
-    })
-  })
+      await this.threeCurve.set_virtual_price(ethers.utils.parseEther("1.02"));
+      this.curveBDV = await ethers.getContractAt(
+        "CurveBDVFacet",
+        this.diamond.address
+      );
+      expect(await this.curveBDV.curveToBDV("1")).to.equal("20181651");
+    });
+  });
 });

--- a/protocol/test/SiloV2.test.js
+++ b/protocol/test/SiloV2.test.js
@@ -1394,9 +1394,11 @@ describe("Silo", function () {
 
     it("properly withdraws beans", async function () {
 	  console.log(await this.BeanSilo.totalDepositedBeans());
+	  console.log(await this.season.season());
       await this.silo2
         .connect(user)
-        .withdrawTokenBySeasons(this.bean.address, [3], [1000]);
+        .withdrawTokenBySeasons(this.bean.address, [3], ["1000"]);
+	  console.log(await this.BeanSilo.totalDepositedBeans());
       expect(await this.BeanSilo.totalDepositedBeans()).to.eq("0");
     });
   });

--- a/protocol/test/SiloV2.test.js
+++ b/protocol/test/SiloV2.test.js
@@ -60,7 +60,7 @@ describe("Silo", function () {
       "1"
     );
 
-    await this.pair.simulateTrade("2000", "2");
+    await this.pair.simulateTrade("2000", "1000");
     await this.season.siloSunrise(0);
     await this.pair.faucet(userAddress, "1");
     await this.bean.mint(userAddress, "1000000000");
@@ -1376,45 +1376,36 @@ describe("Silo", function () {
   });
 
   describe("Bean deposit and withdraw", async function () {
-    before(async function () {
-      this.BeanSilo = await ethers.getContractAt(
-        "BeanSilo",
-        this.diamond.address
-      );
-    });
-
     beforeEach(async function () {
       await this.season.siloSunrise(0);
       await this.silo2.connect(user).deposit(this.bean.address, "1000");
     });
 
     it("properly deposits beans", async function () {
-      expect(await this.BeanSilo.totalDepositedBeans()).to.eq("1000");
+      expect(await this.silo2.getTotalDeposited(this.bean.address)).to.eq("1000");
+      expect(await this.silo2.getTotalWithdrawn(this.bean.address)).to.eq("0");
     });
 
     it("properly withdraws beans", async function () {
-	  console.log(await this.BeanSilo.totalDepositedBeans());
       await this.silo2
         .connect(user)
         .withdrawTokenBySeasons(this.bean.address, [3], ["1000"]);
-	  console.log(await this.BeanSilo.totalDepositedBeans());
-      expect(await this.BeanSilo.totalDepositedBeans()).to.eq("0");
+      expect(await this.silo2.getTotalDeposited(this.bean.address)).to.eq("0");
+      expect(await this.silo2.getTotalWithdrawn(this.bean.address)).to.eq("1000");
     });
   });
 
   describe("LP deposit and withdraw", async function () {
-    before(async function () {
-      this.LPSilo = await ethers.getContractAt("LPSilo", this.diamond.address);
-    });
-
     beforeEach(async function () {
       await this.season.siloSunrise(0);
+	  console.log(await this.pair.balanceOf(userAddress));
       await this.pair.faucet(userAddress, "10000");
+	  console.log(await this.pair.balanceOf(userAddress));
       await this.silo2.connect(user).deposit(this.pair.address, "1000");
     });
 
     it("properly deposits LP", async function () {
-      expect(await this.LPSilo.totalDepositedLP()).to.eq("1000");
+      expect(await this.silo2.getTotalDeposited(this.pair.address)).to.eq("1000");
     });
 
     // it("properly withdraws LP", async function () {

--- a/protocol/test/SiloV2.test.js
+++ b/protocol/test/SiloV2.test.js
@@ -1394,7 +1394,6 @@ describe("Silo", function () {
 
     it("properly withdraws beans", async function () {
 	  console.log(await this.BeanSilo.totalDepositedBeans());
-	  console.log(await this.season.season());
       await this.silo2
         .connect(user)
         .withdrawTokenBySeasons(this.bean.address, [3], ["1000"]);

--- a/protocol/test/SiloV2.test.js
+++ b/protocol/test/SiloV2.test.js
@@ -1393,9 +1393,10 @@ describe("Silo", function () {
     });
 
     it("properly withdraws beans", async function () {
+	  console.log(await this.BeanSilo.totalDepositedBeans());
       await this.silo2
         .connect(user)
-        .withdrawTokenBySeason(this.bean.address, 3, "1000");
+        .withdrawTokenBySeasons(this.bean.address, [3], [1000]);
       expect(await this.BeanSilo.totalDepositedBeans()).to.eq("0");
     });
   });


### PR DESCRIPTION
Here's my solution for the fungible deposits. Much inspiration was taken from the withdraw functions.

There's 4 main functions that people will interact with that are located in SiloV2Facet:
- transferTokenBySeason
- transferTokenBySeasons
- transferTokensBySeason
- transferTokensBySeasons

It uses the same parameters as the withdrawTokenBySeason functions but with an extra parameter, transferTo. This is the address of the user you want to transfer your deposit to.

I think I removed all the commented-out console.logs but I might be wrong. Also my formatter formatted a bunch of the code differently. A lot of the changed lines are just making the params multilined  
