### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc--template.md
+++ b/.github/ISSUE_TEMPLATE/rfc--template.md
@@ -1,0 +1,43 @@
+---
+name: 'RFC: Template'
+about: The default template for Request For Comment issues (RFC)
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Abstract/Summary (optional) 
+One sentence descriptor on what the RFC is changing. 
+
+## Motivation (optional) 
+1-2 paragraph description on the motivation behind the change, and why beanstalk would stand to benefit from this. 
+
+## Problem
+1-2 paragraphs on the issue that beanstalk has. This can be technical or non-technical. 
+
+## Proposed Solution
+1-2 paragraphs on the proposed solution.  Ideally technical, but a non-technical solution is acceptable. 
+
+### Technical Specifications/implementation (optional)
+paragraphs explaining how the proposed solution would be implemented in code. This may include: 
+- redefining variables 
+- logic changes to existing functions
+- redefining existing functions
+- adding/removing functions to the codebase
+- redefining state variables
+- adding/removing state variables in the codebase
+
+Equations in latex format are greatly appreciated, using variables defined in the beanstalk whitepaper. 
+
+Ideas should be ordered as followed: 
+WIP 
+
+### Rationale (optional)
+1-2 paragraphs on the underlying reasons that this change is needed. Can be both economical and technical. 
+
+### Other Considerations (optional)
+Miscellaneous information that does not fit into the other categories. 
+
+### Execution (optional)
+Steps to take in order to execute this issue, and optionally a estimated timeline for this project.


### PR DESCRIPTION
A issue template standard is needed.  Ideally we should have a best practices for issues that mirrors the RFC. For example, we should adopt the modal language commonly used in technical documentation https://www.rfc-editor.org/rfc/rfc2119.

This is a suggested starting point, but very open to changes/additions, as it is very bare bones.  