### PR TITLE
EBIP-6: Resolve EBIP-4 and EBIP-5

### DIFF
--- a/protocol/abi/Beanstalk.json
+++ b/protocol/abi/Beanstalk.json
@@ -4917,6 +4917,39 @@
             },
             {
                 "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "enum LibTransfer.To",
+                "name": "toMode",
+                "type": "uint8"
+            }
+        ],
+        "name": "transferInternalTokenFrom",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IERC20",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
                 "name": "recipient",
                 "type": "address"
             },
@@ -4937,44 +4970,6 @@
             }
         ],
         "name": "transferToken",
-        "outputs": [],
-        "stateMutability": "payable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "contract IERC20",
-                "name": "token",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "recipient",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "internalType": "enum LibTransfer.From",
-                "name": "fromMode",
-                "type": "uint8"
-            },
-            {
-                "internalType": "enum LibTransfer.To",
-                "name": "toMode",
-                "type": "uint8"
-            }
-        ],
-        "name": "transferTokenFrom",
         "outputs": [],
         "stateMutability": "payable",
         "type": "function"

--- a/protocol/contracts/farm/facets/TokenFacet.sol
+++ b/protocol/contracts/farm/facets/TokenFacet.sol
@@ -61,31 +61,24 @@ contract TokenFacet is ReentrancyGuard {
         );
     }
 
