### PR TITLE
github: update workflows to use Node16 compatible actions

### DIFF
--- a/.github/workflows/ci.protocol.yaml
+++ b/.github/workflows/ci.protocol.yaml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Protocol Tests
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Cache Node Modules

--- a/.github/workflows/ci.sdk.yaml
+++ b/.github/workflows/ci.sdk.yaml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: SDK Tests
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Cache Node Modules

--- a/.github/workflows/ci.subgraph-bean.yaml
+++ b/.github/workflows/ci.subgraph-bean.yaml
@@ -12,9 +12,9 @@ jobs:
     name: Compile
     steps:
     - name: Check out source repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
     - name: Cache Node Modules

--- a/.github/workflows/ci.subgraph-beanstalk.yaml
+++ b/.github/workflows/ci.subgraph-beanstalk.yaml
@@ -12,9 +12,9 @@ jobs:
     name: Compile
     steps:
     - name: Check out source repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
     - name: Cache Node Modules

--- a/.github/workflows/ci.ui.yaml
+++ b/.github/workflows/ci.ui.yaml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: UI Tests
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Cache Node Modules

--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -9,9 +9,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Checkout
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Cache Node Modules

--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -9,9 +9,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Checkout
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Cache Node Modules


### PR DESCRIPTION
This PR addresses the new warning in Github to update workflow action versions to use Node16

<img width="819" alt="image" src="https://user-images.githubusercontent.com/99347981/214676630-43ebf420-90c4-4046-b6dd-a7436551c1e5.png">
