### PR TITLE
Remove flaky transfer test

### DIFF
--- a/projects/sdk/src/lib/silo/Transfer.test.ts
+++ b/projects/sdk/src/lib/silo/Transfer.test.ts
@@ -8,10 +8,13 @@ const { sdk, account, utils } = getTestUtils();
 jest.setTimeout(30000);
 
 describe("Silo Transfer", function () {
+  beforeAll(async () => {
+    await utils.resetFork();
+    await utils.setAllBalances(account, "2000");
+  });
+
   const transfer = new Transfer(sdk);
-
-  const SUPPORTED_TOKENS = [sdk.tokens.BEAN, sdk.tokens.BEAN_CRV3_LP, sdk.tokens.UNRIPE_BEAN, sdk.tokens.UNRIPE_BEAN_CRV3];
-
+  const whiteListedTokens = Array.from(sdk.tokens.siloWhitelist);
   const testDestination = ACCOUNTS[1][1];
 
   it("Fails when using a non-whitelisted token", async () => {
@@ -21,14 +24,10 @@ describe("Silo Transfer", function () {
     expect(t).rejects.toThrow("Transfer error; token ETH is not a whitelisted asset");
   });
 
-  describe.each(SUPPORTED_TOKENS)("Transfer", (siloToken: Token) => {
+  describe.each(whiteListedTokens)("Transfer", (siloToken: Token) => {
     describe(`Transfer ${siloToken.displayName} sourced from single crate`, () => {
       beforeAll(async () => {
-        await utils.resetFork();
-
-        // make a deposit
         await siloToken.approveBeanstalk(TokenValue.MAX_UINT256);
-        await utils.setBalance(siloToken, account, 2000);
         const deposit = await sdk.silo.deposit(siloToken, siloToken, siloToken.amount(500), 0.1);
         await deposit.wait();
       });
@@ -58,52 +57,6 @@ describe("Silo Transfer", function () {
         };
         expect(t).rejects.toThrow("Insufficient balance");
       });
-    });
-  });
-
-  describe("Transfer BEAN sourced from multiple crates", () => {
-    beforeAll(async () => {
-      await utils.resetFork();
-
-      // make a deposit
-      await sdk.tokens.BEAN.approveBeanstalk(TokenValue.MAX_UINT256);
-      await utils.setBalance(sdk.tokens.BEAN, account, 2000);
-
-      let deposit = await sdk.silo.deposit(sdk.tokens.BEAN, sdk.tokens.BEAN, sdk.tokens.BEAN.amount(500), 0.1);
-      await deposit.wait();
-
-      // go to next season
-      await utils.sunriseForward();
-
-      // make another deposit
-      deposit = await sdk.silo.deposit(sdk.tokens.BEAN, sdk.tokens.BEAN, sdk.tokens.BEAN.amount(100), 0.1);
-      await deposit.wait();
-    });
-
-    it("Validate starting state", async () => {
-      const { deposited } = await sdk.silo.getBalance(sdk.tokens.BEAN);
-      expect(deposited.crates.length).toBe(2);
-      expect(deposited.amount.eq(sdk.tokens.BEAN.amount(600))).toBe(true);
-    });
-
-    it("Successfully transfers", async () => {
-      const tx = await transfer.transfer(sdk.tokens.BEAN, sdk.tokens.BEAN.amount(150), testDestination);
-      await tx.wait();
-      const { deposited } = await sdk.silo.getBalance(sdk.tokens.BEAN);
-
-      expect(deposited.crates.length).toBe(1);
-      expect(deposited.amount.eq(sdk.tokens.BEAN.amount(450))).toBe(true);
-
-      const { deposited: destinationBalance } = await sdk.silo.getBalance(sdk.tokens.BEAN, testDestination);
-      expect(destinationBalance.crates.length).toBe(2);
-      expect(destinationBalance.amount.eq(sdk.tokens.BEAN.amount(150))).toBe(true);
-    });
-
-    it("Fails when transfer amount exceeds balance", async () => {
-      const t = async () => {
-        const tx = await transfer.transfer(sdk.tokens.BEAN, sdk.tokens.BEAN.amount(3000), testDestination);
-      };
-      expect(t).rejects.toThrow("Insufficient balance");
     });
   });
 });


### PR DESCRIPTION
The use of `sunriseForward` in the multi-crate test is creating issues. I am removing that test for now. We have sufficient coverage on unit tests around picking crates, etc.

Concretely, inside the `sunriseForward` util method, we make an `evm_increaseTime` call, followed by an `evm_mine`. I tried to pass a future timestamp to `evm_mine` per https://github.com/foundry-rs/foundry/pull/4041 but that did not solve it. In the future, we can continue exploring this area but for now I don't think it makes sense to chase this issue further.

One change I did make was to reset anvil at the beginning of the test suite and not before each test case. This is how `deposit` tests do it and that does help run time some.