-    function transferTokenFrom(
+    function transferInternalTokenFrom(
         IERC20 token,
         address sender,
         address recipient,
         uint256 amount,
-        LibTransfer.From fromMode,
         LibTransfer.To toMode
     ) external payable nonReentrant {
-        uint256 beforeAmount = LibBalance.getInternalBalance(sender, token);
         LibTransfer.transferToken(
             token,
             sender,
             recipient,
             amount,
-            fromMode,
+            LibTransfer.From.INTERNAL,
             toMode
         );
 
         if (sender != msg.sender) {
-            uint256 deltaAmount = beforeAmount.sub(
-                LibBalance.getInternalBalance(sender, token)
-            );
-            if (deltaAmount > 0) {
-                LibTokenApprove.spendAllowance(sender, msg.sender, token, deltaAmount);
-            }
+            LibTokenApprove.spendAllowance(sender, msg.sender, token, amount);
         }
     }
 

--- a/protocol/contracts/farm/init/InitEBip5.sol
+++ b/protocol/contracts/farm/init/InitEBip5.sol
@@ -1,0 +1,23 @@
+/*
+ SPDX-License-Identifier: MIT
+*/
+
+pragma solidity =0.7.6;
+pragma experimental ABIEncoderV2;
+
+import {AppStorage} from "../AppStorage.sol";
+
+/**
+ * @author Publius
+ * @title InitEBip5 updates the mappings of Pod Orders created before BIP-29.
+ **/
+contract InitEBip5 {
+    AppStorage internal s;
+
+    function init() external {
+        s.podOrders[0x6f668ae24be6e177f8584600dbffea6e07f260e08e21fa47792385913e786da3] = 10_491_929_346;
+        s.podOrders[0xf47df2678d29e9d57c5e9ed5f8c990e71910918154a2ed6d5235718035d7d8b0] = 1_466_423;
+        s.podOrders[0x186c6468ca4d3ce2575b9527fcf42cc3c86ab7cc915a550c9e84c5443691607a] = 380;
+    }
+
+}

--- a/protocol/contracts/farm/init/InitEBip6.sol
+++ b/protocol/contracts/farm/init/InitEBip6.sol
@@ -9,9 +9,9 @@ import {AppStorage} from "../AppStorage.sol";
 
 /**
  * @author Publius
- * @title InitEBip5 updates the mappings of Pod Orders created before BIP-29.
+ * @title InitEBip6 updates the mappings of Pod Orders created before BIP-29.
  **/
-contract InitEBip5 {
+contract InitEBip6 {
     AppStorage internal s;
 
     function init() external {

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -1,0 +1,37 @@
+const fs = require('fs')
+const { getBeanstalk, impersonateBeanstalkOwner, mintEth } = require("../utils")
+
+async function ebip5(mock = true, account = undefined) {
+    if (account == undefined) {
+        account = await impersonateBeanstalkOwner()
+        await mintEth(account.address)
+    }
+
+    beanstalk = await getBeanstalk()
+    const Ebip5 = await ethers.getContractFactory("InitEBip5", account)
+    const ebip5 = await Ebip5.deploy()
+    const dc = {
+        diamondCut: [
+                        [
+                            '0x0c9F436FBEf08914c1C68fe04bD573de6e327776',
+                            '0',
+                            ['0xdf18a3ee', '0x845a022b', '0x82c65124']
+                        ]
+                    ],
+        initFacetAddress: ebip5.address,
+        functionCall: ebip5.interface.encodeFunctionData('init', [])
+    }
+    if (mock) {
+        const receipt = await beanstalk.connect(account).diamondCut(Object.values(dc))
+    } else {
+        const encodedDiamondCut = await beanstalk.interface.encodeFunctionData('diamondCut', Object.values(dc))
+        console.log(JSON.stringify(dc, null, 4))
+        console.log("Encoded: -------------------------------------------------------------")
+        console.log(encodedDiamondCut)
+        const dcName = `diamondCut-${'InitEBip5'}-${Math.floor(Date.now() / 1000)}-facets.json`
+        await fs.writeFileSync(`./diamondCuts/${dcName}`, JSON.stringify({diamondCut: dc, encoded: encodedDiamondCut }, null, 4));
+        return dc
+    }
+}
+
+exports.ebip5 = ebip5

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -1,28 +1,36 @@
 const fs = require('fs')
 const { getBeanstalk, impersonateBeanstalkOwner, mintEth } = require("../utils")
 
-async function ebip5(mock = true, account = undefined) {
+async function ebip6(mock = true, account = undefined) {
     if (account == undefined) {
         account = await impersonateBeanstalkOwner()
         await mintEth(account.address)
     }
 
     beanstalk = await getBeanstalk()
-    const Ebip5 = await ethers.getContractFactory("InitEBip5", account)
-    const ebip5 = await Ebip5.deploy()
+    const tokenFacet = await (await ethers.getContractFactory("TokenFacet", account)).deploy()
+    console.log(`Token Facet deployed to: ${tokenFacet.address}`)
+    const ebip5 = await (await ethers.getContractFactory("InitEBip5", account)).deploy()
+    console.log(`EBIP-5 deployed to: ${ebip5.address}`)
     const dc = {
         diamondCut: [
                         [
                             '0x0c9F436FBEf08914c1C68fe04bD573de6e327776',
                             '0',
                             ['0xdf18a3ee', '0x845a022b', '0x82c65124']
+                        ],
+                        [
+                            tokenFacet.address,
+                            '0',
+                            ['0xd3f4ec6f']
                         ]
                     ],
         initFacetAddress: ebip5.address,
         functionCall: ebip5.interface.encodeFunctionData('init', [])
     }
+    console.log(Object.values(dc));
     if (mock) {
-        const receipt = await beanstalk.connect(account).diamondCut(Object.values(dc))
+        const receipt = await beanstalk.connect(account).diamondCut(...Object.values(dc))
     } else {
         const encodedDiamondCut = await beanstalk.interface.encodeFunctionData('diamondCut', Object.values(dc))
         console.log(JSON.stringify(dc, null, 4))
@@ -34,4 +42,4 @@ async function ebip5(mock = true, account = undefined) {
     }
 }
 
-exports.ebip5 = ebip5
+exports.ebip6 = ebip6

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -10,8 +10,8 @@ async function ebip6(mock = true, account = undefined) {
     beanstalk = await getBeanstalk()
     const tokenFacet = await (await ethers.getContractFactory("TokenFacet", account)).deploy()
     console.log(`Token Facet deployed to: ${tokenFacet.address}`)
-    const ebip5 = await (await ethers.getContractFactory("InitEBip5", account)).deploy()
-    console.log(`EBIP-5 deployed to: ${ebip5.address}`)
+    const ebip6 = await (await ethers.getContractFactory("InitEBip6", account)).deploy()
+    console.log(`EBIP-6 deployed to: ${ebip6.address}`)
     const dc = {
         diamondCut: [
                         [
@@ -25,10 +25,9 @@ async function ebip6(mock = true, account = undefined) {
                             ['0xd3f4ec6f']
                         ]
                     ],
-        initFacetAddress: ebip5.address,
-        functionCall: ebip5.interface.encodeFunctionData('init', [])
+        initFacetAddress: ebip6.address,
+        functionCall: ebip6.interface.encodeFunctionData('init', [])
     }
-    console.log(Object.values(dc));
     if (mock) {
         const receipt = await beanstalk.connect(account).diamondCut(...Object.values(dc))
     } else {
@@ -36,7 +35,7 @@ async function ebip6(mock = true, account = undefined) {
         console.log(JSON.stringify(dc, null, 4))
         console.log("Encoded: -------------------------------------------------------------")
         console.log(encodedDiamondCut)
-        const dcName = `diamondCut-${'InitEBip5'}-${Math.floor(Date.now() / 1000)}-facets.json`
+        const dcName = `diamondCut-${'InitEBip6'}-${Math.floor(Date.now() / 1000)}-facets.json`
         await fs.writeFileSync(`./diamondCuts/${dcName}`, JSON.stringify({diamondCut: dc, encoded: encodedDiamondCut }, null, 4));
         return dc
     }

--- a/protocol/test/Token.test.js
+++ b/protocol/test/Token.test.js
@@ -153,113 +153,170 @@ describe('Token', function () {
         })
     })
 
-    describe('transfer from', async function () {
-        describe('External to external', async function () {
-            it('basic', async function () {
-                await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', EXTERNAL, EXTERNAL);
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '200', '200')
-            })
+    describe('transfer internal from', async function () {
+      beforeEach(async function () {
+        await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
+      })
+
+      describe("spender = msg.sender", async function () {
+        it('to external', async function () {
+            this.result = await this.tokenFacet.connect(this.user).transferInternalTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', EXTERNAL);
+            checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
+            checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '200', '200')
+            await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
+        })
+  
+        it('to internal', async function () {
+          this.result = await this.tokenFacet.connect(this.user).transferInternalTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL);
+          checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
+          checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '200', '0', '200')
+          await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
+        })
+      })
+
+      describe('spender != msg.sender', async function () {
+        describe('without approval', async function () {
+          it('reverts if approval = 0', async function () {
+            await expect(this.tokenFacet.connect(this.user2).transferInternalTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL)).to.be.revertedWith('Token: insufficient allowance')
+          })
+
+          it('reverts if approval < amount', async function () {
+            await this.tokenFacet.connect(this.user).approveToken(this.user2.address, this.token.address, '100')
+            await expect(this.tokenFacet.connect(this.user2).transferInternalTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL)).to.be.revertedWith('Token: insufficient allowance')
+          })
         })
 
-        describe('External to internal', async function () {
-            it('basic', async function () {
-                this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address,this.user.address,this.recipient.address, '200', EXTERNAL, INTERNAL);
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '200', '0', '200')
-                await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.recipient.address, this.token.address, '200')
-            })
+        describe('with approval', async function () {
+          it('max approval', async function () {
+            await this.tokenFacet.connect(this.user).approveToken(this.user2.address, this.token.address, ethers.constants.MaxUint256)
+            this.result = await this.tokenFacet.connect(this.user2).transferInternalTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL)
+            checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
+            checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '200', '0', '200')
+            await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
+          })
+
+          it('some approval', async function () {
+            await this.tokenFacet.connect(this.user).approveToken(this.user2.address, this.token.address, '200')
+            this.result = await this.tokenFacet.connect(this.user2).transferInternalTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL)
+            checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
+            checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '200', '0', '200')
+            await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
+
+          })
         })
+      })
+  })
 
