### PR TITLE
Annotate curve convert amountOut functions; rename output var

### DIFF
--- a/protocol/contracts/libraries/Convert/LibCurveConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibCurveConvert.sol
@@ -48,12 +48,18 @@ library LibCurveConvert {
         );
     }
 
-    function getBeanAmountOut(address pool, uint256 amountIn) internal view returns(uint256 lp) {
-        lp = ICurvePool(pool).calc_withdraw_one_coin(amountIn, 0);
+    /// @param amountIn The amount of the LP token of `pool` to remove as BEAN.
+    /// @return lp The amount of BEAN received for removing `amountIn` LP tokens.
+    /// @notice Assumes that i=0 corresponds to BEAN.
+    function getBeanAmountOut(address pool, uint256 amountIn) internal view returns(uint256 beans) {
+        beans = ICurvePool(pool).calc_withdraw_one_coin(amountIn, 0); // i=0 -> BEAN
     }
 
+    /// @param amountIn The amount of BEAN to deposit into `pool`.
+    /// @return lp The amount of LP received for depositing BEAN.
+    /// @notice Assumes that i=0 corresponds to BEAN.
     function getLPAmountOut(address pool, uint256 amountIn) internal view returns(uint256 lp) {
-        lp = ICurvePool(pool).calc_token_amount([amountIn, 0], true);
+        lp = ICurvePool(pool).calc_token_amount([amountIn, 0], true); // i=0 -> BEAN
     }
 
     /// @notice Takes in encoded bytes for adding Curve LP in beans, extracts the input data, and then calls the


### PR DESCRIPTION
I'm working on implementing convert functionality into the frontend and found these notes helpful for my own understanding.

For clarity & consistency with other convert functions like `beansToPeg`, this PR renames the output variable of `getBeanAmountOut` from `lp` to `bean`.