### PR TITLE
EBIP-0: Emergency BIP-0

### DIFF
--- a/bips/ebip-0.md
+++ b/bips/ebip-0.md
@@ -14,7 +14,7 @@ Note: Bugs or security vulnerabilities qualify as emergencies. Emergency action 
 
 * GitHub PR: https://github.com/BeanstalkFarms/Beanstalk/pull/80
 * GitHub Commit Hash: fa8612e3698d932004f45cd3260c5ad71893b006
-* Gnosis Transaction: [insert Gnosis transaction details link here]
+* Gnosis Transaction: https://etherscan.io/tx/0x7949bdea1864aa66712bac3d57b79f3030c4cafbb91cdca3d56a0921e1496402
 
 ## Issue
 
@@ -26,7 +26,7 @@ If a Farmer performs an action that removes all of their assets from the Silo, t
 
 ## Magnitude
 
-It is estimated that approximately 1600 Beans across 34 accounts have been forfeited so far. Forfeited Earned Beans were redistributed across remaining Stalkholders. 
+It is estimated that approximately 1717 Beans across 32 accounts have been forfeited so far. Forfeited Earned Beans were redistributed across remaining Stalkholders. 
 
 ## Effective
 

--- a/bips/ebip-0.md
+++ b/bips/ebip-0.md
@@ -1,0 +1,33 @@
+# EBIP-0: Emergency BIP-0
+
+## Submitter
+
+Beanstalk Community Multisig
+
+## Emergency Process Note
+
+Per the process outlined in the [BCM Emergency Response Procedures](https://docs.bean.money/governance/beanstalk/bcm-process#emergency-response-procedures), an emergency hotfix may be implemented by an emergency vote of the BCM if the bug is minor and does not require significant code changes.
+
+Note: Bugs or security vulnerabilities qualify as emergencies. Emergency action will not be taken for any reason related to the economic health of Beanstalk (like a bank run, for example).
+
+## Links
+
+* GitHub PR: https://github.com/BeanstalkFarms/Beanstalk/pull/80
+* GitHub Commit Hash: fa8612e3698d932004f45cd3260c5ad71893b006
+* Gnosis Transaction: [insert Gnosis transaction details link here]
+
+## Issue
+
+If a Farmer performs an action that removed all of their assets from the Silo, all their Earned Beans were forfeited.
+
+## Fix
+
+If a Farmer performs an action that removes all of their assets from the Silo, their Earned Beans remain constant.
+
+## Magnitude
+
+It is estimated that approximately 1600 Beans across 34 accounts have been forfeited so far. Forfeited Earned Beans were redistributed across remaining Stalkholders. 
+
+## Effective
+
+Immediately upon commit by the BCM, which has already happened.

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -91,9 +91,8 @@ library LibSilo {
         AppStorage storage s = LibAppStorage.diamondStorage();
         if (stalk == 0) return;
 
-        uint256 roots = stalk == s.a[account].s.stalk
-            ? s.a[account].roots
-            : s.s.roots.mul(stalk).div(s.s.stalk);
+        uint256 roots = s.s.roots.mul(stalk).div(s.s.stalk);
+        if (roots > s.a[account].roots) roots = s.a[account].roots;
 
         s.s.stalk = s.s.stalk.sub(stalk);
         s.a[account].s.stalk = s.a[account].s.stalk.sub(stalk);


### PR DESCRIPTION
# EBIP-0: Emergency BIP-0

## Submitter

Beanstalk Community Multisig

## Emergency Process Note

Per the process outlined in the [BCM Emergency Response Procedures](https://docs.bean.money/governance/beanstalk/bcm-process#emergency-response-procedures), an emergency hotfix may be implemented by an emergency vote of the BCM if the bug is minor and does not require significant code changes.

Note: Bugs or security vulnerabilities qualify as emergencies. Emergency action will not be taken for any reason related to the economic health of Beanstalk (like a bank run, for example).

## Links

* GitHub PR: https://github.com/BeanstalkFarms/Beanstalk/pull/80
* GitHub Commit Hash: fa8612e3698d932004f45cd3260c5ad71893b006
* Gnosis Transaction: https://etherscan.io/tx/0x7949bdea1864aa66712bac3d57b79f3030c4cafbb91cdca3d56a0921e1496402

## Issue

If a Farmer performs an action that removed all of their assets from the Silo, all their Earned Beans were forfeited.

## Fix

If a Farmer performs an action that removes all of their assets from the Silo, their Earned Beans remain constant.

## Magnitude

It is estimated that approximately 1717 Beans across 32 accounts have been forfeited so far. Forfeited Earned Beans were redistributed across remaining Stalkholders. 

## Effective

Immediately upon commit by the BCM, which has already happened.