-        describe('internal to internal', async function () {
-            it('reverts if > than internal, not tolerant', async function () {
-                await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                await expect(this.tokenFacet.connect(this.user).transferToken(this.token.address, this.recipient.address, '300', INTERNAL, INTERNAL)).to.be.revertedWith("Balance: Insufficient internal balance")
-            })
-            it('internal', async function () {
-                await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL, INTERNAL);
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '200', '0', '200')
-                await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
-                await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.recipient.address, this.token.address, '200')
-            })
 
-            it('internal tolerant', async function () {
-                await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address,this.recipient.address, '300', INTERNAL_EXTERNAL, INTERNAL);
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '700', '700')
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '300', '0', '300')
-                await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
-                await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.recipient.address, this.token.address, '300')
-            })
+    // EBIP-5 renamed 
 
-            it('internal + external', async function () {
-                await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '250', INTERNAL_TOLERANT, INTERNAL);
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '200', '0', '200')
-                await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
-                await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.recipient.address, this.token.address, '200')
-            })
+    // describe('transfer from', async function () {
+    //     describe('External to external', async function () {
+    //         it('basic', async function () {
+    //             await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', EXTERNAL, EXTERNAL);
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '200', '200')
+    //         })
+    //     })
 
-            it('0 internal tolerant', async function () {
-                this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address,this.recipient.address, '0', INTERNAL_TOLERANT, INTERNAL);
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '1000', '1000')
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '0', '0')
-            })
-        })
+    //     describe('External to internal', async function () {
+    //         it('basic', async function () {
+    //             this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address,this.user.address,this.recipient.address, '200', EXTERNAL, INTERNAL);
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '200', '0', '200')
+    //             await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.recipient.address, this.token.address, '200')
+    //         })
+    //     })
 
