### PR TITLE
Add bug bounty program links

### DIFF
--- a/bug-bounty.md
+++ b/bug-bounty.md
@@ -1,0 +1,16 @@
+# Immunefi Bug Bounty Program
+
+A bug bounty program with Immunefi was launched on October 11, 2022. This bug bounty program is focused on the Beanstalk smart contracts and preventing the loss of user funds. The maximum bounty is 1,100,000 Beans.
+
+You can find the bug bounty program and submit bug reports [here](https://immunefi.com/bounty/beanstalk).
+
+In order to be considered for the maximum potential reward, bug reports must come with (1) a Proof of Concept (PoC), and (2) code implementing the fix.
+
+Bug reports that do not come with a PoC and code implementing
+a fix may qualify for a maximum of up to 30% of the potential reward outlined below, as determined by the Beanstalk Immunefi Committee (BIC). You can read more about the BIC here:
+
+- [BIC Process](https://docs.bean.money/governance/beanstalk/bic-process)
+- [BIC Dashboard](https://docs.bean.money/governance/beanstalk/bic-dashboard)
+
+All vulnerabilities noted in [any Halborn audit reports or the Trail of Bits audit report](https://github.com/BeanstalkFarms/Beanstalk-Audits) (or otherwise known by
+the BIC or [BCM](https://docs.bean.money/governance/beanstalk/bcm-dashboard)) are not eligible for a reward.

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,12 @@ The following facets are part of the [diamond functionality](https://github.com/
 |DiamondLoupeFacet    |[0xB51D5C699B749E0382e257244610039dDB272Da0](https://etherscan.io/address/0xB51D5C699B749E0382e257244610039dDB272Da0)|
 |OwnershipFacet       |[0x5D45283Ff53aabDb93693095039b489Af8b18Cf7](https://etherscan.io/address/0x5D45283Ff53aabDb93693095039b489Af8b18Cf7)|
 
+## Bug Bounty
+
+The Beanstalk DAO partnered with Immunefi to launch a bug bounty program with rewards up to 1.1M Beans.
+
+You can find the bug bounty program and submit bug reports [here](https://immunefi.com/bounty/beanstalk).
+
 ## Setup
 1. clone the repository
 2. run `cd protocol` to enter the protocol repository


### PR DESCRIPTION
Immunefi suggests adding links to the bug bounty program from the contract repo to increase awareness.