### PR TITLE
Subgraph - Disregard pod orders that are cancelled but don't exist

### DIFF
--- a/projects/subgraph-beanstalk/src/YieldHandler.ts
+++ b/projects/subgraph-beanstalk/src/YieldHandler.ts
@@ -32,10 +32,12 @@ export function updateBeanEMA(t: i32, timestamp: BigInt): void {
             priorEMA = currentEMA
         }
     } else {
-        // Beta has become stable
-        let season = loadSiloHourlySnapshot(BEANSTALK, t, timestamp)
-        let priorYield = loadSiloYield(t - 1)
-        currentEMA = ((toDecimal(season.deltaBeanMints).minus(priorYield.beansPerSeasonEMA)).times(siloYield.beta)).plus(priorYield.beansPerSeasonEMA)
+        // Calculate EMA for the prior 720 seasons
+        for (let i = t - MAX_WINDOW + 1; i <= t; i++) {
+            let season = loadSiloHourlySnapshot(BEANSTALK, i, timestamp)
+            currentEMA = ((toDecimal(season.deltaBeanMints).minus(priorEMA)).times(siloYield.beta)).plus(priorEMA)
+            priorEMA = currentEMA
+        }
     }
 
     siloYield.beansPerSeasonEMA = currentEMA


### PR DESCRIPTION
It is possible to submit a `cancelPodOrder` transaction to Beanstalk for a pod order that was not previously created. As a result an empty `PodOrder` entity was being created. This updates the handler to disregard the cancellation if the order was not previously created, making the expected result from a query `null`.

Resolves #270 