-        describe('internal to external', async function () {
-            it('basic', async function () {
-                await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL, EXTERNAL);
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '200', '200')
-                await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
-            })
-        })
+    //     describe('internal to internal', async function () {
+    //         it('reverts if > than internal, not tolerant', async function () {
+    //             await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             await expect(this.tokenFacet.connect(this.user).transferToken(this.token.address, this.recipient.address, '300', INTERNAL, INTERNAL)).to.be.revertedWith("Balance: Insufficient internal balance")
+    //         })
+    //         it('internal', async function () {
+    //             await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL, INTERNAL);
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '200', '0', '200')
+    //             await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
+    //             await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.recipient.address, this.token.address, '200')
+    //         })
 
-        describe('internal to external allowance', async function () {
-            it('reverts if spender has insuffient allowance', async function () {
-                await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                await expect(this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL, EXTERNAL)).to.be.revertedWith("Token: insufficient allowance")
-            })
-            it('reverts if > than internal, not tolerant', async function () {
-                await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                await this.tokenFacet.connect(this.user).approveToken(this.user2.address,this.token.address, '500');
-                await expect(this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '300', INTERNAL, EXTERNAL)).to.be.revertedWith("Balance: Insufficient internal balance")
-            })
-            it('basic', async function () {
-                await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                await this.tokenFacet.connect(this.user).approveToken(this.user2.address, this.token.address, '200');
-                this.result = await this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL, EXTERNAL);
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '200', '200')
-                await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
-            })
-        })
+    //         it('internal tolerant', async function () {
+    //             await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address,this.recipient.address, '300', INTERNAL_EXTERNAL, INTERNAL);
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '700', '700')
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '300', '0', '300')
+    //             await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
+    //             await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.recipient.address, this.token.address, '300')
+    //         })
 
