### PR TITLE
Refactor param & function names in SiloFacet, Lib*Silo

### DIFF
--- a/protocol/contracts/beanstalk/init/replant/Replant1.sol
+++ b/protocol/contracts/beanstalk/init/replant/Replant1.sol
@@ -116,8 +116,8 @@ contract Replant1 {
         // emit BeanRemove(PROPOSER, seasons, amounts, PROPOSER_AMOUNT);
 
         // 2. Decrement Total Deposited for each token
-        LibTokenSilo.decrementDepositedToken(EXPLOITER_TOKEN_1, EXPLOITER_AMOUNT_1);
-        LibTokenSilo.decrementDepositedToken(EXPLOITER_TOKEN_2, EXPLOITER_AMOUNT_2);
+        LibTokenSilo.decrementDepositedTokenSupply(EXPLOITER_TOKEN_1, EXPLOITER_AMOUNT_1);
+        LibTokenSilo.decrementDepositedTokenSupply(EXPLOITER_TOKEN_2, EXPLOITER_AMOUNT_2);
         // LibBeanSilo.decrementDepositedBeans(PROPOSER_AMOUNT);
 
         // 3. Decrement total Stalk, Seeds, Roots 

--- a/protocol/contracts/beanstalk/init/replant/Replant1.sol
+++ b/protocol/contracts/beanstalk/init/replant/Replant1.sol
@@ -116,8 +116,8 @@ contract Replant1 {
         // emit BeanRemove(PROPOSER, seasons, amounts, PROPOSER_AMOUNT);
 
         // 2. Decrement Total Deposited for each token
-        LibTokenSilo.decrementDepositedTokenSupply(EXPLOITER_TOKEN_1, EXPLOITER_AMOUNT_1);
-        LibTokenSilo.decrementDepositedTokenSupply(EXPLOITER_TOKEN_2, EXPLOITER_AMOUNT_2);
+        LibTokenSilo.decrementTotalDeposited(EXPLOITER_TOKEN_1, EXPLOITER_AMOUNT_1);
+        LibTokenSilo.decrementTotalDeposited(EXPLOITER_TOKEN_2, EXPLOITER_AMOUNT_2);
         // LibBeanSilo.decrementDepositedBeans(PROPOSER_AMOUNT);
 
         // 3. Decrement total Stalk, Seeds, Roots 

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -126,7 +126,7 @@ contract ConvertFacet is ReentrancyGuard {
             "Convert: Not enough tokens removed."
         );
         a.stalkRemoved = a.stalkRemoved.mul(s.ss[token].seeds);
-        LibTokenSilo.decrementDepositedTokenSupply(token, a.tokensRemoved);
+        LibTokenSilo.decrementTotalDeposited(token, a.tokensRemoved);
         LibSilo.burnSeedsAndStalk(
             msg.sender,
             a.bdvRemoved.mul(s.ss[token].seeds),

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -154,7 +154,7 @@ contract ConvertFacet is ReentrancyGuard {
         uint256 stalk = bdv.mul(LibTokenSilo.stalk(token)).add(grownStalk);
         LibSilo.mintSeedsAndStalk(msg.sender, seeds, stalk);
 
-        LibTokenSilo.incrementDepositedTokenSupply(token, amount);
+        LibTokenSilo.incrementTotalDeposited(token, amount);
         LibTokenSilo.addDeposit(msg.sender, token, _s, amount, bdv);
     }
 

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -154,7 +154,7 @@ contract ConvertFacet is ReentrancyGuard {
         uint256 stalk = bdv.mul(LibTokenSilo.stalk(token)).add(grownStalk);
         LibSilo.depositSiloAssets(msg.sender, seeds, stalk);
 
-        LibTokenSilo.incrementDepositedToken(token, amount);
+        LibTokenSilo.incrementDepositedTokenSupply(token, amount);
         LibTokenSilo.addDeposit(msg.sender, token, _s, amount, bdv);
     }
 

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -126,7 +126,7 @@ contract ConvertFacet is ReentrancyGuard {
             "Convert: Not enough tokens removed."
         );
         a.stalkRemoved = a.stalkRemoved.mul(s.ss[token].seeds);
-        LibTokenSilo.decrementDepositedToken(token, a.tokensRemoved);
+        LibTokenSilo.decrementDepositedTokenSupply(token, a.tokensRemoved);
         LibSilo.withdrawSiloAssets(
             msg.sender,
             a.bdvRemoved.mul(s.ss[token].seeds),

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -127,7 +127,7 @@ contract ConvertFacet is ReentrancyGuard {
         );
         a.stalkRemoved = a.stalkRemoved.mul(s.ss[token].seeds);
         LibTokenSilo.decrementDepositedTokenSupply(token, a.tokensRemoved);
-        LibSilo.withdrawSiloAssets(
+        LibSilo.burnSeedsAndStalk(
             msg.sender,
             a.bdvRemoved.mul(s.ss[token].seeds),
             a.stalkRemoved.add(a.bdvRemoved.mul(s.ss[token].stalk))

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -152,7 +152,7 @@ contract ConvertFacet is ReentrancyGuard {
             _s = __s - _s;
         } else _s = s.season.current;
         uint256 stalk = bdv.mul(LibTokenSilo.stalk(token)).add(grownStalk);
-        LibSilo.depositSiloAssets(msg.sender, seeds, stalk);
+        LibSilo.mintSeedsAndStalk(msg.sender, seeds, stalk);
 
         LibTokenSilo.incrementDepositedTokenSupply(token, amount);
         LibTokenSilo.addDeposit(msg.sender, token, _s, amount, bdv);

--- a/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
@@ -42,9 +42,7 @@ contract Silo is SiloExit {
     //////////////////////// INTERNAL ////////////////////////
 
     /**
-     * @dev:
-     *
-     * Before performing any Silo accounting, we need to account for a user's Grown Stalk.
+     * @dev Before performing any Silo accounting, we need to account for a user's Grown Stalk.
      * 
      * How updating works: FIXME(doc)
      */

--- a/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
@@ -86,7 +86,7 @@ contract Silo is SiloExit {
         uint256 seeds = beans.mul(C.getSeedsPerBean());
 
         // Earned Seeds don't auto-compound, so we need to mint new Seeds
-        LibSilo.incrementBalanceOfSeeds(account, seeds);
+        LibSilo.mintSeeds(account, seeds);
 
         // Earned Stalk auto-compounds and thus is minted alongside Earned Beans
         // Farmers don't receive additional Roots from Earned Stalk.

--- a/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
@@ -52,8 +52,8 @@ contract Silo is SiloExit {
         uint32 _lastUpdate = lastUpdate(account);
 
         // If already updated this season, there's no Stalk to claim.
-        // _lastUpdate > season() should not be possible, but we check it anyway.
-        if (_lastUpdate >= season()) return;
+        // _lastUpdate > _season() should not be possible, but we check it anyway.
+        if (_lastUpdate >= _season()) return;
 
         // Increment Plenty if a SOP has occured or save Rain Roots if its Raining.
         handleRainAndSops(account, _lastUpdate);
@@ -61,8 +61,8 @@ contract Silo is SiloExit {
         // Earn Grown Stalk -> The Stalk gained from Seeds.
         earnGrownStalk(account);
 
-        // Bump the lastUpdate season to the current `season()`.
-        s.a[account].lastUpdate = season();
+        // Bump the lastUpdate season to the current `_season()`.
+        s.a[account].lastUpdate = _season();
     }
 
     function _plant(address account) internal returns (uint256 beans) {
@@ -79,7 +79,7 @@ contract Silo is SiloExit {
         LibTokenSilo.addDeposit(
             account,
             C.beanAddress(),
-            season(),
+            _season(),
             beans,
             beans
         );

--- a/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
@@ -111,7 +111,7 @@ contract Silo is SiloExit {
     function earnGrownStalk(address account) private {
         // If this `account` has no Seeds, skip to save gas.
         if (s.a[account].s.seeds == 0) return;
-        LibSilo.incrementBalanceOfStalk(account, balanceOfGrownStalk(account));
+        LibSilo.mintStalk(account, balanceOfGrownStalk(account));
     }
 
     function handleRainAndSops(address account, uint32 _lastUpdate) private {

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
@@ -263,6 +263,8 @@ contract SiloExit is ReentrancyGuard {
 
     /**
      * @dev Returns the current Season number.
+     *
+     * FIXME(naming) refactor to _season()
      */
     function season() internal view returns (uint32) {
         return s.season.current;

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
@@ -263,8 +263,6 @@ contract SiloExit is ReentrancyGuard {
 
     /**
      * @dev Returns the current Season number.
-     *
-     * FIXME(naming) refactor to _season()
      */
     function _season() internal view returns (uint32) {
         return s.season.current;

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
@@ -131,9 +131,7 @@ contract SiloExit is ReentrancyGuard {
     }
 
     /**
-     * @dev:
-     * 
-     * FIXME(doc) explain why we perform this calculation
+     * @dev FIXME(doc) explain why we perform this calculation
      * TODO(publius)
      */
     function _balanceOfEarnedBeans(address account, uint256 accountStalk)

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
@@ -115,7 +115,7 @@ contract SiloExit is ReentrancyGuard {
         return
             LibSilo.stalkReward(
                 s.a[account].s.seeds,
-                season() - lastUpdate(account)
+                _season() - lastUpdate(account)
             );
     }
     
@@ -266,7 +266,7 @@ contract SiloExit is ReentrancyGuard {
      *
      * FIXME(naming) refactor to _season()
      */
-    function season() internal view returns (uint32) {
+    function _season() internal view returns (uint32) {
         return s.season.current;
     }
 }

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -27,9 +27,8 @@ contract SiloFacet is TokenSilo {
      * @param amount The amount of `token` to Deposit.
      * @param mode The balance to pull tokens from. See {LibTransfer.From}.
      *
-     * @dev:
+     * @dev Depositing should:
      * 
-     * Depositing should:
      *  1. Transfer `amount` of `token` from `account` to Beanstalk.
      *  2. Calculate the current Bean Denominated Value (BDV) for `amount` of `token`.
      *  3. Create a Deposit entry for `account` in the current Season.
@@ -61,9 +60,10 @@ contract SiloFacet is TokenSilo {
      * @param season season the farmer wants to withdraw
      * @param amount tokens to be withdrawn
      *
-     * @dev:
-     * Season determines how much Stalk and Seeds are removed from the Farmer.
+     * @dev Season determines how much Stalk and Seeds are removed from the Farmer.
+     * 
      * Typically the user wants to withdraw from the latest season, as it has the lowest stalk allocation.
+     * 
      * We rely on the subgraph in order to query farmer deposits.
      */
     function withdrawDeposit(
@@ -80,9 +80,7 @@ contract SiloFacet is TokenSilo {
      * @param seasons array of seasons to withdraw from
      * @param amounts array of amounts corresponding to each season to withdraw from
 
-     * @dev:
-     *
-     * Factor in gas costs when withdrawing from multiple deposits to ensure greater UX.
+     * @dev Factor in gas costs when withdrawing from multiple deposits to ensure greater UX.
      *
      * For example, if a user wants to withdraw X beans, its better to withdraw from 1 earlier deposit
      * rather than multiple smaller recent deposits, if the season difference is minimal.
@@ -366,10 +364,10 @@ contract SiloFacet is TokenSilo {
 
     /** 
      * @notice adds Revitalized Stalk and Seeds to your Stalk and Seed balances
-     * @dev only applies to unripe assets
      * @param token address of ERC20
      * @param seasons array of seasons to enroot
      * @param amounts array of amount (corresponding to seasons) to enroot
+     * @dev only applies to unripe assets
      */
     function enrootDeposits(
         address token,

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -296,10 +296,9 @@ contract SiloFacet is TokenSilo {
         return LibSiloPermit.nonces(owner);
     }
 
-     /**
+    /**
      * @dev See {IERC20Permit-DOMAIN_SEPARATOR}.
      */
-    // solhint-disable-next-line func-name-mixedcase
     function depositPermitDomainSeparator() external view returns (bytes32) {
         return LibSiloPermit._domainSeparatorV4();
     }

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -334,24 +334,24 @@ contract SiloFacet is TokenSilo {
     /** 
      * @notice updates unripe deposit
      * @param token address of ERC20
-     * @param _season season to enroot
+     * @param season season to enroot
      * @param amount amount to enroot
      */
     function enrootDeposit(
         address token,
-        uint32 _season,
+        uint32 season,
         uint256 amount
     ) external nonReentrant updateSilo {
         // First, remove Deposit and Redeposit with new BDV
         uint256 ogBDV = LibTokenSilo.removeDeposit(
             msg.sender,
             token,
-            _season,
+            season,
             amount
         );
-        emit RemoveDeposit(msg.sender, token, _season, amount); // Remove Deposit does not emit an event, while Add Deposit does.
+        emit RemoveDeposit(msg.sender, token, season, amount); // Remove Deposit does not emit an event, while Add Deposit does.
         uint256 newBDV = LibTokenSilo.beanDenominatedValue(token, amount);
-        LibTokenSilo.addDeposit(msg.sender, token, _season, amount, newBDV);
+        LibTokenSilo.addDeposit(msg.sender, token, season, amount, newBDV);
 
         // Calculate the different in BDV. Will fail if BDV is lower.
         uint256 deltaBDV = newBDV.sub(ogBDV);
@@ -359,7 +359,7 @@ contract SiloFacet is TokenSilo {
         // Calculate the new Stalk/Seeds associated with BDV and increment Stalk/Seed balances
         uint256 deltaSeeds = deltaBDV.mul(s.ss[token].seeds);
         uint256 deltaStalk = deltaBDV.mul(s.ss[token].stalk).add(
-            LibSilo.stalkReward(deltaSeeds, _season() - _season)
+            LibSilo.stalkReward(deltaSeeds, _season() - season)
         );
         LibSilo.depositSiloAssets(msg.sender, deltaSeeds, deltaStalk);
     }

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -359,7 +359,7 @@ contract SiloFacet is TokenSilo {
         // Calculate the new Stalk/Seeds associated with BDV and increment Stalk/Seed balances
         uint256 deltaSeeds = deltaBDV.mul(s.ss[token].seeds);
         uint256 deltaStalk = deltaBDV.mul(s.ss[token].stalk).add(
-            LibSilo.stalkReward(deltaSeeds, season() - _season)
+            LibSilo.stalkReward(deltaSeeds, _season() - _season)
         );
         LibSilo.depositSiloAssets(msg.sender, deltaSeeds, deltaStalk);
     }
@@ -397,7 +397,7 @@ contract SiloFacet is TokenSilo {
                 bdv.mul(s.ss[token].stalk).add(
                     LibSilo.stalkReward(
                         bdv.mul(s.ss[token].seeds),
-                        season() - seasons[i]
+                        _season() - seasons[i]
                     )
                 )
             );

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -361,7 +361,7 @@ contract SiloFacet is TokenSilo {
         uint256 deltaStalk = deltaBDV.mul(s.ss[token].stalk).add(
             LibSilo.stalkReward(deltaSeeds, _season() - season)
         );
-        LibSilo.depositSiloAssets(msg.sender, deltaSeeds, deltaStalk);
+        LibSilo.mintSeedsAndStalk(msg.sender, deltaSeeds, deltaStalk);
     }
 
     /** 
@@ -406,7 +406,7 @@ contract SiloFacet is TokenSilo {
         uint256 newSeeds = newBDV.mul(s.ss[token].seeds);
 
         // Add new Stalk
-        LibSilo.depositSiloAssets(
+        LibSilo.mintSeedsAndStalk(
             msg.sender,
             newSeeds.sub(ar.seedsRemoved),
             newStalk.sub(ar.stalkRemoved)

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -392,7 +392,7 @@ contract TokenSilo is Silo {
      * This is why
      *
      *
-     * FIXME(naming): LibTokenSilo offers `incrementDepositedTokenSupply` to perform the operation 
+     * FIXME(naming): LibTokenSilo offers `incrementTotalDeposited` to perform the operation 
      * under `// Total`. Should we create a similar helper for Withdrawals for symmetry?
      *
      * FIXME(naming): "Total" discussion

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -372,7 +372,7 @@ contract TokenSilo is Silo {
 
         // Remove deposit
         LibTokenSilo.decrementDepositedTokenSupply(token, amount); // Decrement total Deposited
-        LibSilo.withdrawSiloAssets(account, seeds, stalk); // Burn Seeds and Stalk
+        LibSilo.burnSeedsAndStalk(account, seeds, stalk); // Burn Seeds and Stalk
     }
 
     /**

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -609,8 +609,4 @@ contract TokenSilo is Silo {
         s.a[account].depositAllowances[spender][token] = amount;
         emit DepositApproval(account, spender, token, amount);
     }
-
-    function _season() private view returns (uint32) {
-        return s.season.current;
-    }
 }

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -373,7 +373,7 @@ contract TokenSilo is Silo {
         addTokenWithdrawal(account, token, arrivalSeason, amount); // Increment account & total Withdrawn
 
         // Remove deposit
-        LibTokenSilo.decrementDepositedTokenSupply(token, amount); // Decrement total Deposited
+        LibTokenSilo.decrementTotalDeposited(token, amount); // Decrement total Deposited
         LibSilo.burnSeedsAndStalk(account, seeds, stalk); // Burn Seeds and Stalk
     }
 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -391,7 +391,7 @@ contract TokenSilo is Silo {
      * This is why
      *
      *
-     * FIXME(naming): LibTokenSilo offers `incrementDepositedToken` to perform the operation 
+     * FIXME(naming): LibTokenSilo offers `incrementDepositedTokenSupply` to perform the operation 
      * under `// Total`. Should we create a similar helper for Withdrawals for symmetry?
      *
      * FIXME(naming): "Total" discussion

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -47,7 +47,7 @@ contract TokenSilo is Silo {
      * There is no "AddDeposits" event because there is currently no operation in which Beanstalk
      * creates multiple Deposits in different Seasons.
      *
-     *  - `deposit()` always places the user's deposit in the current `season()`.
+     *  - `deposit()` always places the user's deposit in the current `_season()`.
      *  - `convert()` collapses multiple deposits into a single Season to prevent loss of Stalk.
      */
     event AddDeposit(

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -355,7 +355,7 @@ contract TokenSilo is Silo {
      * @dev Shared between `_withdrawDeposit()` and `_withdrawDeposits()`.
      *
      * FIXME(naming): "withdrawAndBurn"? "withdrawAndReduceSupply"?
-     * FIXME(naming): change .decrementDepositedToken to .decrementDepositedTokenSupply
+     * FIXME(naming): change .decrementDepositedTokenSupply to .decrementDepositedTokenSupply
      *   NOT burn: burn = removing from user and from supply
      */
     function _withdraw(
@@ -372,7 +372,7 @@ contract TokenSilo is Silo {
         addTokenWithdrawal(account, token, arrivalSeason, amount); // Increment account & total Withdrawn
 
         // Remove deposit
-        LibTokenSilo.decrementDepositedToken(token, amount); // Decrement total Deposited
+        LibTokenSilo.decrementDepositedTokenSupply(token, amount); // Decrement total Deposited
         LibSilo.withdrawSiloAssets(account, seeds, stalk); // Burn Seeds and Stalk
     }
 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -530,7 +530,7 @@ contract TokenSilo is Silo {
             amount
         );
         LibTokenSilo.addDeposit(recipient, token, season, amount, bdv);
-        LibSilo.transferSiloAssets(sender, recipient, seeds, stalk);
+        LibSilo.transferSeedsAndStalk(sender, recipient, seeds, stalk);
         return bdv;
     }
 
@@ -577,7 +577,7 @@ contract TokenSilo is Silo {
             ar.bdvRemoved.mul(s.ss[token].stalk)
         );
         emit RemoveDeposits(sender, token, seasons, amounts, ar.tokensRemoved);
-        LibSilo.transferSiloAssets(
+        LibSilo.transferSeedsAndStalk(
             sender,
             recipient,
             ar.seedsRemoved,

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -271,7 +271,7 @@ contract TokenSilo is Silo {
      * @dev:
      *
      * {LibTokenSilo.deposit} creates a Deposit.
-     * {LibSilo.depositSiloAssets} creates the Stalk associated with the Deposit.
+     * {LibSilo.mintSeedsAndStalk} creates the Stalk associated with the Deposit.
      * 
      * This step should enforce that new Deposits are placed into the current `_season()`.
      */
@@ -286,7 +286,7 @@ contract TokenSilo is Silo {
             _season(),
             amount
         );
-        LibSilo.depositSiloAssets(account, seeds, stalk);
+        LibSilo.mintSeedsAndStalk(account, seeds, stalk);
     }
 
     //////////////////////// WITHDRAW ////////////////////////
@@ -355,7 +355,6 @@ contract TokenSilo is Silo {
      * @dev Shared between `_withdrawDeposit()` and `_withdrawDeposits()`.
      *
      * FIXME(naming): "withdrawAndBurn"? "withdrawAndReduceSupply"?
-     * FIXME(naming): change .decrementDepositedTokenSupply to .decrementDepositedTokenSupply
      *   NOT burn: burn = removing from user and from supply
      */
     function _withdraw(

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -353,15 +353,12 @@ contract TokenSilo is Silo {
 
     /**
      * @dev Shared between `_withdrawDeposit()` and `_withdrawDeposits()`.
-     *
-     * FIXME(naming): "withdrawAndBurn"? "withdrawAndReduceSupply"?
-     *   NOT burn: burn = removing from user and from supply
      */
     function _withdraw(
         address account,
         address token,
         uint256 amount,
-        // FIXME ?
+        // FIXME(refactor): param ordering
         uint256 stalk,
         uint256 seeds
     ) private {

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -69,9 +69,6 @@ library LibSilo {
 
     /**
      * @dev Wrapper: Depositing increments balance of Stalk & Seeds.
-     *
-     * FIXME(naming): mintSeedsAndStalk, reorder
-     *  - ✅ Approved
      */
     function mintSeedsAndStalk(
         address account,
@@ -84,9 +81,6 @@ library LibSilo {
 
     /**
      * @dev Wrapper: Withdrawing increments balance of Stalk & Seeds.
-     *
-     * FIXME(naming): burnSeedsAndStalk, reorder
-     *  - ✅ Approved
      */
     function burnSeedsAndStalk(
         address account,
@@ -100,9 +94,6 @@ library LibSilo {
     /**
      * @dev Wrapper: Transferring increments balance of Seeds & Stalk for
      * `receipient`, and decrements balance of Seeds & Stalk for `sender`.
-     *
-     * FIXME(naming): transferSeedsAndStalk, reorder
-     *  - ✅ Approved
      */
     function transferSiloAssets(
         address sender,
@@ -117,11 +108,7 @@ library LibSilo {
     //////////////////////// INCREMENT ////////////////////////
 
     /**
-     * @dev:
-     *  
-     * FIXME(naming): perhaps "mintSeeds" would better convey that Seeds
-     * are being added to the account's balance AND to the total supply?
-     *  - ✅ Approved
+     * @dev Mint Seeds to `account`.
      */
     function mintSeeds(address account, uint256 seeds) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -136,10 +123,6 @@ library LibSilo {
      * @dev Mint Stalk to `account`.
      * 
      * See {FIXME(doc)} for an explanation of Roots accounting.
-     *
-     * FIXME(naming): perhaps "mintStalk" would better convey that Stalk
-     * are being added to the account's balance AND to the total supply?
-     *  - ✅ Approved
      */
     function mintStalk(address account, uint256 stalk) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -163,11 +146,7 @@ library LibSilo {
     //////////////////////// DECREMENT ////////////////////////
 
     /**
-     * @dev:
-     *  
-     * FIXME(naming): perhaps "burnSeeds" would better convey that Seeds
-     * are being added to the account's balance AND to the total supply?
-     *  - ✅ Approved
+     * @dev FIXME(doc)
      */
     function burnSeeds(address account, uint256 seeds) private {
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -178,11 +157,7 @@ library LibSilo {
     }
 
     /**
-     * @dev:
-     *  
-     * FIXME(naming): perhaps "burnStalk" would better convey that Stalk
-     * are being added to the account's balance AND to the total supply?
-     *  - ✅ Approved
+     * @dev FIXME(doc)
      */
     function burnStalk(address account, uint256 stalk) private {
         AppStorage storage s = LibAppStorage.diamondStorage();

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -93,7 +93,7 @@ library LibSilo {
         uint256 seeds,
         uint256 stalk
     ) internal {
-        decrementBalanceOfStalk(account, stalk);
+        burnStalk(account, stalk);
         decrementBalanceOfSeeds(account, seeds);
     }
 
@@ -184,7 +184,7 @@ library LibSilo {
      * are being added to the account's balance AND to the total supply?
      *  - ✅ Approved
      */
-    function decrementBalanceOfStalk(address account, uint256 stalk) private {
+    function burnStalk(address account, uint256 stalk) private {
         AppStorage storage s = LibAppStorage.diamondStorage();
         if (stalk == 0) return;
 

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -19,12 +19,9 @@ library LibSilo {
 
     /**
      * @notice Emitted when `account` gains or loses Seeds.
-     * @param account 
+     * @param account The account that gained or lost Seeds.
      * @param delta The change in Seeds.
      * 
-     * @dev:
-     *
-     * Emitted for ALL changes in Seeds balance for `account`, including:
      *   
      *   - Add or remove a Deposit
      *   - Transfer a Deposit
@@ -42,13 +39,11 @@ library LibSilo {
 
     /**
      * @notice Emitted when `account` gains or loses Stalk.
-     * @param account 
+     * @param account The account that gained or lost Stalk.
      * @param delta The change in Stalk.
      * @param deltaRoots FIXME(doc)
      * 
-     * @dev:
-     *
-     * Emitted for ALL changes in Stalk balance for `account`, including:
+     * @dev Emitted for ALL changes in Stalk balance for `account`, including:
      *   
      *   - Add or remove a Deposit
      *   - Transfer a Deposit
@@ -216,8 +211,19 @@ library LibSilo {
     //////////////////////// UTILITIES ////////////////////////
 
     /**
-     * @param seeds 
-     * @param seasons 
+     * @param seeds The number of Seeds held.
+     * @param seasons The number of Seasons that have elapsed.
+     *
+     * @dev Each Seed yields 1E-4 (0.0001, or 1 / 10_000) Stalk per Season.
+     *
+     * Seasons is measured to 0 decimals. There are no fractional Seasons.
+     * Seeds are measured to 6 decimals.
+     * Stalk is measured to 10 decimals.
+     * 
+     * Example:
+     *  - `seeds = 1E6` (1 Seed)
+     *  - `seasons = 1` (1 Season)
+     *  - The result is `1E6 * 1 = 1E6`. Since Stalk is measured to 10 decimals, this is `1E6/1E10 = 1E-4` Stalk.
      */
     function stalkReward(uint256 seeds, uint32 seasons)
         internal

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -88,7 +88,7 @@ library LibSilo {
      * FIXME(naming): burnSeedsAndStalk, reorder
      *  - ✅ Approved
      */
-    function withdrawSiloAssets(
+    function burnSeedsAndStalk(
         address account,
         uint256 seeds,
         uint256 stalk

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -78,7 +78,7 @@ library LibSilo {
         uint256 seeds,
         uint256 stalk
     ) internal {
-        incrementBalanceOfStalk(account, stalk);
+        mintStalk(account, stalk);
         incrementBalanceOfSeeds(account, seeds);
     }
 
@@ -141,7 +141,7 @@ library LibSilo {
      * are being added to the account's balance AND to the total supply?
      *  - ✅ Approved
      */
-    function incrementBalanceOfStalk(address account, uint256 stalk) internal {
+    function mintStalk(address account, uint256 stalk) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         // Calculate amount of Roots for this amount of Stalk

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -73,7 +73,7 @@ library LibSilo {
      * FIXME(naming): mintSeedsAndStalk, reorder
      *  - ✅ Approved
      */
-    function depositSiloAssets(
+    function mintSeedsAndStalk(
         address account,
         uint256 seeds,
         uint256 stalk

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -12,7 +12,7 @@ import "../LibAppStorage.sol";
 /**
  * @title LibSilo
  * @author Publius
- * @notice
+ * @notice FIXME(doc)
  */
 library LibSilo {
     using SafeMath for uint256;
@@ -65,10 +65,10 @@ library LibSilo {
         int256 deltaRoots
     );
 
-    //////////////////////// WRAPPERS ////////////////////////
+    //////////////////////// MINT ////////////////////////
 
     /**
-     * @dev Wrapper: Depositing increments balance of Stalk & Seeds.
+     * @dev WRAPPER: Increment the balance balance of Stalk & Seeds.
      */
     function mintSeedsAndStalk(
         address account,
@@ -78,34 +78,6 @@ library LibSilo {
         mintStalk(account, stalk);
         mintSeeds(account, seeds);
     }
-
-    /**
-     * @dev Wrapper: Withdrawing increments balance of Stalk & Seeds.
-     */
-    function burnSeedsAndStalk(
-        address account,
-        uint256 seeds,
-        uint256 stalk
-    ) internal {
-        burnStalk(account, stalk);
-        burnSeeds(account, seeds);
-    }
-
-    /**
-     * @dev Wrapper: Transferring increments balance of Seeds & Stalk for
-     * `receipient`, and decrements balance of Seeds & Stalk for `sender`.
-     */
-    function transferSeedsAndStalk(
-        address sender,
-        address recipient,
-        uint256 seeds,
-        uint256 stalk
-    ) internal {
-        transferStalk(sender, recipient, stalk);
-        transferSeeds(sender, recipient, seeds);
-    }
-
-    //////////////////////// INCREMENT ////////////////////////
 
     /**
      * @dev Mint Seeds to `account`.
@@ -122,7 +94,7 @@ library LibSilo {
     /**
      * @dev Mint Stalk to `account`.
      * 
-     * See {FIXME(doc)} for an explanation of Roots accounting.
+     * Minting Stalk also mints associated Roots. See {FIXME(doc)} for an explanation of Roots accounting.
      */
     function mintStalk(address account, uint256 stalk) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -143,13 +115,26 @@ library LibSilo {
         emit StalkBalanceChanged(account, int256(stalk), int256(roots));
     }
 
-    //////////////////////// DECREMENT ////////////////////////
+    //////////////////////// BURN ////////////////////////
+
+    /**
+     * @dev WRAPPER: Withdrawing increments balance of Stalk & Seeds.
+     */
+    function burnSeedsAndStalk(
+        address account,
+        uint256 seeds,
+        uint256 stalk
+    ) internal {
+        burnStalk(account, stalk);
+        burnSeeds(account, seeds);
+    }
 
     /**
      * @dev FIXME(doc)
      */
     function burnSeeds(address account, uint256 seeds) private {
         AppStorage storage s = LibAppStorage.diamondStorage();
+        
         s.s.seeds = s.s.seeds.sub(seeds);
         s.a[account].s.seeds = s.a[account].s.seeds.sub(seeds);
 
@@ -181,6 +166,20 @@ library LibSilo {
     }
 
     //////////////////////// TRANSFER ////////////////////////
+
+    /**
+     * @dev WRAPPER: Transferring increments balance of Seeds & Stalk for
+     * `receipient`, and decrements balance of Seeds & Stalk for `sender`.
+     */
+    function transferSeedsAndStalk(
+        address sender,
+        address recipient,
+        uint256 seeds,
+        uint256 stalk
+    ) internal {
+        transferStalk(sender, recipient, stalk);
+        transferSeeds(sender, recipient, seeds);
+    }
 
     function transferSeeds(
         address sender,

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -69,6 +69,9 @@ library LibSilo {
 
     /**
      * @dev Wrapper: Depositing increments balance of Stalk & Seeds.
+     *
+     * FIXME(naming): mintSeedsAndStalk, reorder
+     *  - ✅ Approved
      */
     function depositSiloAssets(
         address account,
@@ -81,6 +84,9 @@ library LibSilo {
 
     /**
      * @dev Wrapper: Withdrawing increments balance of Stalk & Seeds.
+     *
+     * FIXME(naming): burnSeedsAndStalk, reorder
+     *  - ✅ Approved
      */
     function withdrawSiloAssets(
         address account,
@@ -94,6 +100,9 @@ library LibSilo {
     /**
      * @dev Wrapper: Transferring increments balance of Seeds & Stalk for
      * `receipient`, and decrements balance of Seeds & Stalk for `sender`.
+     *
+     * FIXME(naming): transferSeedsAndStalk, reorder
+     *  - ✅ Approved
      */
     function transferSiloAssets(
         address sender,
@@ -112,6 +121,7 @@ library LibSilo {
      *  
      * FIXME(naming): perhaps "mintSeeds" would better convey that Seeds
      * are being added to the account's balance AND to the total supply?
+     *  - ✅ Approved
      */
     function incrementBalanceOfSeeds(address account, uint256 seeds) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -129,6 +139,7 @@ library LibSilo {
      *
      * FIXME(naming): perhaps "mintStalk" would better convey that Stalk
      * are being added to the account's balance AND to the total supply?
+     *  - ✅ Approved
      */
     function incrementBalanceOfStalk(address account, uint256 stalk) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -156,10 +167,10 @@ library LibSilo {
      *  
      * FIXME(naming): perhaps "burnSeeds" would better convey that Seeds
      * are being added to the account's balance AND to the total supply?
+     *  - ✅ Approved
      */
     function decrementBalanceOfSeeds(address account, uint256 seeds) private {
         AppStorage storage s = LibAppStorage.diamondStorage();
-
         s.s.seeds = s.s.seeds.sub(seeds);
         s.a[account].s.seeds = s.a[account].s.seeds.sub(seeds);
 
@@ -171,6 +182,7 @@ library LibSilo {
      *  
      * FIXME(naming): perhaps "burnStalk" would better convey that Stalk
      * are being added to the account's balance AND to the total supply?
+     *  - ✅ Approved
      */
     function decrementBalanceOfStalk(address account, uint256 stalk) private {
         AppStorage storage s = LibAppStorage.diamondStorage();

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -94,7 +94,7 @@ library LibSilo {
         uint256 stalk
     ) internal {
         burnStalk(account, stalk);
-        decrementBalanceOfSeeds(account, seeds);
+        burnSeeds(account, seeds);
     }
 
     /**
@@ -169,7 +169,7 @@ library LibSilo {
      * are being added to the account's balance AND to the total supply?
      *  - ✅ Approved
      */
-    function decrementBalanceOfSeeds(address account, uint256 seeds) private {
+    function burnSeeds(address account, uint256 seeds) private {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.s.seeds = s.s.seeds.sub(seeds);
         s.a[account].s.seeds = s.a[account].s.seeds.sub(seeds);

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -79,7 +79,7 @@ library LibSilo {
         uint256 stalk
     ) internal {
         mintStalk(account, stalk);
-        incrementBalanceOfSeeds(account, seeds);
+        mintSeeds(account, seeds);
     }
 
     /**
@@ -123,7 +123,7 @@ library LibSilo {
      * are being added to the account's balance AND to the total supply?
      *  - ✅ Approved
      */
-    function incrementBalanceOfSeeds(address account, uint256 seeds) internal {
+    function mintSeeds(address account, uint256 seeds) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         s.s.seeds = s.s.seeds.add(seeds);

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -95,7 +95,7 @@ library LibSilo {
      * @dev Wrapper: Transferring increments balance of Seeds & Stalk for
      * `receipient`, and decrements balance of Seeds & Stalk for `sender`.
      */
-    function transferSiloAssets(
+    function transferSeedsAndStalk(
         address sender,
         address recipient,
         uint256 seeds,

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -75,8 +75,8 @@ library LibSilo {
         uint256 seeds,
         uint256 stalk
     ) internal {
-        mintStalk(account, stalk);
         mintSeeds(account, seeds);
+        mintStalk(account, stalk);
     }
 
     /**
@@ -125,8 +125,8 @@ library LibSilo {
         uint256 seeds,
         uint256 stalk
     ) internal {
-        burnStalk(account, stalk);
         burnSeeds(account, seeds);
+        burnStalk(account, stalk);
     }
 
     /**
@@ -134,7 +134,7 @@ library LibSilo {
      */
     function burnSeeds(address account, uint256 seeds) private {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        
+
         s.s.seeds = s.s.seeds.sub(seeds);
         s.a[account].s.seeds = s.a[account].s.seeds.sub(seeds);
 
@@ -177,8 +177,8 @@ library LibSilo {
         uint256 seeds,
         uint256 stalk
     ) internal {
-        transferStalk(sender, recipient, stalk);
         transferSeeds(sender, recipient, seeds);
+        transferStalk(sender, recipient, stalk);
     }
 
     function transferSeeds(

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -57,9 +57,7 @@ library LibTokenSilo {
      * @return seeds The amount of Seeds received for this Deposit.
      * @return stalk The amount of Stalk received for this Deposit.
      * 
-     * @dev:
-     * 
-     * Calculate the current BDV for `amount` of `token`.
+     * @dev Calculate the current BDV for `amount` of `token`.
      * Then perform deposit accounting with known BDV.
      */
     function deposit(

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -59,7 +59,7 @@ library LibTokenSilo {
      * 
      * @dev Calculate the current BDV for `amount` of `token` and propagate.
      * 
-     * FIXME(naming): why `_s` instead of `season`?
+     * FIXME(doc): _season is a function
      */
     function deposit(
         address account,
@@ -219,7 +219,7 @@ library LibTokenSilo {
      * 
      * See {AppStorage.sol:Storage.SiloSettings} for more information.
      *
-     * FIXME(naming): rename myFunctionCall
+     * FIXME(naming): rename myFunctionCall -> callData
      */
     function beanDenominatedValue(address token, uint256 amount)
         internal

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -34,7 +34,7 @@ library LibTokenSilo {
     /**
      * @dev Increment the total amount of `token` deposited in the Silo.
      */
-    function incrementDepositedTokenSupply(address token, uint256 amount) internal {
+    function incrementTotalDeposited(address token, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.siloBalances[token].deposited = s.siloBalances[token].deposited.add(
             amount
@@ -89,7 +89,7 @@ library LibTokenSilo {
         AppStorage storage s = LibAppStorage.diamondStorage();
         require(bdv > 0, "Silo: No Beans under Token.");
 
-        incrementDepositedTokenSupply(token, amount); // Total
+        incrementTotalDeposited(token, amount); // Total
         addDeposit(account, token, season, amount, bdv); // Account
 
         return (

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -44,7 +44,7 @@ library LibTokenSilo {
     /**
      * @dev Decrement the total amount of `token` deposited in the Silo.
      */
-    function decrementDepositedTokenSupply(address token, uint256 amount) internal {
+    function decrementTotalDeposited(address token, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.siloBalances[token].deposited = s.siloBalances[token].deposited.sub(
             amount

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -57,18 +57,19 @@ library LibTokenSilo {
      * @return seeds The amount of Seeds received for this Deposit.
      * @return stalk The amount of Stalk received for this Deposit.
      * 
-     * @dev Calculate the current BDV for `amount` of `token` and propagate.
+     * @dev:
      * 
-     * FIXME(doc): _season is a function
+     * Calculate the current BDV for `amount` of `token`.
+     * Then perform deposit accounting with known BDV.
      */
     function deposit(
         address account,
         address token,
-        uint32 _s,
+        uint32 season,
         uint256 amount
     ) internal returns (uint256, uint256) {
         uint256 bdv = beanDenominatedValue(token, amount);
-        return depositWithBDV(account, token, _s, amount, bdv);
+        return depositWithBDV(account, token, season, amount, bdv);
     }
 
     /**
@@ -83,7 +84,7 @@ library LibTokenSilo {
     function depositWithBDV(
         address account,
         address token,
-        uint32 _s,
+        uint32 season,
         uint256 amount,
         uint256 bdv
     ) internal returns (uint256, uint256) {
@@ -91,7 +92,7 @@ library LibTokenSilo {
         require(bdv > 0, "Silo: No Beans under Token.");
 
         incrementDepositedToken(token, amount); // Total
-        addDeposit(account, token, _s, amount, bdv); // Account
+        addDeposit(account, token, season, amount, bdv); // Account
 
         return (
             bdv.mul(s.ss[token].seeds), // Seeds
@@ -109,16 +110,16 @@ library LibTokenSilo {
     function addDeposit(
         address account,
         address token,
-        uint32 _s,
+        uint32 season,
         uint256 amount,
         uint256 bdv
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        s.a[account].deposits[token][_s].amount += uint128(amount);
-        s.a[account].deposits[token][_s].bdv += uint128(bdv);
+        s.a[account].deposits[token][season].amount += uint128(amount);
+        s.a[account].deposits[token][season].bdv += uint128(bdv);
 
-        emit AddDeposit(account, token, _s, amount, bdv);
+        emit AddDeposit(account, token, season, amount, bdv);
     }
 
     //////////////////////// REMOVE DEPOSIT ////////////////////////

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -44,7 +44,7 @@ library LibTokenSilo {
     /**
      * @dev Decrement the total amount of `token` deposited in the Silo.
      */
-    function decrementDepositedToken(address token, uint256 amount) internal {
+    function decrementDepositedTokenSupply(address token, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.siloBalances[token].deposited = s.siloBalances[token].deposited.sub(
             amount

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -34,7 +34,7 @@ library LibTokenSilo {
     /**
      * @dev Increment the total amount of `token` deposited in the Silo.
      */
-    function incrementDepositedToken(address token, uint256 amount) internal {
+    function incrementDepositedTokenSupply(address token, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.siloBalances[token].deposited = s.siloBalances[token].deposited.add(
             amount
@@ -91,7 +91,7 @@ library LibTokenSilo {
         AppStorage storage s = LibAppStorage.diamondStorage();
         require(bdv > 0, "Silo: No Beans under Token.");
 
-        incrementDepositedToken(token, amount); // Total
+        incrementDepositedTokenSupply(token, amount); // Total
         addDeposit(account, token, season, amount, bdv); // Account
 
         return (

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -46,7 +46,7 @@ contract MockSiloFacet is SiloFacet {
         LibTokenSilo.incrementDepositedTokenSupply(C.unripeLPAddress(), unripeLP);
         bdv = bdv.mul(C.initialRecap()).div(1e18);
         uint256 seeds = bdv.mul(s.ss[C.unripeLPAddress()].seeds);
-        uint256 stalk = bdv.mul(s.ss[C.unripeLPAddress()].stalk).add(LibSilo.stalkReward(seeds, season() - _s));
+        uint256 stalk = bdv.mul(s.ss[C.unripeLPAddress()].stalk).add(LibSilo.stalkReward(seeds, _season() - _s));
         LibSilo.mintSeedsAndStalk(msg.sender, seeds, stalk);
     }
 
@@ -56,7 +56,7 @@ contract MockSiloFacet is SiloFacet {
         LibTokenSilo.incrementDepositedTokenSupply(C.unripeBeanAddress(), amount);
         amount = amount.mul(C.initialRecap()).div(1e18);
         uint256 seeds = amount.mul(s.ss[C.unripeBeanAddress()].seeds);
-        uint256 stalk = amount.mul(s.ss[C.unripeBeanAddress()].stalk).add(LibSilo.stalkReward(seeds, season() - _s));
+        uint256 stalk = amount.mul(s.ss[C.unripeBeanAddress()].stalk).add(LibSilo.stalkReward(seeds, _season() - _s));
         LibSilo.mintSeedsAndStalk(msg.sender, seeds, stalk);
     }
 

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -43,7 +43,7 @@ contract MockSiloFacet is SiloFacet {
         else if (t == 1) LibTokenSilo.addDeposit(msg.sender, C.unripeLPPool1(), _s, amount, bdv);
         else if (t == 2) LibTokenSilo.addDeposit(msg.sender, C.unripeLPPool2(), _s, amount, bdv);
         uint256 unripeLP = getUnripeForAmount(t, amount);
-        LibTokenSilo.incrementDepositedTokenSupply(C.unripeLPAddress(), unripeLP);
+        LibTokenSilo.incrementTotalDeposited(C.unripeLPAddress(), unripeLP);
         bdv = bdv.mul(C.initialRecap()).div(1e18);
         uint256 seeds = bdv.mul(s.ss[C.unripeLPAddress()].seeds);
         uint256 stalk = bdv.mul(s.ss[C.unripeLPAddress()].stalk).add(LibSilo.stalkReward(seeds, _season() - _s));
@@ -53,7 +53,7 @@ contract MockSiloFacet is SiloFacet {
     function mockUnripeBeanDeposit(uint32 _s, uint256 amount) external {
         _update(msg.sender);
         s.a[msg.sender].bean.deposits[_s] += amount;
-        LibTokenSilo.incrementDepositedTokenSupply(C.unripeBeanAddress(), amount);
+        LibTokenSilo.incrementTotalDeposited(C.unripeBeanAddress(), amount);
         amount = amount.mul(C.initialRecap()).div(1e18);
         uint256 seeds = amount.mul(s.ss[C.unripeBeanAddress()].seeds);
         uint256 stalk = amount.mul(s.ss[C.unripeBeanAddress()].stalk).add(LibSilo.stalkReward(seeds, _season() - _s));

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -43,7 +43,7 @@ contract MockSiloFacet is SiloFacet {
         else if (t == 1) LibTokenSilo.addDeposit(msg.sender, C.unripeLPPool1(), _s, amount, bdv);
         else if (t == 2) LibTokenSilo.addDeposit(msg.sender, C.unripeLPPool2(), _s, amount, bdv);
         uint256 unripeLP = getUnripeForAmount(t, amount);
-        LibTokenSilo.incrementDepositedToken(C.unripeLPAddress(), unripeLP);
+        LibTokenSilo.incrementDepositedTokenSupply(C.unripeLPAddress(), unripeLP);
         bdv = bdv.mul(C.initialRecap()).div(1e18);
         uint256 seeds = bdv.mul(s.ss[C.unripeLPAddress()].seeds);
         uint256 stalk = bdv.mul(s.ss[C.unripeLPAddress()].stalk).add(LibSilo.stalkReward(seeds, season() - _s));
@@ -53,7 +53,7 @@ contract MockSiloFacet is SiloFacet {
     function mockUnripeBeanDeposit(uint32 _s, uint256 amount) external {
         _update(msg.sender);
         s.a[msg.sender].bean.deposits[_s] += amount;
-        LibTokenSilo.incrementDepositedToken(C.unripeBeanAddress(), amount);
+        LibTokenSilo.incrementDepositedTokenSupply(C.unripeBeanAddress(), amount);
         amount = amount.mul(C.initialRecap()).div(1e18);
         uint256 seeds = amount.mul(s.ss[C.unripeBeanAddress()].seeds);
         uint256 stalk = amount.mul(s.ss[C.unripeBeanAddress()].stalk).add(LibSilo.stalkReward(seeds, season() - _s));

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -47,7 +47,7 @@ contract MockSiloFacet is SiloFacet {
         bdv = bdv.mul(C.initialRecap()).div(1e18);
         uint256 seeds = bdv.mul(s.ss[C.unripeLPAddress()].seeds);
         uint256 stalk = bdv.mul(s.ss[C.unripeLPAddress()].stalk).add(LibSilo.stalkReward(seeds, season() - _s));
-        LibSilo.depositSiloAssets(msg.sender, seeds, stalk);
+        LibSilo.mintSeedsAndStalk(msg.sender, seeds, stalk);
     }
 
     function mockUnripeBeanDeposit(uint32 _s, uint256 amount) external {
@@ -57,7 +57,7 @@ contract MockSiloFacet is SiloFacet {
         amount = amount.mul(C.initialRecap()).div(1e18);
         uint256 seeds = amount.mul(s.ss[C.unripeBeanAddress()].seeds);
         uint256 stalk = amount.mul(s.ss[C.unripeBeanAddress()].stalk).add(LibSilo.stalkReward(seeds, season() - _s));
-        LibSilo.depositSiloAssets(msg.sender, seeds, stalk);
+        LibSilo.mintSeedsAndStalk(msg.sender, seeds, stalk);
     }
 
     function getUnripeForAmount(uint256 t, uint256 amount) private pure returns (uint256) {


### PR DESCRIPTION
### Silo module
- find instances of `_s` or `_season` as parameter names and remove underscore
- remove existing `_season()` function in TokenSilo
- rename the current `season()` function in SiloExit to `_season()`

### Silo libraries and upstream usage
- See commit history for summary of replacements.