### PR TITLE
fix: Clicking the backdrop of a modal or pressing ESC doesn't close it

### DIFF
--- a/projects/ui/src/components/Field/PlotSelectDialog.tsx
+++ b/projects/ui/src/components/Field/PlotSelectDialog.tsx
@@ -40,14 +40,14 @@ const PlotSelectDialog: FC<PlotSelectDialogProps & DialogProps> = ({
 
   return (
     <Dialog
-      onClose={onClose}
+      onClose={handleClose}
       open={open}
       fullWidth
     >
       <StyledDialogTitle onClose={handleClose}>My Plots</StyledDialogTitle>
       <StyledDialogContent
         sx={{
-          pb: 1, // enforces 10px padding around all 
+          pb: 1, // enforces 10px padding around all
         }}
       >
         {Object.keys(plots).length > 0 ? (


### PR DESCRIPTION
Fixes #192 