-        describe('internal to external tolerant allowance', async function () {
-            it('reverts if spender has insuffient allowance', async function () {
-                await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                await expect(this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL_EXTERNAL, EXTERNAL)).to.be.revertedWith("Token: insufficient allowance")
-            })
-            it('reverts if > than internal and external', async function () {
-                await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                await this.tokenFacet.connect(this.user).approveToken(this.user2.address, this.token.address, '500');
-                await expect(this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '1200', INTERNAL_EXTERNAL, EXTERNAL)).to.be.revertedWith("ERC20: transfer amount exceeds balance")
-            })
-            it('basic', async function () {
-                await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
-                await this.tokenFacet.connect(this.user).approveToken(this.user2.address, this.token.address, '200');
-                this.result = await this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '300', INTERNAL_EXTERNAL, EXTERNAL);
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '700', '700')
-                checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '300', '300')
-                await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
-            })
-        })
-    })
+    //         it('internal + external', async function () {
+    //             await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '250', INTERNAL_TOLERANT, INTERNAL);
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '200', '0', '200')
+    //             await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
+    //             await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.recipient.address, this.token.address, '200')
+    //         })
+
+    //         it('0 internal tolerant', async function () {
+    //             this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address,this.recipient.address, '0', INTERNAL_TOLERANT, INTERNAL);
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '1000', '1000')
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '0', '0')
+    //         })
+    //     })
+
+    //     describe('internal to external', async function () {
+    //         it('basic', async function () {
+    //             await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             this.result = await this.tokenFacet.connect(this.user).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL, EXTERNAL);
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '200', '200')
+    //             await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
+    //         })
+    //     })
+
+    //     describe('internal to external allowance', async function () {
+    //         it('reverts if spender has insuffient allowance', async function () {
+    //             await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             await expect(this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL, EXTERNAL)).to.be.revertedWith("Token: insufficient allowance")
+    //         })
+    //         it('reverts if > than internal, not tolerant', async function () {
+    //             await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             await this.tokenFacet.connect(this.user).approveToken(this.user2.address,this.token.address, '500');
+    //             await expect(this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '300', INTERNAL, EXTERNAL)).to.be.revertedWith("Balance: Insufficient internal balance")
+    //         })
+    //         it('basic', async function () {
+    //             await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             await this.tokenFacet.connect(this.user).approveToken(this.user2.address, this.token.address, '200');
+    //             this.result = await this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL, EXTERNAL);
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '800', '800')
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '200', '200')
+    //             await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
+    //         })
+    //     })
+
+    //     describe('internal to external tolerant allowance', async function () {
+    //         it('reverts if spender has insuffient allowance', async function () {
+    //             await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             await expect(this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '200', INTERNAL_EXTERNAL, EXTERNAL)).to.be.revertedWith("Token: insufficient allowance")
+    //         })
+    //         it('reverts if > than internal and external', async function () {
+    //             await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             await this.tokenFacet.connect(this.user).approveToken(this.user2.address, this.token.address, '500');
+    //             await expect(this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '1200', INTERNAL_EXTERNAL, EXTERNAL)).to.be.revertedWith("ERC20: transfer amount exceeds balance")
+    //         })
+    //         it('basic', async function () {
+    //             await this.tokenFacet.connect(this.user).transferToken(this.token.address, this.user.address, '200', EXTERNAL, INTERNAL);
+    //             await this.tokenFacet.connect(this.user).approveToken(this.user2.address, this.token.address, '200');
+    //             this.result = await this.tokenFacet.connect(this.user2).transferTokenFrom(this.token.address, this.user.address, this.recipient.address, '300', INTERNAL_EXTERNAL, EXTERNAL);
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.user.address, this.token.address), '0', '700', '700')
+    //             checkAllBalance(await this.tokenFacet.getAllBalance(this.recipient.address, this.token.address), '0', '300', '300')
+    //             await expect(this.result).to.emit(this.tokenFacet, 'InternalBalanceChanged').withArgs(this.user.address, this.token.address, '-200')
+    //         })
+    //     })
+    // })
 
     describe("weth", async function () {
         it('deposit WETH to external', async function () {


### PR DESCRIPTION
# EBIP-6: Resolve EBIP-4 and EBIP-5

Committed: November 15, 2022

---

- [Submitter](#submitter)
- [Emergency Process Note](#emergency-process-note)
- [Links](#links)
- [Problem](#problem)
- [Solution](#solution)
- [Contract Changes](#contract-changes)
- [Effective](#effective)

## Submitter

Beanstalk Community Multisig

## Emergency Process Note

Per the process outlined in the [BCM Emergency Response Procedures](https://docs.bean.money/governance/beanstalk/bcm-process#emergency-response-procedures), the BCM can take swift action to protect Beanstalk in the event of a bug or security vulnerability.

In the case of EBIP-6, functionality that was removed in [EBIP-4](https://arweave.net/WE73eyNcrbkCSZBAQerylbQ8VAoPjD0HBhVM6-OARVg) and [EBIP-5](https://arweave.net/rihDlnrjmAlFHRmsR3OeP3svGXcxFy_h1dEb0akpylk) is reintroduced this EBIP.

## Links

- [GitHub PR](https://github.com/BeanstalkFarms/Beanstalk/pull/146)
- [Gnosis Transaction](https://app.safe.global/eth:0xa9bA2C40b263843C04d344727b954A545c81D043/transactions/tx?id=multisig_0xa9bA2C40b263843C04d344727b954A545c81D043_0x488c125cb2c9c0fb06d11913e037a193423728075afed1c51f7e6d024e3f05a6)
- [Etherscan Transaction](https://etherscan.io/tx/0x7e0f3c0a574edb5658028ff0c8460d0d2ddbfd8cfb486b98ed7b10c7aa12b8d1)

## Problem

### EBIP-4 Problem

In `s.podOrders[id]`, the number of Pods Ordered is stored for the `id`s of the 3 remaining V1 Pod Orders. 

The `createPodOrder(...)`, `fillPodOrder(...)` and `cancelPodOrder(...)` functions were removed in [EBIP-4](https://arweave.net/WE73eyNcrbkCSZBAQerylbQ8VAoPjD0HBhVM6-OARVg).

### EBIP-5 Problem

The `transferTokenFrom(...)` function was removed in [EBIP-5](https://arweave.net/rihDlnrjmAlFHRmsR3OeP3svGXcxFy_h1dEb0akpylk).

## Solution

### EBIP-4 Solution

Update `s.podOrders[id]` for the `id`s of the 3 remaining V1 Pod Orders from the number of Pods Ordered to the number of Beans locked. Information about the 3 V1 Pod Orders is included below:

| Beans locked   | Price per Pod | Pods Ordered   | Order Id                                                              |
:----------------|:--------------|:---------------|:----------------------------------------------------------------------|
| 10,491.929346  | 0.10          | 104,919.293460 | `0x6f668ae24be6e177f8584600dbffea6e07f260e08e21fa47792385913e786da3`  |
| 1.466423       | 0.001         | 1,466.423000   | `0xf47df2678d29e9d57c5e9ed5f8c990e71910918154a2ed6d5235718035d7d8b0`  | 
| 0.000380       | 0.01001       | 0.037962       | `0x186c6468ca4d3ce2575b9527fcf42cc3c86ab7cc915a550c9e84c5443691607a`  |

Re-add the `createPodOrder(...)`, `fillPodOrder(...)` and `cancelPodOrder(...)` functions.

Notably, because the whitehat from [EBIP-4](https://arweave.net/WE73eyNcrbkCSZBAQerylbQ8VAoPjD0HBhVM6-OARVg) returned the extra 9,228.946824 Beans they received from Cancelling their Pod Order to Beanstalk (see [return transaction](https://etherscan.io/tx/0x09ad148ba695a05d08fd0726b9927411f94eceede13a730d4550f52ce9dc5e7d)), no Beans need to be minted to Beanstalk as part of the fix.

### EBIP-5 Solution

Change `transferTokenFrom(...)` to `transferInternalTokenFrom(...)` and re-add the function to Beanstalk. This function always transfers with `INTERNAL` `fromMode`.

All fixes have been reviewed by Halborn.

## Contract Changes

### MarketplaceFacet

The following `MarketplaceFacet` is still part of Beanstalk:
* [`0x0c9F436FBEf08914c1C68fe04bD573de6e327776`](https://etherscan.io/address/0x0c9F436FBEf08914c1C68fe04bD573de6e327776#code)

The following functions are **added** to `MarketplaceFacet`:

| Name                       | Selector     | 
|:---------------------------|:-------------|
| `createPodOrder(...)`      | `0x82c65124` |
| `fillPodOrder(...)`        | `0x845a022b` |
| `cancelPodOrder(...)`      | `0xdf18a3ee` |

### TokenFacet

The following `TokenFacet` is still part of Beanstalk:
* [`0x8D00eF08775872374a327355FE0FdbDece1106cF`](https://etherscan.io/address/0x8D00eF08775872374a327355FE0FdbDece1106cF#code)

The following `TokenFacet` is being **added** to Beanstalk: 
* [`0x50eb0085C31dfa8CF86cA16DeF77520E762EAD4a`](https://etherscan.io/address/0x50eb0085C31dfa8CF86cA16DeF77520E762EAD4a#code)

With the following functions:

| Name                              | Selector     | 
|:----------------------------------|:-------------|
| `transferInternalTokenFrom(...)`  | `0xd3f4ec6f` |

## Effective

Effective immediately upon commit by the BCM, which has already happened.
