### PR TITLE
fix: use unripeBeanAddress when converting Unripe BEAN to Unripe LP

### DIFF
--- a/protocol/contracts/libraries/Convert/LibConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibConvert.sol
@@ -51,14 +51,22 @@ library LibConvert {
         view
         returns (uint256 amountIn)
     {
+        /// BEAN:3CRV LP -> BEAN
         if (tokenIn == C.curveMetapoolAddress() && tokenOut == C.beanAddress())
             return LibCurveConvert.lpToPeg(C.curveMetapoolAddress());
+        
+        /// BEAN -> BEAN:3CRV LP
         if (tokenIn == C.beanAddress() && tokenOut == C.curveMetapoolAddress())
             return LibCurveConvert.beansToPeg(C.curveMetapoolAddress());
+        
+        /// urBEAN:3CRV LP -> urBEAN
         if (tokenIn == C.unripeLPAddress() && tokenOut == C.unripeBeanAddress())
             return LibUnripeConvert.lpToPeg();
+
+        /// urBEAN -> urBEAN:3CRV LP
         if (tokenIn == C.unripeBeanAddress() && tokenOut == C.unripeLPAddress())
             return LibUnripeConvert.beansToPeg();
+        
         require(false, "Convert: Tokens not supported");
     }
 
@@ -67,14 +75,22 @@ library LibConvert {
         view
         returns (uint256 amountOut)
     {
+        /// BEAN:3CRV LP -> BEAN
         if (tokenIn == C.curveMetapoolAddress() && tokenOut == C.beanAddress())
             return LibCurveConvert.getBeanAmountOut(C.curveMetapoolAddress(), amountIn);
+        
+        /// BEAN -> BEAN:3CRV LP
         if (tokenIn == C.beanAddress() && tokenOut == C.curveMetapoolAddress())
             return LibCurveConvert.getLPAmountOut(C.curveMetapoolAddress(), amountIn);
+
+        /// urBEAN:3CRV LP -> BEAN
         if (tokenIn == C.unripeLPAddress() && tokenOut == C.unripeBeanAddress())
             return LibUnripeConvert.getBeanAmountOut(amountIn);
-        if (tokenIn == C.beanAddress() && tokenOut == C.unripeLPAddress())
+        
+        /// urBEAN -> urBEAN:3CRV LP
+        if (tokenIn == C.unripeBeanAddress() && tokenOut == C.unripeLPAddress())
             return LibUnripeConvert.getLPAmountOut(amountIn);
+        
         require(false, "Convert: Tokens not supported");
     }
 }

--- a/protocol/contracts/libraries/Convert/LibCurveConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibCurveConvert.sol
@@ -49,7 +49,7 @@ library LibCurveConvert {
     }
 
     /// @param amountIn The amount of the LP token of `pool` to remove as BEAN.
-    /// @return lp The amount of BEAN received for removing `amountIn` LP tokens.
+    /// @return beans The amount of BEAN received for removing `amountIn` LP tokens.
     /// @notice Assumes that i=0 corresponds to BEAN.
     function getBeanAmountOut(address pool, uint256 amountIn) internal view returns(uint256 beans) {
         beans = ICurvePool(pool).calc_withdraw_one_coin(amountIn, 0); // i=0 -> BEAN


### PR DESCRIPTION
Previously this call was reverting with `Convert: Tokens not supported`.

Tested all four conversion modes against a local fork:

```
// BEAN -> BEAN:3CRV
getAmountOut(
  0xBEA0000029AD1c77D3d5D23Ba2D8893dB9d1Efab,
  0xc9C32cd16Bf7eFB85Ff14e0c8603cc90F6F2eE49,
  1000000
) // => "1037291677839082467"

// urBEAN -> urBEAN:3CRV
getAmountOut(
  0x1BEA0050E63e05FBb5D8BA2f10cf5800B6224449,
  0x1BEA3CcD22F4EBd3d37d731BA31Eeca95713716D,
  1000000
) // => "1048437"

// BEAN:3CRV -> BEAN
getAmountOut(
  0xc9C32cd16Bf7eFB85Ff14e0c8603cc90F6F2eE49,
  0xBEA0000029AD1c77D3d5D23Ba2D8893dB9d1Efab,
  1000000000000000000
) // => "963849"

// urBEAN:3CRV -> urBEAN
getAmountOut(
  0x1BEA3CcD22F4EBd3d37d731BA31Eeca95713716D,
  0x1BEA0050E63e05FBb5D8BA2f10cf5800B6224449,
  1000000
) // => "953594"
```
