### PR TITLE
Grown stalk per bdv

### DIFF
--- a/protocol/contracts/C.sol
+++ b/protocol/contracts/C.sol
@@ -51,7 +51,7 @@ library C {
     uint256 private constant SEEDS_PER_BEAN = 2;
     uint256 private constant STALK_PER_BEAN = 10000;
     uint256 private constant ROOTS_BASE = 1e12;
-    uint32 private constant SILOV3_START_SEASON = 10;
+    // uint32 private constant SILOV3_START_SEASON = 10; //maybe move to constant here eventually
 
 
     // Exploit
@@ -265,7 +265,8 @@ library C {
         return SOIL_COEFFICIENT_LOW;
     }
 
-    function siloV3StartSeason() internal pure returns (uint32) {
-        return SILOV3_START_SEASON;
-    }
+    //can be added after initial deploy for gas savings
+    // function siloV3StartSeason() internal pure returns (uint32) {
+    //     return SILOV3_START_SEASON;
+    // }
 }

--- a/protocol/contracts/C.sol
+++ b/protocol/contracts/C.sol
@@ -51,6 +51,7 @@ library C {
     uint256 private constant SEEDS_PER_BEAN = 2;
     uint256 private constant STALK_PER_BEAN = 10000;
     uint256 private constant ROOTS_BASE = 1e12;
+    uint32 private constant SILOV3_START_SEASON = 10;
 
 
     // Exploit
@@ -262,5 +263,9 @@ library C {
 
     function soilCoefficientLow() internal pure returns (uint256) {
         return SOIL_COEFFICIENT_LOW;
+    }
+
+    function siloV3StartSeason() internal pure returns (uint32) {
+        return SILOV3_START_SEASON;
     }
 }

--- a/protocol/contracts/beanstalk/AppStorage.sol
+++ b/protocol/contracts/beanstalk/AppStorage.sol
@@ -272,9 +272,9 @@ contract Storage {
          */
         uint32 stalkPerBdv;
         /*
-         * @dev The Grown Stalk Per BDV Per Season represents how much Stalk one BDV of the underlaying deposited token grows each season. In the past, this was represented by seeds.
+         * @dev The Stalk Per BDV Per Season represents how much Stalk one BDV of the underlaying deposited token grows each season. In the past, this was represented by seeds.
          */
-        uint32 grownStalkPerBdvPerSeason;
+        uint32 stalkPerBdvPerSeason;
         /*
          * @dev The last season in which the Cumulative Grown Stalk Per BDV was updated
          */

--- a/protocol/contracts/beanstalk/AppStorage.sol
+++ b/protocol/contracts/beanstalk/AppStorage.sol
@@ -56,6 +56,12 @@ contract Account {
         uint256 seeds; // Balance of the Farmer's normal Seeds.
     }
 
+    // This struct stores the mow status for each Silo-able token, for each farmer. This gets updated each time a farmer mows, or adds/removes deposits.
+    struct MowStatus {
+        int128 lastCumulativeGrownStalkPerBDV; // the last cumulative grown stalk per bdv index at which the farmer mowed
+        uint128 bdv; // bdv of all of a farmer's deposits of this token type
+    }
+
     // Season Of Plenty stores Season of Plenty (SOP) related balances
     struct SeasonOfPlenty {
         // uint256 base; // DEPRECATED – Post Replant SOPs are denominated in plenty Tokens instead of base.
@@ -120,6 +126,7 @@ contract Account {
         uint256 depositPermitNonces; // A Farmer's current deposit permit nonce
         uint256 tokenPermitNonces; // A Farmer's current token permit nonce
         mapping(address => mapping(int128 => Deposit)) deposits; //SiloV3 deposits stored as a map from Cumulative Grown Stalk
+        mapping(address => MowStatus) mowStatuses; //Store a MowStatus for each Silo-able token
     }
 }
 
@@ -185,7 +192,7 @@ contract Storage {
     // Silo stores global level Silo balances.
     struct Silo {
         uint256 stalk; // The total amount of active Stalk (including Earned Stalk, excluding Grown Stalk).
-        uint256 seeds; // The total amount of active Seeds (excluding Earned Seeds).
+        uint256 seeds; // The total amount of active Seeds (excluding Earned Seeds). No longer used.
         uint256 roots; // Total amount of Roots.
     }
 

--- a/protocol/contracts/beanstalk/AppStorage.sol
+++ b/protocol/contracts/beanstalk/AppStorage.sol
@@ -276,6 +276,7 @@ contract Storage {
         bytes4 selector;
         /*
          * @dev The Stalk Per BDV that the Silo grants in exchange for Depositing this Token.
+         * previously just called stalk.
          */
         uint32 stalkPerBdv;
         /*

--- a/protocol/contracts/beanstalk/AppStorage.sol
+++ b/protocol/contracts/beanstalk/AppStorage.sol
@@ -225,6 +225,7 @@ contract Storage {
         uint32 rainStart; // rainStart stores the most recent Season in which Rain started.
         bool raining; // True if it is Raining (P < 1, Pod Rate Excessively Low).
         bool fertilizing; // True if Beanstalk has Fertilizer left to be paid off.
+        uint16 grownStalkPerBdvStartSeason; //season in which the grownStalkPerBdv storage method starts
         uint256 start; // The timestamp of the Beanstalk deployment rounded down to the nearest hour.
         uint256 period; // The length of each season in Beanstalk.
         uint256 timestamp; // The timestamp of the start of the current Season.
@@ -275,15 +276,15 @@ contract Storage {
          */
         bytes4 selector;
         /*
-         * @dev The Stalk Per BDV that the Silo grants in exchange for Depositing this Token.
-         * previously just called stalk.
-         */
-        uint32 stalkPerBdv;
-        /*
          * @dev The Stalk Per BDV Per Season represents how much Stalk one BDV of the underlaying deposited token grows each season. In the past, this was represented by seeds. This is stored as 1e6, plus stalk is stored as 1e10, so 1 legacy
          seed would be 1e6 * 1e10.
          */
         uint32 stalkPerBdvPerSeason;
+        /*
+         * @dev The Stalk Per BDV that the Silo grants in exchange for Depositing this Token.
+         * previously just called stalk.
+         */
+        uint32 stalkPerBdv;
         /*
          * @dev The last season in which the Cumulative Grown Stalk Per BDV was updated
          */

--- a/protocol/contracts/beanstalk/AppStorage.sol
+++ b/protocol/contracts/beanstalk/AppStorage.sol
@@ -112,13 +112,14 @@ contract Account {
         SeasonOfPlenty deprecated; // DEPRECATED – Replant reset the Season of Plenty mechanism
         uint256 roots; // A Farmer's Root balance.
         uint256 wrappedBeans; // DEPRECATED – Replant generalized Internal Balances. Wrapped Beans are now stored at the AppStorage level.
-        mapping(address => mapping(uint32 => Deposit)) deposits; // A Farmer's Silo Deposits stored as a map from Token address to Season of Deposit to Deposit.
+        mapping(address => mapping(uint32 => Deposit)) legacyDeposits; // Legacy Silo Deposits stored as a map from Token address to Season of Deposit to Deposit.
         mapping(address => mapping(uint32 => uint256)) withdrawals; // DEPRECATED - Zero withdraw eliminates a need for withdraw mapping
         SeasonOfPlenty sop; // A Farmer's Season Of Plenty storage.
         mapping(address => mapping(address => uint256)) depositAllowances; // Spender => Silo Token
         mapping(address => mapping(IERC20 => uint256)) tokenAllowances; // Token allowances
         uint256 depositPermitNonces; // A Farmer's current deposit permit nonce
         uint256 tokenPermitNonces; // A Farmer's current token permit nonce
+        mapping(address => mapping(int128 => Deposit)) deposits; //SiloV3 deposits stored as a map from Cumulative Grown Stalk
     }
 }
 
@@ -267,13 +268,25 @@ contract Storage {
          */
         bytes4 selector;
         /*
-         * @dev The Seeds Per BDV that the Silo mints in exchange for Depositing this Token.
+         * @dev The Stalk Per BDV that the Silo grants in exchange for Depositing this Token.
          */
-        uint32 seeds;
+        uint32 stalkPerBdv;
         /*
-         * @dev The Stalk Per BDV that the Silo mints in exchange for Depositing this Token.
+         * @dev The Grown Stalk Per BDV Per Season represents how much Stalk one BDV of the underlaying deposited token grows each season. In the past, this was represented by seeds.
          */
-        uint32 stalk;
+        uint32 grownStalkPerBdvPerSeason;
+        /*
+         * @dev The last season in which the Cumulative Grown Stalk Per BDV was updated
+         */
+		uint32 lastUpdateSeason;
+        /*
+         * @dev The cumulative amount of grown stalk per BDV for this Silo depositable token.
+         */
+		int128 lastCumulativeGrownStalkPerBdv;
+        /*
+         * @dev This is the old seedsPerBdv value (previously 2 for Bean and 4 for LP tokens)
+         */
+		uint32 legacySeedsPerBdv;
     }
 
     // UnripeSettings stores the settings for an Unripe Token in Beanstalk.

--- a/protocol/contracts/beanstalk/AppStorage.sol
+++ b/protocol/contracts/beanstalk/AppStorage.sol
@@ -279,7 +279,8 @@ contract Storage {
          */
         uint32 stalkPerBdv;
         /*
-         * @dev The Stalk Per BDV Per Season represents how much Stalk one BDV of the underlaying deposited token grows each season. In the past, this was represented by seeds. This is stored as 1e6, i.e. 1 old "seed" means 1_000_000 units of stalkPerBdvPerSeason.
+         * @dev The Stalk Per BDV Per Season represents how much Stalk one BDV of the underlaying deposited token grows each season. In the past, this was represented by seeds. This is stored as 1e6, plus stalk is stored as 1e10, so 1 legacy
+         seed would be 1e6 * 1e10.
          */
         uint32 stalkPerBdvPerSeason;
         /*

--- a/protocol/contracts/beanstalk/AppStorage.sol
+++ b/protocol/contracts/beanstalk/AppStorage.sol
@@ -42,7 +42,7 @@ contract Account {
         mapping(uint32 => uint256) deposits; // Unripe Bean/LP Deposits (previously Bean/LP Deposits).
         mapping(uint32 => uint256) depositSeeds; // BDV of Unripe LP Deposits / 4 (previously # of Seeds in corresponding LP Deposit).
     }
-
+ 
     // Deposit represents a Deposit in the Silo of a given Token at a given Season.
     // Stored as two uint128 state variables to save gas.
     struct Deposit {

--- a/protocol/contracts/beanstalk/AppStorage.sol
+++ b/protocol/contracts/beanstalk/AppStorage.sol
@@ -279,7 +279,7 @@ contract Storage {
          */
         uint32 stalkPerBdv;
         /*
-         * @dev The Stalk Per BDV Per Season represents how much Stalk one BDV of the underlaying deposited token grows each season. In the past, this was represented by seeds.
+         * @dev The Stalk Per BDV Per Season represents how much Stalk one BDV of the underlaying deposited token grows each season. In the past, this was represented by seeds. This is stored as 1e6, i.e. 1 old "seed" means 1_000_000 units of stalkPerBdvPerSeason.
          */
         uint32 stalkPerBdvPerSeason;
         /*

--- a/protocol/contracts/beanstalk/AppStorage.sol
+++ b/protocol/contracts/beanstalk/AppStorage.sol
@@ -58,7 +58,7 @@ contract Account {
 
     // This struct stores the mow status for each Silo-able token, for each farmer. This gets updated each time a farmer mows, or adds/removes deposits.
     struct MowStatus {
-        int128 lastCumulativeGrownStalkPerBDV; // the last cumulative grown stalk per bdv index at which the farmer mowed
+        int128 lastCumulativeGrownStalkPerBdv; // the last cumulative grown stalk per bdv index at which the farmer mowed
         uint128 bdv; // bdv of all of a farmer's deposits of this token type
     }
 

--- a/protocol/contracts/beanstalk/init/InitBipNewSilo.sol
+++ b/protocol/contracts/beanstalk/init/InitBipNewSilo.sol
@@ -52,11 +52,11 @@ contract InitBipNewSilo {
         s.ss[C.unripeBeanAddress()].legacySeedsPerBdv = 2;
 
 
-        s.ss[address(C.unripeLP())].stalkPerBdvPerSeason = 4;
+        s.ss[address(C.unripeLP())].stalkPerBdvPerSeason = 2;
         s.ss[address(C.unripeLP())].stalkPerBdv = 1;
         s.ss[address(C.unripeLP())].lastUpdateSeason = s.season.current;
         s.ss[address(C.unripeLP())].lastCumulativeGrownStalkPerBdv = 0;
-        s.ss[address(C.unripeLP())].legacySeedsPerBdv = 2;
+        s.ss[address(C.unripeLP())].legacySeedsPerBdv = 4;
 
         //emit event for unripe LP from 4 to 2 grown stalk per bdv per season
         emit UpdatedStalkPerBdvPerSeason(address(C.unripeLP()), 2, s.season.current);

--- a/protocol/contracts/beanstalk/init/InitBipNewSilo.sol
+++ b/protocol/contracts/beanstalk/init/InitBipNewSilo.sol
@@ -1,0 +1,69 @@
+/*
+ SPDX-License-Identifier: MIT
+*/
+
+pragma solidity =0.7.6;
+pragma experimental ABIEncoderV2;
+
+import {IBean} from "../../interfaces/IBean.sol";
+import {AppStorage} from "../AppStorage.sol";
+import "~/C.sol";
+import "hardhat/console.sol";
+
+/**
+ * @author Publius
+ * @title InitBip8 runs the code for BIP-8.
+**/
+
+contract InitBipNewSilo {
+
+    AppStorage internal s;
+
+    event UpdatedStalkPerBdvPerSeason(
+        address indexed token,
+        uint32 stalkPerBdvPerSeason,
+        uint32 season
+    );
+    
+    
+    function init() external {
+        console.log("InitBipNewSilo.init() got called");
+        
+        //update all silo info for current Silo-able assets
+
+        s.ss[C.beanAddress()].stalkPerBdvPerSeason = 2;
+        s.ss[C.beanAddress()].stalkPerBdv = 1;
+        s.ss[C.beanAddress()].lastUpdateSeason = s.season.current;
+        s.ss[C.beanAddress()].lastCumulativeGrownStalkPerBdv = 0;
+        s.ss[C.beanAddress()].legacySeedsPerBdv = 2;
+
+
+        s.ss[C.curveMetapoolAddress()].stalkPerBdvPerSeason = 4;
+        s.ss[C.curveMetapoolAddress()].stalkPerBdv = 1;
+        s.ss[C.curveMetapoolAddress()].lastUpdateSeason = s.season.current;
+        s.ss[C.curveMetapoolAddress()].lastCumulativeGrownStalkPerBdv = 0;
+        s.ss[C.curveMetapoolAddress()].legacySeedsPerBdv = 4;
+
+
+        s.ss[C.unripeBeanAddress()].stalkPerBdvPerSeason = 2;
+        s.ss[C.unripeBeanAddress()].stalkPerBdv = 1;
+        s.ss[C.unripeBeanAddress()].lastUpdateSeason = s.season.current;
+        s.ss[C.unripeBeanAddress()].lastCumulativeGrownStalkPerBdv = 0;
+        s.ss[C.unripeBeanAddress()].legacySeedsPerBdv = 2;
+
+
+        s.ss[address(C.unripeLP())].stalkPerBdvPerSeason = 4;
+        s.ss[address(C.unripeLP())].stalkPerBdv = 1;
+        s.ss[address(C.unripeLP())].lastUpdateSeason = s.season.current;
+        s.ss[address(C.unripeLP())].lastCumulativeGrownStalkPerBdv = 0;
+        s.ss[address(C.unripeLP())].legacySeedsPerBdv = 2;
+
+        //emit event for unripe LP from 4 to 2 grown stalk per bdv per season
+        emit UpdatedStalkPerBdvPerSeason(address(C.unripeLP()), 2, s.season.current);
+
+
+
+        //set the grownStalkPerBdvStartSeason to the current season
+        s.season.grownStalkPerBdvStartSeason = uint16(s.season.current); //storing as uint16 to save storage space
+    }
+}

--- a/protocol/contracts/beanstalk/init/InitWhitelist.sol
+++ b/protocol/contracts/beanstalk/init/InitWhitelist.sol
@@ -41,37 +41,41 @@ contract InitWhitelist {
     }
 
     function whitelistBean3Crv() internal {
-        LibWhitelist.whitelistToken(
+        LibWhitelist.whitelistTokenLegacy(
             C.curveMetapoolAddress(),
             IBS.curveToBDV.selector,
             BEAN_3CRV_STALK,
+            BEAN_3CRV_SEEDS * 1e6, //stalkPerBdvPerSeason stored as 1e6 equals 1 legacy seed
             BEAN_3CRV_SEEDS
         );
     }
 
     function whitelistBean() internal {
-        LibWhitelist.whitelistToken(
+        LibWhitelist.whitelistTokenLegacy(
             C.beanAddress(),
             IBS.beanToBDV.selector,
             BEAN_STALK,
+            BEAN_SEEDS * 1e6,
             BEAN_SEEDS
         );
     }
 
     function whitelistUnripeBean() internal {
-        LibWhitelist.whitelistToken(
+        LibWhitelist.whitelistTokenLegacy(
             C.unripeBeanAddress(),
             IBS.unripeBeanToBDV.selector,
             BEAN_STALK,
+            BEAN_SEEDS * 1e6,
             BEAN_SEEDS
         );
     }
 
     function whitelistUnripeLP() internal {
-        LibWhitelist.whitelistToken(
+        LibWhitelist.whitelistTokenLegacy(
             C.unripeLPAddress(),
             IBS.unripeLPToBDV.selector,
             BEAN_3CRV_STALK,
+            BEAN_3CRV_SEEDS * 1e6,
             BEAN_3CRV_SEEDS
         );
     }

--- a/protocol/contracts/beanstalk/init/InitWhitelist.sol
+++ b/protocol/contracts/beanstalk/init/InitWhitelist.sol
@@ -30,8 +30,8 @@ contract InitWhitelist {
     uint32 private constant BEAN_3CRV_STALK = 10000;
     uint32 private constant BEAN_3CRV_SEEDS = 4;
 
-    uint32 private constant BEAN_STALK = 10000;
-    uint32 private constant BEAN_SEEDS = 2;
+    uint32 private constant BEAN_STALK = 10000; //stalk per bdv (bdv is 6, stalk is 10, so need 4 here)
+    uint32 private constant BEAN_SEEDS = 2; //seeds per bdv of bean (1e6 is one bean)
 
     function whitelistPools() internal {
         whitelistBean3Crv();
@@ -45,7 +45,7 @@ contract InitWhitelist {
             C.curveMetapoolAddress(),
             IBS.curveToBDV.selector,
             BEAN_3CRV_STALK,
-            BEAN_3CRV_SEEDS * 1e6 * 1e4, //stalkPerBdvPerSeason stored as 1e6, but each old seed yielded 1e4 stalk every season
+            BEAN_3CRV_SEEDS * 1e6, //stalkPerBdvPerSeason stored as 1e6, but each old seed yielded 1e4 stalk every season
             BEAN_3CRV_SEEDS
         );
     }
@@ -55,7 +55,7 @@ contract InitWhitelist {
             C.beanAddress(),
             IBS.beanToBDV.selector,
             BEAN_STALK,
-            BEAN_SEEDS * 1e6 * 1e4,
+            BEAN_SEEDS * 1e6,
             BEAN_SEEDS
         );
     }
@@ -65,7 +65,7 @@ contract InitWhitelist {
             C.unripeBeanAddress(),
             IBS.unripeBeanToBDV.selector,
             BEAN_STALK,
-            BEAN_SEEDS * 1e6 * 1e4,
+            BEAN_SEEDS * 1e6,
             BEAN_SEEDS
         );
     }
@@ -75,7 +75,7 @@ contract InitWhitelist {
             C.unripeLPAddress(),
             IBS.unripeLPToBDV.selector,
             BEAN_3CRV_STALK,
-            BEAN_3CRV_SEEDS * 1e6 * 1e4,
+            BEAN_3CRV_SEEDS * 1e6,
             BEAN_3CRV_SEEDS
         );
     }

--- a/protocol/contracts/beanstalk/init/InitWhitelist.sol
+++ b/protocol/contracts/beanstalk/init/InitWhitelist.sol
@@ -45,7 +45,7 @@ contract InitWhitelist {
             C.curveMetapoolAddress(),
             IBS.curveToBDV.selector,
             BEAN_3CRV_STALK,
-            BEAN_3CRV_SEEDS * 1e6, //stalkPerBdvPerSeason stored as 1e6 equals 1 legacy seed
+            BEAN_3CRV_SEEDS * 1e6 * 1e4, //stalkPerBdvPerSeason stored as 1e6, but each old seed yielded 1e4 stalk every season
             BEAN_3CRV_SEEDS
         );
     }
@@ -55,7 +55,7 @@ contract InitWhitelist {
             C.beanAddress(),
             IBS.beanToBDV.selector,
             BEAN_STALK,
-            BEAN_SEEDS * 1e6,
+            BEAN_SEEDS * 1e6 * 1e4,
             BEAN_SEEDS
         );
     }
@@ -65,7 +65,7 @@ contract InitWhitelist {
             C.unripeBeanAddress(),
             IBS.unripeBeanToBDV.selector,
             BEAN_STALK,
-            BEAN_SEEDS * 1e6,
+            BEAN_SEEDS * 1e6 * 1e4,
             BEAN_SEEDS
         );
     }
@@ -75,7 +75,7 @@ contract InitWhitelist {
             C.unripeLPAddress(),
             IBS.unripeLPToBDV.selector,
             BEAN_3CRV_STALK,
-            BEAN_3CRV_SEEDS * 1e6,
+            BEAN_3CRV_SEEDS * 1e6 * 1e4,
             BEAN_3CRV_SEEDS
         );
     }

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -53,7 +53,10 @@ contract ConvertFacet is ReentrancyGuard {
         nonReentrant
         returns (int128 toCumulativeGrownStalk, uint256 fromAmount, uint256 toAmount, uint256 fromBdv, uint256 toBdv)
     {
-        LibInternal.mow(msg.sender);
+
+        //a mow must be done before any convert, currently this happens in the guts of each convert
+        //function. TODOSEEDS: pull out the parsing of convert data, find tokenIn, mow here, then pass
+        //parsed data in to corresponding mow functions?
 
         address toToken; address fromToken; uint256 grownStalk;
         (toToken, fromToken, toAmount, fromAmount) = LibConvert.convert(
@@ -90,6 +93,8 @@ contract ConvertFacet is ReentrancyGuard {
         uint256 i = 0;
         while ((i < grownStalkPerBdvs.length) && (a.tokensRemoved < maxTokens)) {
             if (a.tokensRemoved.add(amounts[i]) < maxTokens) {
+                console.log('grownStalkPerBdvs[i]: ');
+                console.logInt(grownStalkPerBdvs[i]);
                 //keeping track of stalk removed must happen before we actually remove the deposit
                 //this is because LibTokenSilo.grownStalkForDeposit() uses the current deposit info
                 a.stalkRemoved = a.stalkRemoved.add(LibTokenSilo.grownStalkForDeposit(msg.sender, IERC20(token), grownStalkPerBdvs[i]));

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -35,7 +35,8 @@ contract ConvertFacet is ReentrancyGuard {
         address indexed token,
         int128[] grownStalkPerBdvs,
         uint256[] amounts,
-        uint256 amount
+        uint256 amount,
+        uint256[] bdvs
     );
 
     struct AssetsRemoved {
@@ -92,6 +93,7 @@ contract ConvertFacet is ReentrancyGuard {
         AssetsRemoved memory a;
         uint256 depositBDV;
         uint256 i = 0;
+        uint256[] memory bdvsRemoved = new uint256[](grownStalkPerBdvs.length);
         while ((i < grownStalkPerBdvs.length) && (a.tokensRemoved < maxTokens)) {
             if (a.tokensRemoved.add(amounts[i]) < maxTokens) {
                 console.log('grownStalkPerBdvs[i]: ');
@@ -105,6 +107,8 @@ contract ConvertFacet is ReentrancyGuard {
                     grownStalkPerBdvs[i],
                     amounts[i]
                 );
+                console.log('_withdrawTokens depositBDV: ', depositBDV);
+                bdvsRemoved[i] = depositBDV;
                 a.stalkRemoved = a.stalkRemoved.add(
                     LibSilo.stalkReward(
                         grownStalkPerBdvs[i],
@@ -121,6 +125,8 @@ contract ConvertFacet is ReentrancyGuard {
                     grownStalkPerBdvs[i],
                     amounts[i]
                 );
+                console.log('_withdrawTokens depositBDV: ', depositBDV);
+                bdvsRemoved[i] = depositBDV;
                 a.stalkRemoved = a.stalkRemoved.add(
                     LibSilo.stalkReward(
                         grownStalkPerBdvs[i],
@@ -148,7 +154,8 @@ contract ConvertFacet is ReentrancyGuard {
             token,
             grownStalkPerBdvs,
             amounts,
-            a.tokensRemoved
+            a.tokensRemoved,
+            bdvsRemoved
         );
 
         require(

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -140,7 +140,9 @@ contract ConvertFacet is ReentrancyGuard {
             i++;
         }
         for (i; i < grownStalkPerBdvs.length; ++i) amounts[i] = 0;
+
         console.log('emitting RemoveDeposits event');
+        
         emit RemoveDeposits(
             msg.sender,
             token,

--- a/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
@@ -121,8 +121,8 @@ contract Silo is SiloExit {
     }
 
     function __mow(address account, address token) private {
-        // If this `account` has no Seeds, skip to save gas. //TODOSEEDS is there a post-seeds equiv?
-        // if (s.a[account].s.seeds == 0) return;
+        // If this `account` has no BDV, skip to save gas.
+        if (s.a[account].mowStatuses[token].bdv == 0) return;
         LibSilo.mintStalk(account, balanceOfGrownStalk(account, token));
 
         s.a[account].mowStatuses[token].lastCumulativeGrownStalkPerBDV = LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token));

--- a/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
@@ -121,11 +121,17 @@ contract Silo is SiloExit {
     }
 
     function __mow(address account, address token) private {
-        // If this `account` has no BDV, skip to save gas.
-        if (s.a[account].mowStatuses[token].bdv == 0) return;
-        LibSilo.mintStalk(account, balanceOfGrownStalk(account, token));
+        // If this `account` has no BDV, skip to save gas. Still need to update lastCumulativeGrownStalkPerBdv (happen on initial deposit, since mow is called before any deposit)
+        if (s.a[account].mowStatuses[token].bdv == 0) {
+            s.a[account].mowStatuses[token].lastCumulativeGrownStalkPerBdv = LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token));
+            return;
+        }
 
-        s.a[account].mowStatuses[token].lastCumulativeGrownStalkPerBDV = LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token));
+        uint256 grownStalk = balanceOfGrownStalk(account, token);
+        console.log('__mow grownStalk: ', grownStalk);
+
+        LibSilo.mintStalk(account, balanceOfGrownStalk(account, token));
+        s.a[account].mowStatuses[token].lastCumulativeGrownStalkPerBdv = LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token));
     }
 
     //////////////////////// INTERNAL: PLANT ////////////////////////

--- a/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
@@ -127,6 +127,9 @@ contract Silo is SiloExit {
             return;
         }
 
+        //TODOSEEDS handle case where mow status hasn't been init'd, if last upadte season > 0 and older than update season
+
+
         uint256 grownStalk = balanceOfGrownStalk(account, token);
         console.log('__mow grownStalk: ', grownStalk);
 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
@@ -83,10 +83,12 @@ contract Silo is SiloExit {
     /**
      * @dev Claims the Grown Stalk for `msg.sender`.
      */
-    modifier mowSender() {
-        _mow(msg.sender);
+    modifier mowSender(address token) {
+        _mow(msg.sender, token);
         _;
     }
+
+    //TODO: make function that can mow multiple tokens
 
     /**
      * @dev Claims the Grown Stalk for `account` and applies it to their Stalk
@@ -115,7 +117,7 @@ contract Silo is SiloExit {
 
         // Calculate the amount of Grown Stalk claimable by `account`.
         // Increase the account's balance of Stalk and Roots.
-        __mow(account);
+        __mow(account, token);
 
         // Reset timer so that Grown Stalk for a particular Season can only be 
         // claimed one time. 
@@ -125,7 +127,7 @@ contract Silo is SiloExit {
     function __mow(address account, address token) private {
         // If this `account` has no Seeds, skip to save gas. //TODOSEEDS is there a post-seeds equiv?
         // if (s.a[account].s.seeds == 0) return;
-        LibSilo.mintStalk(account, balanceOfGrownStalk(account));
+        LibSilo.mintStalk(account, balanceOfGrownStalk(account, token, s.a[account].mowStatuses[token].bdv));
     }
 
     //////////////////////// INTERNAL: PLANT ////////////////////////
@@ -136,10 +138,10 @@ contract Silo is SiloExit {
      * 
      * For more info on Planting, see: {SiloFacet-plant}
      */
-    function _plant(address account) internal returns (uint256 beans) {
+    function _plant(address account, address token) internal returns (uint256 beans) {
         // Need to Mow for `account` before we calculate the balance of 
-        // Earned Beans.
-        _mow(account);
+        // Earned Beans. //TODOSEEDS do we need to mow all tokens?
+        _mow(account, token);
         uint256 accountStalk = s.a[account].s.stalk;
 
         // Calculate balance of Earned Beans.

--- a/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
@@ -118,16 +118,14 @@ contract Silo is SiloExit {
         // Calculate the amount of Grown Stalk claimable by `account`.
         // Increase the account's balance of Stalk and Roots.
         __mow(account, token);
-
-        // Reset timer so that Grown Stalk for a particular Season can only be 
-        // claimed one time. 
-        s.a[account].lastUpdate = _season(); // move this to __mow
     }
 
     function __mow(address account, address token) private {
         // If this `account` has no Seeds, skip to save gas. //TODOSEEDS is there a post-seeds equiv?
         // if (s.a[account].s.seeds == 0) return;
-        LibSilo.mintStalk(account, balanceOfGrownStalk(account, token, s.a[account].mowStatuses[token].bdv));
+        LibSilo.mintStalk(account, balanceOfGrownStalk(account, token));
+
+        s.a[account].mowStatuses[token].lastCumulativeGrownStalkPerBDV = LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token));
     }
 
     //////////////////////// INTERNAL: PLANT ////////////////////////

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
@@ -247,26 +247,31 @@ contract SiloExit is ReentrancyGuard {
             // If there has been a SOP duing the rain sesssion since last update, process SOP.
             if (lastRainPPR > previousPPR) {
                 uint256 plentyPerRoot = lastRainPPR - previousPPR;
+                console.log('1 plentyPerRoot: ', plentyPerRoot);
                 previousPPR = lastRainPPR;
                 plenty = plenty.add(
                     plentyPerRoot.mul(s.a[account].sop.roots).div(
                         C.getSopPrecision()
                     )
                 );
+                console.log('1 plenty: ', plenty);
             }
         } else {
             // If it was not raining, just use the PPR at previous SOP.
             previousPPR = s.sops[s.a[account].lastSop];
+            console.log('previousPPR: ', previousPPR);
         }
 
         // Handle and SOPs that started + ended before after last Silo update.
         if (s.season.lastSop > lastUpdate(account)) {
             uint256 plentyPerRoot = s.sops[s.season.lastSop].sub(previousPPR);
+            console.log('2 plentyPerRoot: ', plentyPerRoot);
             plenty = plenty.add(
                 plentyPerRoot.mul(balanceOfRoots(account)).div(
                     C.getSopPrecision()
                 )
             );
+            console.log('2 plenty: ', plenty);
         }
     }
 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
@@ -120,7 +120,7 @@ contract SiloExit is ReentrancyGuard {
      * @dev The balance of Grown Stalk for an account can be calculated as:
      *
      * ```
-     * elapsedSeasons = currentSeason - lastUpdatedSeason
+     * elapsedSeasons = currentSeason - lastUpdateSeason
      * grownStalk = balanceOfSeeds * elapsedSeasons
      * ```
      */

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
@@ -9,6 +9,7 @@ pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "~/beanstalk/ReentrancyGuard.sol";
 import "~/libraries/Silo/LibSilo.sol";
+import "~/libraries/Silo/LibTokenSilo.sol";
 import "~/libraries/LibSafeMath32.sol";
 import "~/libraries/LibSafeMath128.sol";
 import "~/libraries/LibPRBMath.sol";
@@ -132,8 +133,8 @@ contract SiloExit is ReentrancyGuard {
         //need to fetch last updated grownStalkPerBdv for this deposit and current grownStalkPerBdv
         return
             LibSilo.stalkReward(
-                s.a[account].mowStatuses[token].lastCumulativeGrownStalkPerBDV, //last GSPBDV farmer mowed
-                s.ss[address(token)].lastCumulativeGrownStalkPerBdv, //latest index, updated at last sunrise
+                s.a[account].mowStatuses[token].lastCumulativeGrownStalkPerBdv, //last GSPBDV farmer mowed
+                LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)), //get latest grown stalk per bdv for this token
                 s.a[account].mowStatuses[token].bdv
             );
     }

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
@@ -124,7 +124,7 @@ contract SiloExit is ReentrancyGuard {
      * grownStalk = balanceOfSeeds * elapsedSeasons
      * ```
      */
-    function balanceOfGrownStalk(address account, address token, uint128 bdv)
+    function balanceOfGrownStalk(address account, address token)
         public
         view
         returns (uint256)
@@ -134,7 +134,7 @@ contract SiloExit is ReentrancyGuard {
             LibSilo.stalkReward(
                 s.a[account].mowStatuses[token].lastCumulativeGrownStalkPerBDV, //last GSPBDV farmer mowed
                 s.ss[address(token)].lastCumulativeGrownStalkPerBdv, //latest index, updated at last sunrise
-                bdv
+                s.a[account].mowStatuses[token].bdv
             );
     }
     

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -496,4 +496,12 @@ contract SiloFacet is TokenSilo {
         require(LibLegacyTokenSilo.isDepositSeason(token, grownStalkPerBdv), "No matching season for input grownStalkPerBdv");
         season = LibLegacyTokenSilo.grownStalkPerBdvToSeason(token, grownStalkPerBdv);
     }
+
+    function seasonToGrownStalkPerBdv(IERC20 token, uint32 season)
+        public
+        view
+        returns (int128 grownStalkPerBdv)
+    {
+        grownStalkPerBdv = LibLegacyTokenSilo.seasonToGrownStalkPerBdv(token, season);
+    }
 }

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -328,15 +328,6 @@ contract SiloFacet is TokenSilo {
 
     //////////////////////// UPDATE SILO ////////////////////////
 
-    /** 
-     * @notice DEPRECATED: Renamed to `mow()`.
-     * @dev See {SiloFacet-mow}.
-     */
-    //TODOSEEDS is this update function still used by somebody?
-    // function update(address account) external payable {
-    //     _mow(account);
-    // }
-
     /**
      * @notice Claim Grown Stalk for `account`.
      * @dev See {Silo-_mow}.
@@ -344,6 +335,10 @@ contract SiloFacet is TokenSilo {
     function mow(address account, address token) external payable {
         _mow(account, token);
     }
+
+    // function mowMultiple(address account, address token) external payable {
+        // _mow(account, token);
+    // }
 
     /** 
      * @notice Claim Earned Beans and their associated Stalk for 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -481,6 +481,7 @@ contract SiloFacet is TokenSilo {
     //////////////////////// GETTERS ////////////////////////
 
     function cumulativeGrownStalkPerBdv(IERC20 token)
+        public
         view
         returns (int128 _cumulativeGrownStalkPerBdv)
     {
@@ -490,6 +491,7 @@ contract SiloFacet is TokenSilo {
     }
 
     function grownStalkPerBdvToSeason(IERC20 token, int128 grownStalkPerBdv)
+        public
         view
         returns (uint32 season)
     {

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -398,7 +398,7 @@ contract SiloFacet is TokenSilo {
             amount
         );
         console.log('enrootDeposit ogBDV: ', ogBDV);
-        emit RemoveDeposit(msg.sender, token, grownStalkPerBdv, amount); // Remove Deposit does not emit an event, while Add Deposit does.
+        emit RemoveDeposit(msg.sender, token, grownStalkPerBdv, amount, ogBDV); // Remove Deposit does not emit an event, while Add Deposit does.
 
         // Calculate the current BDV for `amount` of `token` and add a Deposit.
         uint256 newBDV = LibTokenSilo.beanDenominatedValue(token, amount);

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -477,4 +477,23 @@ contract SiloFacet is TokenSilo {
             newStalk.sub(ar.stalkRemoved)
         );
     }
+
+    //////////////////////// GETTERS ////////////////////////
+
+    function cumulativeGrownStalkPerBdv(IERC20 token)
+        view
+        returns (int128 _cumulativeGrownStalkPerBdv)
+    {
+        cumulativeGrownStalkPerBdv = LibTokenSilo.cumulativeGrownStalkPerBdv(
+            token
+        );
+    }
+
+    function grownStalkPerBdvToSeason(IERC20 token, int128 grownStalkPerBdv)
+        view
+        returns (uint32 season)
+    {
+        require(LibLegacyTokenSilo.isDepositSeason(token, grownStalkPerBdv, "No matching season for input grownStalkPerBdv"));
+        season = LibLegacyTokenSilo.grownStalkPerBdvToSeason(token, grownStalkPerBdv);
+    }
 }

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -336,9 +336,17 @@ contract SiloFacet is TokenSilo {
         _mow(account, token);
     }
 
-    // function mowMultiple(address account, address token) external payable {
-        // _mow(account, token);
-    // }
+    //function to mow multiple tokens given an address
+    function mowMultiple(address account, address[] calldata tokens) external payable {
+        for (uint256 i; i < tokens.length; ++i) {
+            _mow(account, tokens[i]);
+        }
+    }
+
+    //function to mow and migrate
+    function mowAndMigrate(address[] calldata tokens, uint32[][] calldata seasons) external payable {
+        _mowAndMigrate(msg.sender, tokens, seasons);
+    }
 
     /** 
      * @notice Claim Earned Beans and their associated Stalk for 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -397,10 +397,12 @@ contract SiloFacet is TokenSilo {
             grownStalkPerBdv,
             amount
         );
+        console.log('enrootDeposit ogBDV: ', ogBDV);
         emit RemoveDeposit(msg.sender, token, grownStalkPerBdv, amount); // Remove Deposit does not emit an event, while Add Deposit does.
 
         // Calculate the current BDV for `amount` of `token` and add a Deposit.
         uint256 newBDV = LibTokenSilo.beanDenominatedValue(token, amount);
+        console.log('newBDV: ', newBDV);
         LibTokenSilo.addDepositToAccount(msg.sender, token, grownStalkPerBdv, amount, newBDV); // emits AddDeposit event
 
         // Calculate the difference in BDV. Reverts if `ogBDV > newBDV`.
@@ -409,9 +411,10 @@ contract SiloFacet is TokenSilo {
         // Mint Stalk associated with the new BDV.
         uint256 deltaStalk = deltaBDV.mul(s.ss[token].stalkPerBdv).add(
             LibSilo.stalkReward(grownStalkPerBdv,
-                                s.ss[address(token)].lastCumulativeGrownStalkPerBdv,
-                                uint128(newBDV))
+                                LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)),
+                                uint128(deltaBDV))
         );
+        console.log('deltaStalk: ', deltaStalk);
         LibSilo.mintStalk(msg.sender, deltaStalk);
     }
 
@@ -442,7 +445,7 @@ contract SiloFacet is TokenSilo {
         uint256 newStalk;
 
         //pulled these vars out because of "CompilerError: Stack too deep, try removing local variables."
-        int128 _lastCumulativeGrownStalkPerBdv = s.ss[address(token)].lastCumulativeGrownStalkPerBdv;
+        int128 _lastCumulativeGrownStalkPerBdv = LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)); //need for present season
         uint32 _stalkPerBdv = s.ss[token].stalkPerBdv;
 
         // Iterate through all grownStalkPerBdvs, redeposit the tokens with new BDV and

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -202,6 +202,7 @@ contract TokenSilo is Silo {
         address token,
         uint256 amount
     ) internal {
+        console.log('_deposit: ', amount);
         (uint256 stalk) = LibTokenSilo.deposit(
             account,
             token,

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -62,12 +62,14 @@ contract TokenSilo is Silo {
      * @param token Address of the whitelisted ERC20 token that was removed.
      * @param grownStalkPerBdv The grownStalkPerBdv that this `amount` was removed from.
      * @param amount Amount of `token` removed from `grownStalkPerBdv`.
+     * //add bdv here?
      */
     event RemoveDeposit(
         address indexed account,
         address indexed token,
         int128 grownStalkPerBdv,
         uint256 amount
+        
     );
 
     /**
@@ -88,8 +90,8 @@ contract TokenSilo is Silo {
         address indexed token,
         int128[] grownStalkPerBdvs,
         uint256[] amounts,
-        uint256 amount
-    );
+        uint256 amount 
+    ); //add bdv[] here? in favor of array
 
     // note add/remove withdrawal(s) are removed as claiming is removed
     // FIXME: to discuss with subgraph team to update
@@ -364,6 +366,7 @@ contract TokenSilo is Silo {
         uint256[] calldata amounts
     ) internal returns (AssetsRemoved memory ar) {
         console.log('removeDepositsFromAccount: ', account);
+        //make bdv array and add here?
         for (uint256 i; i < grownStalkPerBdvs.length; ++i) {
             uint256 crateBdv = LibTokenSilo.removeDepositFromAccount(
                 account,
@@ -389,6 +392,7 @@ contract TokenSilo is Silo {
         );
         console.log('2 ar.stalkRemoved: ', ar.stalkRemoved);
 
+        //need to add BDV array here
         emit RemoveDeposits(account, token, grownStalkPerBdvs, amounts, ar.tokensRemoved);
     }
 
@@ -455,11 +459,11 @@ contract TokenSilo is Silo {
             );
             ar.bdvRemoved = ar.bdvRemoved.add(crateBdv);
             ar.tokensRemoved = ar.tokensRemoved.add(amounts[i]);
-            ar.stalkRemoved = crateBdv.mul(s.ss[token].stalkPerBdv).add(
+            ar.stalkRemoved = ar.stalkRemoved.add(
                 LibSilo.stalkReward(
                     grownStalkPerBdvs[i],
-                    s.ss[address(token)].lastCumulativeGrownStalkPerBdv,
-                    uint128(crateBdv)
+                    LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)),
+                    crateBdv.toUint128()
                 )
             );
             bdvs[i] = crateBdv;

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -48,7 +48,7 @@ contract TokenSilo is Silo {
     event AddDeposit(
         address indexed account,
         address indexed token,
-        int32 grownStalkPerBdv,
+        int128 grownStalkPerBdv,
         uint256 amount,
         uint256 bdv
     );
@@ -129,7 +129,7 @@ contract TokenSilo is Silo {
     function getDeposit(
         address account,
         address token,
-        uint32 grownStalkPerBdv
+        int128 grownStalkPerBdv
     ) external view returns (uint256, uint256) {
         return LibTokenSilo.tokenDeposit(account, token, grownStalkPerBdv);
     }
@@ -206,6 +206,7 @@ contract TokenSilo is Silo {
             LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)),
             amount
         );
+        console.log('_deposit now mint stalk: ', stalk);
         LibSilo.mintStalk(account, stalk);
     }
 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -344,6 +344,7 @@ contract TokenSilo is Silo {
         int128[] calldata grownStalkPerBdvs,
         uint256[] calldata amounts
     ) internal returns (AssetsRemoved memory ar) {
+        console.log('removeDepositsFromAccount: ', account);
         for (uint256 i; i < grownStalkPerBdvs.length; ++i) {
             uint256 crateBdv = LibTokenSilo.removeDepositFromAccount(
                 account,
@@ -353,18 +354,21 @@ contract TokenSilo is Silo {
             );
             ar.bdvRemoved = ar.bdvRemoved.add(crateBdv);
             ar.tokensRemoved = ar.tokensRemoved.add(amounts[i]);
-            ar.stalkRemoved = crateBdv.mul(s.ss[token].stalkPerBdv).add(
+            console.log('s.ss[token].stalkPerBdv: ', s.ss[token].stalkPerBdv);
+            ar.stalkRemoved = ar.stalkRemoved.add(
                 LibSilo.stalkReward(
                     grownStalkPerBdvs[i],
                     LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)),
                     crateBdv.toUint128()
                 )
             );
+            console.log('ar.stalkRemoved from: ', i, ar.stalkRemoved);
         }
-
+        console.log('1 ar.stalkRemoved: ', ar.stalkRemoved);
         ar.stalkRemoved = ar.stalkRemoved.add(
             ar.bdvRemoved.mul(s.ss[token].stalkPerBdv)
         );
+        console.log('2 ar.stalkRemoved: ', ar.stalkRemoved);
 
         emit RemoveDeposits(account, token, grownStalkPerBdvs, amounts, ar.tokensRemoved);
     }

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -319,12 +319,23 @@ contract TokenSilo is Silo {
         )
     {
         bdvRemoved = LibTokenSilo.removeDepositFromAccount(account, token, grownStalkPerBdv, amount);
+        console.log('s.ss[token].stalk: ', s.ss[token].stalkPerBdv);
+        console.log('bdvRemoved.mul(s.ss[token].stalk: ', bdvRemoved.mul(s.ss[token].stalkPerBdv));
         console.log('removeDepositFromAccount grownStalkPerBdv: ');
         console.logInt(grownStalkPerBdv);
 
         console.log('removeDepositFromAccount cumulativeGrownStalkPerBdv: ');
         console.logInt(LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)));
         console.log('removeDepositFromAccount bdvRemoved: ', bdvRemoved);
+
+        uint256 stalkReward = LibSilo.stalkReward(
+                grownStalkPerBdv, //this is the index of when it was deposited
+                LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)), //this is latest for this token
+                bdvRemoved.toUint128()
+            );
+        console.log('removeDepositFromAccount stalkReward: ', stalkReward);
+
+
         //need to get amount of stalk earned by this deposit (index of now minus index of when deposited)
         stalkRemoved = bdvRemoved.mul(s.ss[token].stalkPerBdv).add(
             LibSilo.stalkReward(

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -321,8 +321,8 @@ contract TokenSilo is Silo {
         //need to get amount of stalk earned by this deposit (index of now minus index of when deposited)
         stalkRemoved = bdvRemoved.mul(s.ss[token].stalkPerBdv).add(
             LibSilo.stalkReward(
-                grownStalkPerBdv,
-                s.ss[address(token)].lastCumulativeGrownStalkPerBdv,
+                grownStalkPerBdv, //this is the index of when it was deposited
+                LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)), //this is latest for this token
                 bdvRemoved.toUint128()
             )
         );
@@ -356,8 +356,8 @@ contract TokenSilo is Silo {
             ar.stalkRemoved = crateBdv.mul(s.ss[token].stalkPerBdv).add(
                 LibSilo.stalkReward(
                     grownStalkPerBdvs[i],
-                    s.ss[address(token)].lastCumulativeGrownStalkPerBdv,
-                    uint128(crateBdv)
+                    LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)),
+                    crateBdv.toUint128()
                 )
             );
         }

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -221,7 +221,7 @@ contract TokenSilo is Silo {
         uint256 amount
     ) internal {
         // Remove the Deposit from `account`.
-        (uint256 stalkRemoved, uint256 bdvRemoved) = removeDepositFromAccount(
+        (uint256 stalkRemoved, ) = removeDepositFromAccount(
             account,
             token,
             grownStalkPerBdv,

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -86,7 +86,7 @@ contract TokenSilo is Silo {
     event RemoveDeposits(
         address indexed account,
         address indexed token,
-        uint128[] grownStalkPerBdvs,
+        int128[] grownStalkPerBdvs,
         uint256[] amounts,
         uint256 amount
     );
@@ -217,7 +217,7 @@ contract TokenSilo is Silo {
     function _withdrawDeposit(
         address account,
         address token,
-        int32 grownStalkPerBdv,
+        int128 grownStalkPerBdv,
         uint256 amount
     ) internal {
         // Remove the Deposit from `account`.
@@ -247,7 +247,7 @@ contract TokenSilo is Silo {
     function _withdrawDeposits(
         address account,
         address token,
-        uint32[] calldata grownStalkPerBdvs,
+        int128[] calldata grownStalkPerBdvs,
         uint256[] calldata amounts
     ) internal returns (uint256) {
         require(
@@ -340,7 +340,7 @@ contract TokenSilo is Silo {
     function removeDepositsFromAccount(
         address account,
         address token,
-        uint32[] calldata grownStalkPerBdvs,
+        int128[] calldata grownStalkPerBdvs,
         uint256[] calldata amounts
     ) internal returns (AssetsRemoved memory ar) {
         for (uint256 i; i < grownStalkPerBdvs.length; ++i) {
@@ -352,17 +352,17 @@ contract TokenSilo is Silo {
             );
             ar.bdvRemoved = ar.bdvRemoved.add(crateBdv);
             ar.tokensRemoved = ar.tokensRemoved.add(amounts[i]);
-            ar.stalkRemoved = crateBdv.mul(s.ss[token].stalk).add(
+            ar.stalkRemoved = crateBdv.mul(s.ss[token].stalkPerBdv).add(
                 LibSilo.stalkReward(
                     grownStalkPerBdvs[i],
                     s.ss[address(token)].lastCumulativeGrownStalkPerBdv,
-                    crateBdv
+                    uint128(crateBdv)
                 )
             );
         }
 
         ar.stalkRemoved = ar.stalkRemoved.add(
-            ar.bdvRemoved.mul(s.ss[token].stalk)
+            ar.bdvRemoved.mul(s.ss[token].stalkPerBdv)
         );
 
         emit RemoveDeposits(account, token, grownStalkPerBdvs, amounts, ar.tokensRemoved);
@@ -379,7 +379,7 @@ contract TokenSilo is Silo {
         address sender,
         address recipient,
         address token,
-        uint32 grownStalkPerBdvs,
+        int128 grownStalkPerBdvs,
         uint256 amount
     ) internal returns (uint256) {
         (uint256 stalk, uint256 bdv) = removeDepositFromAccount(
@@ -402,7 +402,7 @@ contract TokenSilo is Silo {
         address sender,
         address recipient,
         address token,
-        uint32[] calldata grownStalkPerBdvs,
+        int128[] calldata grownStalkPerBdvs,
         uint256[] calldata amounts
     ) internal returns (uint256[] memory) {
         require(
@@ -431,18 +431,18 @@ contract TokenSilo is Silo {
             );
             ar.bdvRemoved = ar.bdvRemoved.add(crateBdv);
             ar.tokensRemoved = ar.tokensRemoved.add(amounts[i]);
-            ar.stalkRemoved = crateBdv.mul(s.ss[token].stalk).add(
+            ar.stalkRemoved = crateBdv.mul(s.ss[token].stalkPerBdv).add(
                 LibSilo.stalkReward(
                     grownStalkPerBdvs[i],
                     s.ss[address(token)].lastCumulativeGrownStalkPerBdv,
-                    crateBdv
+                    uint128(crateBdv)
                 )
             );
             bdvs[i] = crateBdv;
         }
 
         ar.stalkRemoved = ar.stalkRemoved.add(
-            ar.bdvRemoved.mul(s.ss[token].stalk)
+            ar.bdvRemoved.mul(s.ss[token].stalkPerBdv)
         );
 
         emit RemoveDeposits(sender, token, grownStalkPerBdvs, amounts, ar.tokensRemoved);

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -68,8 +68,8 @@ contract TokenSilo is Silo {
         address indexed account,
         address indexed token,
         int128 grownStalkPerBdv,
-        uint256 amount
-        
+        uint256 amount,
+        uint256 bdv
     );
 
     /**
@@ -90,7 +90,8 @@ contract TokenSilo is Silo {
         address indexed token,
         int128[] grownStalkPerBdvs,
         uint256[] amounts,
-        uint256 amount 
+        uint256 amount,
+        uint256[] bdvs
     ); //add bdv[] here? in favor of array
 
     // note add/remove withdrawal(s) are removed as claiming is removed
@@ -349,7 +350,7 @@ contract TokenSilo is Silo {
         );
         console.log('removeDepositFromAccount stalkRemoved: ', stalkRemoved);
 
-        emit RemoveDeposit(account, token, grownStalkPerBdv, amount);
+        emit RemoveDeposit(account, token, grownStalkPerBdv, amount, bdvRemoved);
     }
 
     /**
@@ -368,6 +369,7 @@ contract TokenSilo is Silo {
     ) internal returns (AssetsRemoved memory ar) {
         console.log('removeDepositsFromAccount: ', account);
         //make bdv array and add here?
+        uint256[] memory bdvsRemoved = new uint256[](grownStalkPerBdvs.length);
         for (uint256 i; i < grownStalkPerBdvs.length; ++i) {
             uint256 crateBdv = LibTokenSilo.removeDepositFromAccount(
                 account,
@@ -375,6 +377,7 @@ contract TokenSilo is Silo {
                 grownStalkPerBdvs[i],
                 amounts[i]
             );
+            bdvsRemoved[i] = crateBdv;
             ar.bdvRemoved = ar.bdvRemoved.add(crateBdv);
             ar.tokensRemoved = ar.tokensRemoved.add(amounts[i]);
             console.log('s.ss[token].stalkPerBdv: ', s.ss[token].stalkPerBdv);
@@ -394,7 +397,7 @@ contract TokenSilo is Silo {
         console.log('2 ar.stalkRemoved: ', ar.stalkRemoved);
 
         //need to add BDV array here
-        emit RemoveDeposits(account, token, grownStalkPerBdvs, amounts, ar.tokensRemoved);
+        emit RemoveDeposits(account, token, grownStalkPerBdvs, amounts, ar.tokensRemoved, bdvsRemoved);
     }
 
     //////////////////////// TRANSFER ////////////////////////
@@ -474,7 +477,7 @@ contract TokenSilo is Silo {
             ar.bdvRemoved.mul(s.ss[token].stalkPerBdv)
         );
 
-        emit RemoveDeposits(sender, token, grownStalkPerBdvs, amounts, ar.tokensRemoved);
+        emit RemoveDeposits(sender, token, grownStalkPerBdvs, amounts, ar.tokensRemoved, bdvs);
 
         // Transfer all the Stalk
         LibSilo.transferStalk(

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -228,7 +228,7 @@ contract TokenSilo is Silo {
             grownStalkPerBdv,
             amount
         );
-
+        console.log('_withdrawDeposit stalkRemoved: ', stalkRemoved);
         // Add a Withdrawal, update totals, burn Stalk.
         _withdraw(
             account,
@@ -291,6 +291,8 @@ contract TokenSilo is Silo {
         uint256 stalk
     ) private {
         LibTokenSilo.decrementTotalDeposited(token, amount); // Decrement total Deposited
+        console.log('_withdraw amount: ', amount);
+        console.log('_withdraw stalk: ', stalk);
         LibSilo.burnStalk(account, stalk); // Burn Stalk
     }
 
@@ -317,7 +319,12 @@ contract TokenSilo is Silo {
         )
     {
         bdvRemoved = LibTokenSilo.removeDepositFromAccount(account, token, grownStalkPerBdv, amount);
+        console.log('removeDepositFromAccount grownStalkPerBdv: ');
+        console.logInt(grownStalkPerBdv);
 
+        console.log('removeDepositFromAccount cumulativeGrownStalkPerBdv: ');
+        console.logInt(LibTokenSilo.cumulativeGrownStalkPerBdv(IERC20(token)));
+        console.log('removeDepositFromAccount bdvRemoved: ', bdvRemoved);
         //need to get amount of stalk earned by this deposit (index of now minus index of when deposited)
         stalkRemoved = bdvRemoved.mul(s.ss[token].stalkPerBdv).add(
             LibSilo.stalkReward(
@@ -326,6 +333,7 @@ contract TokenSilo is Silo {
                 bdvRemoved.toUint128()
             )
         );
+        console.log('removeDepositFromAccount stalkRemoved: ', stalkRemoved);
 
         emit RemoveDeposit(account, token, grownStalkPerBdv, amount);
     }

--- a/protocol/contracts/beanstalk/silo/WhitelistFacet.sol
+++ b/protocol/contracts/beanstalk/silo/WhitelistFacet.sol
@@ -17,7 +17,7 @@ contract WhitelistFacet {
     event WhitelistToken(
         address indexed token,
         bytes4 selector,
-        uint256 seeds,
+        uint256 stalkPerBdvPerSeason,
         uint256 stalk
     );
 
@@ -32,14 +32,14 @@ contract WhitelistFacet {
         address token,
         bytes4 selector,
         uint32 stalk,
-        uint32 seeds
+        uint32 stalkPerBdvPerSeason
     ) external payable {
         LibDiamond.enforceIsOwnerOrContract();
         LibWhitelist.whitelistToken(
             token,
             selector,
             stalk,
-            seeds
+            stalkPerBdvPerSeason
         );
     }
 }

--- a/protocol/contracts/beanstalk/silo/WhitelistFacet.sol
+++ b/protocol/contracts/beanstalk/silo/WhitelistFacet.sol
@@ -17,7 +17,7 @@ contract WhitelistFacet {
     event WhitelistToken(
         address indexed token,
         bytes4 selector,
-        uint256 stalkPerBdvPerSeason,
+        uint32 stalkPerBdvPerSeason,
         uint256 stalk
     );
 

--- a/protocol/contracts/beanstalk/silo/WhitelistFacet.sol
+++ b/protocol/contracts/beanstalk/silo/WhitelistFacet.sol
@@ -20,6 +20,12 @@ contract WhitelistFacet {
         uint32 stalkPerBdvPerSeason,
         uint256 stalk
     );
+    
+    event UpdatedStalkPerBdvPerSeason(
+        address indexed token,
+        uint32 stalkPerBdvPerSeason,
+        uint32 season
+    );
 
     event DewhitelistToken(address indexed token);
 
@@ -39,6 +45,17 @@ contract WhitelistFacet {
             token,
             selector,
             stalk,
+            stalkPerBdvPerSeason
+        );
+    }
+
+    function updateStalkPerBdvPerSeasonForToken(
+        address token,
+        uint32 stalkPerBdvPerSeason
+    ) external payable {
+        LibDiamond.enforceIsOwnerOrContract();
+        LibWhitelist.updateStalkPerBdvPerSeasonForToken(
+            token,
             stalkPerBdvPerSeason
         );
     }

--- a/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
@@ -11,6 +11,7 @@ import "~/libraries/LibSafeMath128.sol";
 import "~/C.sol";
 import "~/libraries/LibFertilizer.sol";
 import "./Oracle.sol";
+import "hardhat/console.sol";
 
 /**
  * @author Publius
@@ -118,8 +119,9 @@ contract Sun is Oracle {
         // Stalk is created here, rather than in {rewardBeans}, because only
         // Beans that are allocated to the Silo will receive Stalk. 
         uint256 seasonStalk = amount.mul(C.getStalkPerBean());
+        console.log('rewardToSilo previous total stalk s.s.stalk: ', s.s.stalk);
         s.s.stalk = s.s.stalk.add(seasonStalk);
-
+        console.log('rewardToSilo current total stalk s.s.stalk: ', s.s.stalk);
         // `s.newEarnedStalk` is an accounting mechanism that tracks the  number
         // of Earned stalk that is allocated during the season. 
         // This is used in _balanceOfEarnedBeans() to linearly distrubute 

--- a/protocol/contracts/beanstalk/sun/SeasonFacet/Weather.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/Weather.sol
@@ -162,7 +162,7 @@ contract Weather is Sun {
         int256 newBeans = LibBeanMetaCurve.getDeltaB();
         if (newBeans <= 0) return;
         uint256 sopBeans = uint256(newBeans);
-
+        console.log('sop() sopBeans: ', sopBeans);
         uint256 newHarvestable;
         if (s.f.harvestable < s.r.pods) {
             newHarvestable = s.r.pods - s.f.harvestable;
@@ -170,15 +170,19 @@ contract Weather is Sun {
             C.bean().mint(address(this), newHarvestable.add(sopBeans));
         } else C.bean().mint(address(this), sopBeans);
         uint256 amountOut = C.curveMetapool().exchange(0, 1, sopBeans, 0);
+        console.log('amountOut: ', amountOut);
         rewardSop(amountOut);
         emit SeasonOfPlenty(s.season.current, amountOut, newHarvestable);
     }
 
     function rewardSop(uint256 amount) private {
+        console.log('rewardSop: ', amount);
         s.sops[s.season.rainStart] = s.sops[s.season.lastSop].add(
             amount.mul(C.getSopPrecision()).div(s.r.roots)
         );
         s.season.lastSop = s.season.rainStart;
+        console.log('rewardSop s.season.lastSop: ', s.season.lastSop);
         s.season.lastSopSeason = s.season.current;
+        console.log('rewardSop s.season.lastSopSeason: ', s.season.lastSopSeason);
     }
 }

--- a/protocol/contracts/ecosystem/root/Root.sol
+++ b/protocol/contracts/ecosystem/root/Root.sol
@@ -449,7 +449,6 @@ contract Root is UUPSUpgradeable, ERC20PermitUpgradeable, OwnableUpgradeable {
     /// @return shares number of shares will be mint/burn
     /// @return bdv total bdv of depositTransfers
     /// @return stalk total stalk of depositTransfers
-    /// @return stalkPerBdvPerSeasons total stalkPerBdvPerSeasons of depositTransfers
     function _transferDeposits(
         DepositTransfer[] calldata depositTransfers,
         bool isDeposit
@@ -458,7 +457,7 @@ contract Root is UUPSUpgradeable, ERC20PermitUpgradeable, OwnableUpgradeable {
         returns (
             uint256 shares,
             uint256 bdv,
-            uint256 stalk,
+            uint256 stalk
         )
     {
         IBeanstalk(BEANSTALK_ADDRESS).update(address(this));
@@ -509,7 +508,7 @@ contract Root is UUPSUpgradeable, ERC20PermitUpgradeable, OwnableUpgradeable {
                             PRECISION,
                             balanceOfStalkBefore,
                             MathUpgradeable.Rounding.Down
-                        ),
+                        )
                     ),
                     PRECISION,
                     MathUpgradeable.Rounding.Down
@@ -529,7 +528,7 @@ contract Root is UUPSUpgradeable, ERC20PermitUpgradeable, OwnableUpgradeable {
                             PRECISION,
                             balanceOfStalkBefore,
                             MathUpgradeable.Rounding.Up
-                        ),
+                        )
                     ),
                     PRECISION,
                     MathUpgradeable.Rounding.Up

--- a/protocol/contracts/ecosystem/root/Root.sol
+++ b/protocol/contracts/ecosystem/root/Root.sol
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: MIT
  **/
-
+/*
 pragma solidity ^0.8.17;
 pragma experimental ABIEncoderV2;
 
@@ -551,3 +551,4 @@ contract Root is UUPSUpgradeable, ERC20PermitUpgradeable, OwnableUpgradeable {
         );
     }
 }
+*/

--- a/protocol/contracts/ecosystem/root/Root.sol
+++ b/protocol/contracts/ecosystem/root/Root.sol
@@ -184,7 +184,7 @@ contract Root is UUPSUpgradeable, ERC20PermitUpgradeable, OwnableUpgradeable {
 
     /// @notice Update Bdv of multiple silo deposits and underlyingBdv
     /// @dev Will revert if the bdv of the deposits doesn't increase
-    function updateBdvs(address[] calldata tokens, uint32[] calldata grownStalkPerBdvs)
+    function updateBdvs(address[] calldata tokens, uint128[] calldata grownStalkPerBdvs)
         external
     {
         for (uint256 i; i < tokens.length; ++i) {

--- a/protocol/contracts/libraries/Convert/LibConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibConvert.sol
@@ -50,6 +50,44 @@ library LibConvert {
         }
     }
 
+    /*function getConvertData(bytes calldata convertData)
+        internal 
+        returns (
+            LibConvertData.ConvertKind kind,
+            address tokenOut,
+            address tokenIn,
+            uint256 outAmount,
+            uint256 inAmount
+        )
+    {
+        kind = convertData.convertKind();
+
+
+
+
+    }*/
+
+    /*function getFromTokenAddress(bytes calldata convertData)
+        internal
+        pure
+        returns (address fromToken) {
+        LibConvertData.ConvertKind kind = convertData.convertKind();
+        
+        if (kind == LibConvertData.ConvertKind.BEANS_TO_CURVE_LP) {
+            return C.beanAddress();
+        } else if (kind == LibConvertData.ConvertKind.CURVE_LP_TO_BEANS) {
+            return C.curveMetapoolAddress();
+        } else if (kind == LibConvertData.ConvertKind.UNRIPE_BEANS_TO_UNRIPE_LP) {
+            return C.unripeBeanAddress();
+        } else if (kind == LibConvertData.ConvertKind.UNRIPE_LP_TO_UNRIPE_BEANS) {
+            return C.unripeLPAddress();
+        } else if (kind == LibConvertData.ConvertKind.LAMBDA_LAMBDA) {
+            //how can I get the incoming token type?
+        } else {
+            revert("getFromTokenAddress: Token not supported");
+        }
+    }*/
+
     function getMaxAmountIn(address tokenIn, address tokenOut)
         internal
         view

--- a/protocol/contracts/libraries/Convert/LibCurveConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibCurveConvert.sol
@@ -11,6 +11,7 @@ import "./LibConvertData.sol";
 import "./LibMetaCurveConvert.sol";
 import "./LibBeanLUSDConvert.sol";
 import "../Curve/LibBeanMetaCurve.sol";
+import "~/libraries/LibInternal.sol";
 
 /**
  * @author Publius
@@ -69,6 +70,7 @@ library LibCurveConvert {
             uint256 inAmount
         )
     {
+        LibInternal.mow(msg.sender, C.curveMetapoolAddress());
         (uint256 lp, uint256 minBeans, address pool) = convertData
             .convertWithAddress();
         (outAmount, inAmount) = _curveRemoveLPAndBuyToPeg(lp, minBeans, pool);
@@ -87,6 +89,7 @@ library LibCurveConvert {
             uint256 inAmount
         )
     {
+        LibInternal.mow(msg.sender, C.beanAddress());
         (uint256 beans, uint256 minLP, address pool) = convertData
             .convertWithAddress();
         (outAmount, inAmount) = _curveSellToPegAndAddLiquidity(

--- a/protocol/contracts/libraries/Convert/LibLambdaConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibLambdaConvert.sol
@@ -6,6 +6,7 @@ pragma solidity =0.7.6;
 pragma experimental ABIEncoderV2;
 
 import "./LibConvertData.sol";
+import "~/libraries/LibInternal.sol";
 
 /**
  * @title Lib Lambda Convert
@@ -25,6 +26,7 @@ library LibLambdaConvert {
         )
     {
         (inAmount, tokenIn) = convertData.lambdaConvert();
+        LibInternal.mow(msg.sender, tokenIn);
         tokenOut = tokenIn;
         outAmount = inAmount;
     }

--- a/protocol/contracts/libraries/Convert/LibLambdaConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibLambdaConvert.sol
@@ -17,7 +17,6 @@ library LibLambdaConvert {
 
     function convert(bytes memory convertData)
         internal
-        pure
         returns (
             address tokenOut,
             address tokenIn,
@@ -26,7 +25,7 @@ library LibLambdaConvert {
         )
     {
         (inAmount, tokenIn) = convertData.lambdaConvert();
-        LibInternal.mow(msg.sender, tokenIn);
+        LibInternal.mow(msg.sender, tokenIn); //this convert function used to be pure, had to remove pure in order to mow
         tokenOut = tokenIn;
         outAmount = inAmount;
     }

--- a/protocol/contracts/libraries/Convert/LibUnripeConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibUnripeConvert.sol
@@ -9,6 +9,7 @@ import "./LibCurveConvert.sol";
 import "../../C.sol";
 import "../../interfaces/IBean.sol";
 import "../LibUnripe.sol";
+import "~/libraries/LibInternal.sol";
 
 /**
  * @author Publius
@@ -29,6 +30,7 @@ library LibUnripeConvert {
     {
         tokenOut = C.unripeBeanAddress();
         tokenIn = C.unripeLPAddress();
+        LibInternal.mow(msg.sender, tokenIn);
         (uint256 lp, uint256 minBeans) = convertData.basicConvert();
 
         uint256 minAmountOut = LibUnripe
@@ -68,6 +70,7 @@ library LibUnripeConvert {
     {
         tokenIn = C.unripeBeanAddress();
         tokenOut = C.unripeLPAddress();
+        LibInternal.mow(msg.sender, tokenIn);
         (uint256 beans, uint256 minLP) = convertData.basicConvert();
 
         uint256 minAmountOut = LibUnripe

--- a/protocol/contracts/libraries/LibBytes.sol
+++ b/protocol/contracts/libraries/LibBytes.sol
@@ -31,6 +31,22 @@ library LibBytes {
     * @notice From Solidity Bytes Arrays Utils
     * @author Gonçalo Sá <goncalo.sa@consensys.net>
     */
+    function toUint32(bytes memory _bytes, uint256 _start) internal pure returns (uint32) {
+        require(_start + 4 >= _start, "toUint32_overflow");
+        require(_bytes.length >= _start + 4, "toUint32_outOfBounds");
+        uint32 tempUint;
+
+        assembly {
+            tempUint := mload(add(add(_bytes, 0x4), _start))
+        }
+
+        return tempUint;
+    }
+
+    /*
+    * @notice From Solidity Bytes Arrays Utils
+    * @author Gonçalo Sá <goncalo.sa@consensys.net>
+    */
     function toUint256(bytes memory _bytes, uint256 _start) internal pure returns (uint256) {
         require(_start + 32 >= _start, "toUint256_overflow");
         require(_bytes.length >= _start + 32, "toUint256_outOfBounds");

--- a/protocol/contracts/libraries/LibInternal.sol
+++ b/protocol/contracts/libraries/LibInternal.sol
@@ -8,7 +8,7 @@ pragma experimental ABIEncoderV2;
 import {LibDiamond} from "./LibDiamond.sol";
 
 interface IBS {
-    function mow(address account) external payable;
+    function mow(address account, address token) external payable;
 }
 
 /**
@@ -16,7 +16,7 @@ interface IBS {
  * @title Internal Library handles gas efficient function calls between facets.
  */
 library LibInternal {
-    function mow(address account) internal {
+    function mow(address account, address token) internal {
         LibDiamond.DiamondStorage storage ds;
         bytes32 position = LibDiamond.DIAMOND_STORAGE_POSITION;
         assembly {
@@ -27,7 +27,8 @@ library LibInternal {
             .facetAddress;
         bytes memory callData = abi.encodeWithSelector(
             IBS.mow.selector,
-            account
+            account,
+            token
         );
         (bool success, ) = address(facet).delegatecall(callData);
         require(success, "Silo: update failed.");

--- a/protocol/contracts/libraries/LibSafeMathSigned128.sol
+++ b/protocol/contracts/libraries/LibSafeMathSigned128.sol
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+/**
+ * @author Publius
+ * @title LibSafeMath128 is a int128 variation of Open Zeppelin's Safe Math library.
+**/
+library LibSafeMathSigned128 {
+    /**
+     * @dev Returns the addition of two unsigned integers, with an overflow flag.
+     *
+     * _Available since v3.4._
+     */
+    function tryAdd(int128 a, int128 b) internal pure returns (bool, int128) {
+        int128 c = a + b;
+        if (c < a) return (false, 0);
+        return (true, c);
+    }
+
+    /**
+     * @dev Returns the substraction of two unsigned integers, with an overflow flag.
+     *
+     * _Available since v3.4._
+     */
+    function trySub(int128 a, int128 b) internal pure returns (bool, int128) {
+        if (b > a) return (false, 0);
+        return (true, a - b);
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, with an overflow flag.
+     *
+     * _Available since v3.4._
+     */
+    function tryMul(int128 a, int128 b) internal pure returns (bool, int128) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) return (true, 0);
+        int128 c = a * b;
+        if (c / a != b) return (false, 0);
+        return (true, c);
+    }
+
+    /**
+     * @dev Returns the division of two unsigned integers, with a division by zero flag.
+     *
+     * _Available since v3.4._
+     */
+    function tryDiv(int128 a, int128 b) internal pure returns (bool, int128) {
+        if (b == 0) return (false, 0);
+        return (true, a / b);
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers, with a division by zero flag.
+     *
+     * _Available since v3.4._
+     */
+    function tryMod(int128 a, int128 b) internal pure returns (bool, int128) {
+        if (b == 0) return (false, 0);
+        return (true, a % b);
+    }
+
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(int128 a, int128 b) internal pure returns (int128) {
+        int128 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(int128 a, int128 b) internal pure returns (int128) {
+        require(b <= a, "SafeMath: subtraction overflow");
+        return a - b;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(int128 a, int128 b) internal pure returns (int128) {
+        if (a == 0) return 0;
+        int128 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers, reverting on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(int128 a, int128 b) internal pure returns (int128) {
+        require(b > 0, "SafeMath: division by zero");
+        return a / b;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * reverting when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(int128 a, int128 b) internal pure returns (int128) {
+        require(b > 0, "SafeMath: modulo by zero");
+        return a % b;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * CAUTION: This function is deprecated because it requires allocating memory for the error
+     * message unnecessarily. For custom revert reasons use {trySub}.
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(int128 a, int128 b, string memory errorMessage) internal pure returns (int128) {
+        require(b <= a, errorMessage);
+        return a - b;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers, reverting with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * CAUTION: This function is deprecated because it requires allocating memory for the error
+     * message unnecessarily. For custom revert reasons use {tryDiv}.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(int128 a, int128 b, string memory errorMessage) internal pure returns (int128) {
+        require(b > 0, errorMessage);
+        return a / b;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * reverting with custom message when dividing by zero.
+     *
+     * CAUTION: This function is deprecated because it requires allocating memory for the error
+     * message unnecessarily. For custom revert reasons use {tryMod}.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(int128 a, int128 b, string memory errorMessage) internal pure returns (int128) {
+        require(b > 0, errorMessage);
+        return a % b;
+    }
+}

--- a/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
@@ -25,6 +25,7 @@ import "hardhat/console.sol";
  */
 library LibLegacyTokenSilo {
     using SafeMath for uint256;
+    using SafeMath for uint32;
     using SafeCast for uint256;
     using LibSafeMathSigned128 for int128;
 
@@ -169,23 +170,26 @@ library LibLegacyTokenSilo {
         returns (uint32 season)
     {
         // require(grownStalkPerBdv > 0);
-        console.log('logging grown stalk per bdv');
+        console.log('grownStalkPerBdvToSeason logging grown stalk per bdv');
         console.logInt(grownStalkPerBdv);
         AppStorage storage s = LibAppStorage.diamondStorage();
         uint256 seedsPerBdv = uint256(s.ss[address(token)].legacySeedsPerBdv);
 
         uint32 lastUpdateSeasonStored = s.ss[address(token)].lastUpdateSeason;
-        console.log('lastUpdateSeasonStored: ', lastUpdateSeasonStored);
+        console.log('grownStalkPerBdvToSeason lastUpdateSeasonStored: ', lastUpdateSeasonStored);
 
-        console.log('token: ', address(token));
+        console.log('grownStalkPerBdvToSeason token: ', address(token));
         // console.log('s.ss[address(token)]: ', s.ss[address(token)]);
-        console.log('seedsPerBdv: ', seedsPerBdv);
+        console.log('grownStalkPerBdvToSeason seedsPerBdv: ', seedsPerBdv);
         // console.log('grownStalkPerBdv: %d', grownStalkPerBdv);
         // console.log('uint256(-grownStalkPerBdv).div(seedsPerBdv): ', uint256(-grownStalkPerBdv).div(seedsPerBdv));
 
-        uint256 seasonAs256 = uint256(int128(s.ss[address(token)].lastUpdateSeason).sub(grownStalkPerBdv)).div(seedsPerBdv);
-        console.log('seasonAs256: ', seasonAs256);
+        // uint256 seasonAs256 = uint256(int128(s.ss[address(token)].lastCumulativeGrownStalkPerBdv).sub(grownStalkPerBdv)).div(seedsPerBdv);
+        // console.log('seasonAs256: ', seasonAs256);
 
-        season = seasonAs256.toUint32();
+        //need to divide by 1e6 but make sure we don't round
+        season = s.season.current.sub(uint(grownStalkPerBdv).div(seedsPerBdv)).toUint32();
+        console.log('grownStalkPerBdvToSeason season: ', season);
+        // season = seasonAs256.toUint32();
     }
 }

--- a/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
@@ -226,7 +226,7 @@ library LibLegacyTokenSilo {
         console.log('diff: ');
         console.logInt(diff);
         //using regular + here becauase we want to "overflow" (which for signed just means add negative)
-        season = uint256(int128(s.season.current)+diff).toUint32();
+        season = uint256(int128(C.siloV3StartSeason())+diff).toUint32();
         console.log('grownStalkPerBdvToSeason season: ', season);
         // season = seasonAs256.toUint32();
     }

--- a/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
@@ -12,6 +12,8 @@ import "../../C.sol";
 import "./LibUnripeSilo.sol";
 import "./LibTokenSilo.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/SafeCast.sol";
+import "~/libraries/LibSafeMathSigned128.sol";
+import "hardhat/console.sol";
 
 /**
  * @title LibLegacyTokenSilo
@@ -24,6 +26,7 @@ import {SafeCast} from "@openzeppelin/contracts/utils/SafeCast.sol";
 library LibLegacyTokenSilo {
     using SafeMath for uint256;
     using SafeCast for uint256;
+    using LibSafeMathSigned128 for int128;
 
     //////////////////////// REMOVE DEPOSIT ////////////////////////
 
@@ -165,8 +168,24 @@ library LibLegacyTokenSilo {
         view
         returns (uint32 season)
     {
+        // require(grownStalkPerBdv > 0);
+        console.log('logging grown stalk per bdv');
+        console.logInt(grownStalkPerBdv);
         AppStorage storage s = LibAppStorage.diamondStorage();
         uint256 seedsPerBdv = uint256(s.ss[address(token)].legacySeedsPerBdv);
-        season = uint256(-grownStalkPerBdv).div(seedsPerBdv).toUint32(); // use OpenZeppelin's safecast to uint32
+
+        uint32 lastUpdateSeasonStored = s.ss[address(token)].lastUpdateSeason;
+        console.log('lastUpdateSeasonStored: ', lastUpdateSeasonStored);
+
+        console.log('token: ', address(token));
+        // console.log('s.ss[address(token)]: ', s.ss[address(token)]);
+        console.log('seedsPerBdv: ', seedsPerBdv);
+        // console.log('grownStalkPerBdv: %d', grownStalkPerBdv);
+        // console.log('uint256(-grownStalkPerBdv).div(seedsPerBdv): ', uint256(-grownStalkPerBdv).div(seedsPerBdv));
+
+        uint256 seasonAs256 = uint256(int128(s.ss[address(token)].lastUpdateSeason).sub(grownStalkPerBdv)).div(seedsPerBdv);
+        console.log('seasonAs256: ', seasonAs256);
+
+        season = seasonAs256.toUint32();
     }
 }

--- a/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
@@ -9,6 +9,7 @@ import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
 import "../LibAppStorage.sol";
 import "../../C.sol";
 import "./LibUnripeSilo.sol";
+import "./LibTokenSilo.sol";
 
 /**
  * @title LibLegacyTokenSilo
@@ -42,8 +43,8 @@ library LibLegacyTokenSilo {
         AppStorage storage s = LibAppStorage.diamondStorage();
         require(bdv > 0, "Silo: No Beans under Token.");
 
-        incrementTotalDeposited(token, amount); // Update Totals
-        addDepositToAccount(account, token, season, amount, bdv); // Add to Account
+        LibTokenSilo.incrementTotalDeposited(token, amount); // Update Totals
+        LibTokenSilo.addDepositToAccount(account, token, season, amount, bdv); // Add to Account
 
         return (bdv.mul(s.ss[token].seeds), bdv.mul(s.ss[token].stalk));
     }
@@ -176,9 +177,11 @@ library LibLegacyTokenSilo {
         view
         returns (bool)
     {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        uint256 seedsPerBdv = uint256(s.ss[token].legacySeedsPerBdv);
         return
             grownStalkPerBdv < 0 &&
-            uint256(-_grownStalkPerBdv) % seedsPerBdv != 0;
+            uint256(-grownStalkPerBdv) % seedsPerBdv != 0;
     }
 
     function grownStalkPerBdvToSeason(IERC20 token, int128 grownStalkPerBdv)
@@ -186,6 +189,7 @@ library LibLegacyTokenSilo {
         view
         returns (uint32 season)
     {
+        AppStorage storage s = LibAppStorage.diamondStorage();
         uint256 seedsPerBdv = uint256(s.ss[token].legacySeedsPerBdv);
         season = uint256(-grownStalkPerBdv).div(seedsPerBdv).toUint32(); // use OpenZeppelin's safecast to uint32
     }

--- a/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
@@ -54,6 +54,7 @@ library LibLegacyTokenSilo {
         uint32 season,
         uint256 amount
     ) internal returns (uint256 crateBDV) {
+        console.log('removeDepositFromAccount season: ', season);
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         uint256 crateAmount;
@@ -164,7 +165,7 @@ library LibLegacyTokenSilo {
         uint256 seedsPerBdv = uint256(s.ss[address(token)].legacySeedsPerBdv);
         console.log('seedsPerBdv: ', seedsPerBdv);
         return
-            grownStalkPerBdv < 0 && //old deposits in seasons will have a negative grown stalk per bdv
+            grownStalkPerBdv <= 0 && //old deposits in seasons will have a negative grown stalk per bdv
             uint256(-grownStalkPerBdv) % seedsPerBdv == 0;
     }
 

--- a/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
@@ -164,7 +164,7 @@ library LibLegacyTokenSilo {
      * ```
      */
     function balanceOfGrownStalk(address account)
-        public
+        internal
         view
         returns (uint256)
     {

--- a/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
@@ -1,0 +1,192 @@
+/**
+ * SPDX-License-Identifier: MIT
+ **/
+
+pragma solidity =0.7.6;
+pragma experimental ABIEncoderV2;
+
+import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+import "../LibAppStorage.sol";
+import "../../C.sol";
+import "./LibUnripeSilo.sol";
+
+/**
+ * @title LibLegacyTokenSilo
+ * @author Publius
+ * @notice Contains functions for depositing, withdrawing and claiming
+ * whitelisted Silo tokens.
+ *
+ * For functionality related to Seeds, Stalk, and Roots, see {LibSilo}.
+ */
+library LibLegacyTokenSilo {
+    using SafeMath for uint256;
+
+    /**
+     * @dev Once the BDV received for Depositing `amount` of `token` is known,
+     * add a Deposit for `account` and update the total amount Deposited.
+     *
+     * `s.ss[token].seeds` stores the number of Seeds per BDV for `token`.
+     * `s.ss[token].stalk` stores the number of Stalk per BDV for `token`.
+     *
+     * FIXME(discuss): If we think of Deposits like 1155s, we might call the
+     * combination of "incrementTotalDeposited" and "addDepositToAccount" as
+     * "minting a deposit".
+     */
+    function depositWithBDV(
+        address account,
+        address token,
+        uint32 season,
+        uint256 amount,
+        uint256 bdv
+    ) internal returns (uint256, uint256) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        require(bdv > 0, "Silo: No Beans under Token.");
+
+        incrementTotalDeposited(token, amount); // Update Totals
+        addDepositToAccount(account, token, season, amount, bdv); // Add to Account
+
+        return (bdv.mul(s.ss[token].seeds), bdv.mul(s.ss[token].stalk));
+    }
+
+    //////////////////////// REMOVE DEPOSIT ////////////////////////
+
+    /**
+     * @dev Remove `amount` of `token` from a user's Deposit in `season`.
+     *
+     * A "Crate" refers to the existing Deposit in storage at:
+     *  `s.a[account].legacyDeposits[token][season]`
+     *
+     * Partially removing a Deposit should scale its BDV proportionally. For ex.
+     * removing 80% of the tokens from a Deposit should reduce its BDV by 80%.
+     *
+     * During an update, `amount` & `bdv` are cast uint256 -> uint128 to
+     * optimize storage cost, since both values can be packed into one slot.
+     *
+     * This function DOES **NOT** EMIT a {RemoveDeposit} event. This
+     * asymmetry occurs because {removeDepositFromAccount} is called in a loop
+     * in places where multiple deposits are removed simultaneously, including
+     * {TokenSilo-removeDepositsFromAccount} and {TokenSilo-_transferDeposits}.
+     */
+    function removeDepositFromAccount(
+        address account,
+        address token,
+        uint32 season,
+        uint256 amount
+    ) internal returns (uint256 crateBDV) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        uint256 crateAmount;
+        (crateAmount, crateBDV) = (
+            s.a[account].legacyDeposits[token][season].amount,
+            s.a[account].legacyDeposits[token][season].bdv
+        );
+
+        // Partial remove
+        if (amount < crateAmount) {
+            uint256 removedBDV = amount.mul(crateBDV).div(crateAmount);
+            uint256 updatedBDV = uint256(
+                s.a[account].legacyDeposits[token][season].bdv
+            ).sub(removedBDV);
+            uint256 updatedAmount = uint256(
+                s.a[account].legacyDeposits[token][season].amount
+            ).sub(amount);
+
+            require(
+                updatedBDV <= uint128(-1) && updatedAmount <= uint128(-1),
+                "Silo: uint128 overflow."
+            );
+
+            s.a[account].legacyDeposits[token][season].amount = uint128(
+                updatedAmount
+            );
+            s.a[account].legacyDeposits[token][season].bdv = uint128(
+                updatedBDV
+            );
+
+            return removedBDV;
+        }
+
+        // Full remove
+        if (crateAmount > 0) delete s.a[account].legacyDeposits[token][season];
+
+        // Excess remove
+        // This can only occur for Unripe Beans and Unripe LP Tokens, and is a
+        // result of using Silo V1 storage slots to store Unripe BEAN/LP
+        // Deposit information. See {AppStorage.sol:Account-State}.
+        if (amount > crateAmount) {
+            amount -= crateAmount;
+            if (LibUnripeSilo.isUnripeBean(token))
+                return
+                    crateBDV.add(
+                        LibUnripeSilo.removeUnripeBeanDeposit(
+                            account,
+                            season,
+                            amount
+                        )
+                    );
+            else if (LibUnripeSilo.isUnripeLP(token))
+                return
+                    crateBDV.add(
+                        LibUnripeSilo.removeUnripeLPDeposit(
+                            account,
+                            season,
+                            amount
+                        )
+                    );
+            revert("Silo: Crate balance too low.");
+        }
+    }
+
+    //////////////////////// GETTERS ////////////////////////
+
+    /**
+     * @dev Locate the `amount` and `bdv` for a user's Deposit in storage.
+     *
+     * Silo V2 Deposits are stored within each {Account} as a mapping of:
+     *  `address token => uint32 season => { uint128 amount, uint128 bdv }`
+     *
+     * Unripe BEAN and Unripe LP are handled independently so that data
+     * stored in the legacy Silo V1 format and the new Silo V2 format can
+     * be appropriately merged. See {LibUnripeSilo} for more information.
+     *
+     * FIXME(naming): rename to `getDeposit()`?
+     */
+    function tokenDeposit(
+        address account,
+        address token,
+        uint32 season
+    ) internal view returns (uint256, uint256) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        if (LibUnripeSilo.isUnripeBean(token))
+            return LibUnripeSilo.unripeBeanDeposit(account, season);
+
+        if (LibUnripeSilo.isUnripeLP(token))
+            return LibUnripeSilo.unripeLPDeposit(account, season);
+
+        return (
+            s.a[account].legacyDeposits[token][season].amount,
+            s.a[account].legacyDeposits[token][season].bdv
+        );
+    }
+
+
+    function isDepositSeason(IERC20 token, int128 grownStalkPerBdv)
+        internal
+        view
+        returns (bool)
+    {
+        return
+            grownStalkPerBdv < 0 &&
+            uint256(-_grownStalkPerBdv) % seedsPerBdv != 0;
+    }
+
+    function grownStalkPerBdvToSeason(IERC20 token, int128 grownStalkPerBdv)
+        internal
+        view
+        returns (uint32 season)
+    {
+        uint256 seedsPerBdv = uint256(s.ss[token].legacySeedsPerBdv);
+        season = uint256(-grownStalkPerBdv).div(seedsPerBdv).toUint32(); // use OpenZeppelin's safecast to uint32
+    }
+}

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -9,6 +9,7 @@ import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
 import "../../C.sol";
 import "../LibAppStorage.sol";
 import "../LibPRBMath.sol";
+import "~/libraries/LibSafeMathSigned128.sol";
 
 /**
  * @title LibSilo
@@ -31,6 +32,8 @@ import "../LibPRBMath.sol";
  */
 library LibSilo {
     using SafeMath for uint256;
+    using SafeMath for uint128;
+    using SafeMath for int128;
     using LibPRBMath for uint256;
     
     //////////////////////// EVENTS ////////////////////////    
@@ -96,7 +99,7 @@ library LibSilo {
      *
      * For an explanation of Roots accounting, see {FIXME(doc)}.
      */
-    function burnStalk(address account, uint256 stalk) private {
+    function burnStalk(address account, uint256 stalk) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         if (stalk == 0) return;
 
@@ -173,11 +176,11 @@ library LibSilo {
      *  - The result is `1E6 * 1 = 1E6`. Since Stalk is measured to 10 decimals,
      *    this is `1E6/1E10 = 1E-4` Stalk.
      */
-    function stalkReward(uint128 startStalkPerBDV, uint128 endStalkPerBDV, uint128 bdv)
+    function stalkReward(int128 startStalkPerBDV, int128 endStalkPerBDV, uint128 bdv)
         internal
         pure
         returns (uint256)
     {
-        return endStalkPerBDV.sub(startStalkPerBDV).mul(bdv);
+        return uint128(endStalkPerBDV-startStalkPerBDV)*bdv; //TODOSEEDS get safemath working here? endStalkPerBDV.sub(startStalkPerBDV).mul(bdv);
     }
 }

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -136,6 +136,7 @@ library LibSilo {
         // For more info on Rain, see {FIXME(doc)}. 
         if (s.season.raining) {
             s.r.roots = s.r.roots.sub(roots);
+            console.log('burnStalk updating s.a[account].sop.roots', s.a[account].sop.roots);
             s.a[account].sop.roots = s.a[account].roots;
         }
 

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -110,6 +110,7 @@ library LibSilo {
         if (stalk == 0) return;
 
         console.log('burnStalk: ', stalk);
+        console.log('current total stalk s.s.stalk: ', s.s.stalk);
         // Calculate the amount of Roots for the given amount of Stalk.
         // We round up as it prevents an account having roots but no stalk.
          uint256 roots = s.s.roots.mulDiv(

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -183,4 +183,12 @@ library LibSilo {
     {
         return uint128(endStalkPerBDV-startStalkPerBDV)*bdv; //TODOSEEDS get safemath working here? endStalkPerBDV.sub(startStalkPerBDV).mul(bdv);
     }
+
+    function stalkRewardLegacy(uint256 seeds, uint32 seasons)
+        internal
+        pure
+        returns (uint256)
+    {
+        return seeds.mul(seasons);
+    }
 }

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -140,7 +140,7 @@ library LibSilo {
         address sender,
         address recipient,
         uint256 stalk
-    ) private {
+    ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         // (Fixme?) Calculate the amount of Roots for the given amount of Stalk.
         uint256 roots = stalk == s.a[sender].s.stalk
@@ -176,7 +176,7 @@ library LibSilo {
      *  - The result is `1E6 * 1 = 1E6`. Since Stalk is measured to 10 decimals,
      *    this is `1E6/1E10 = 1E-4` Stalk.
      */
-    function stalkReward(int128 startStalkPerBDV, int128 endStalkPerBDV, uint128 bdv)
+    function stalkReward(int128 startStalkPerBDV, int128 endStalkPerBDV, uint128 bdv) //are the types what we want here?
         internal
         pure
         returns (uint256)

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -40,6 +40,7 @@ library LibSilo {
     //////////////////////// EVENTS ////////////////////////    
 
     //TODOSEEDS what should we emit here? presumably now seeds could change every season even
+    //should probably include token, grown stalk index, current season?
     event SeedsBalanceChanged(
         address indexed account,
         int256 delta

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -85,8 +85,9 @@ library LibSilo {
         else roots = s.s.roots.mul(stalk).div(s.s.stalk);
 
         // Increase supply of Stalk; Add Stalk to the balance of `account`
+        console.log('mintStalk previous total stalk s.s.stalk: ', s.s.stalk);
         s.s.stalk = s.s.stalk.add(stalk);
-        console.log('new total stalk s.s.stalk: ', s.s.stalk);
+        console.log('mintStalk new total stalk s.s.stalk: ', s.s.stalk);
         s.a[account].s.stalk = s.a[account].s.stalk.add(stalk);
 
         // console.log('new total stalk s.a[account].s.stalk: ', s.a[account].s.stalk);
@@ -110,7 +111,7 @@ library LibSilo {
         if (stalk == 0) return;
 
         console.log('burnStalk: ', stalk);
-        console.log('current total stalk s.s.stalk: ', s.s.stalk);
+        console.log('burnStalk current total stalk s.s.stalk: ', s.s.stalk);
         // Calculate the amount of Roots for the given amount of Stalk.
         // We round up as it prevents an account having roots but no stalk.
          uint256 roots = s.s.roots.mulDiv(
@@ -120,8 +121,9 @@ library LibSilo {
         if (roots > s.a[account].roots) roots = s.a[account].roots;
 
         // Decrease supply of Stalk; Remove Stalk from the balance of `account`
+        console.log('burnStalk previous total stalk s.s.stalk: ', s.s.stalk);
         s.s.stalk = s.s.stalk.sub(stalk);
-        console.log('new stalk after burn s.s.stalk: ', s.s.stalk);
+        console.log('burnStalk new stalk after burn s.s.stalk: ', s.s.stalk);
         s.a[account].s.stalk = s.a[account].s.stalk.sub(stalk);
 
         // Decrease supply of Roots; Remove Roots from the balance of `account`

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -111,7 +111,7 @@ library LibSilo {
         AppStorage storage s = LibAppStorage.diamondStorage();
         if (stalk == 0) return;
 
-        console.log('burnStalk: ', stalk);
+        console.log('burnStalk burn amount: ', stalk);
         console.log('burnStalk current total stalk s.s.stalk: ', s.s.stalk);
         // Calculate the amount of Roots for the given amount of Stalk.
         // We round up as it prevents an account having roots but no stalk.

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -10,6 +10,7 @@ import "../../C.sol";
 import "../LibAppStorage.sol";
 import "../LibPRBMath.sol";
 import "~/libraries/LibSafeMathSigned128.sol";
+import "hardhat/console.sol";
 
 /**
  * @title LibSilo
@@ -74,6 +75,8 @@ library LibSilo {
      * For an explanation of Roots accounting, see {FIXME(doc)}.
      */
     function mintStalk(address account, uint256 stalk) internal {
+        console.log('mintStalk account: ', account);
+        console.log('mintStalk stalk: ', stalk);
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         // Calculate the amount of Roots for the given amount of Stalk.
@@ -83,7 +86,10 @@ library LibSilo {
 
         // Increase supply of Stalk; Add Stalk to the balance of `account`
         s.s.stalk = s.s.stalk.add(stalk);
+        console.log('new total stalk s.s.stalk: ', s.s.stalk);
         s.a[account].s.stalk = s.a[account].s.stalk.add(stalk);
+
+        // console.log('new total stalk s.a[account].s.stalk: ', s.a[account].s.stalk);
 
         // Increase supply of Roots; Add Roots to the balance of `account`
         s.s.roots = s.s.roots.add(roots);
@@ -103,6 +109,7 @@ library LibSilo {
         AppStorage storage s = LibAppStorage.diamondStorage();
         if (stalk == 0) return;
 
+        console.log('burnStalk: ', stalk);
         // Calculate the amount of Roots for the given amount of Stalk.
         // We round up as it prevents an account having roots but no stalk.
          uint256 roots = s.s.roots.mulDiv(
@@ -113,6 +120,7 @@ library LibSilo {
 
         // Decrease supply of Stalk; Remove Stalk from the balance of `account`
         s.s.stalk = s.s.stalk.sub(stalk);
+        console.log('new stalk after burn s.s.stalk: ', s.s.stalk);
         s.a[account].s.stalk = s.a[account].s.stalk.sub(stalk);
 
         // Decrease supply of Roots; Remove Roots from the balance of `account`
@@ -164,23 +172,17 @@ library LibSilo {
      * This function will take in a start stalk per bdv, end stalk per bdv,
      * and the deposited bdv amount, and return
      *
-     * Each Seed yields 1E-4 (0.0001, or 1 / 10_000) Stalk per Season.
-     *
-     * Seasons is measured to 0 decimals. There are no fractional Seasons.
-     * Seeds are measured to 6 decimals.
-     * Stalk is measured to 10 decimals.
-     * 
-     * Example:
-     *  - `seeds = 1E6` (1 Seed)
-     *  - `seasons = 1` (1 Season)
-     *  - The result is `1E6 * 1 = 1E6`. Since Stalk is measured to 10 decimals,
-     *    this is `1E6/1E10 = 1E-4` Stalk.
      */
     function stalkReward(int128 startStalkPerBDV, int128 endStalkPerBDV, uint128 bdv) //are the types what we want here?
         internal
-        pure
+        view //change back to pure
         returns (uint256)
     {
+        console.log('stalkReward startStalkPerBDV: ');
+        console.logInt(startStalkPerBDV);
+        console.log('stalkReward endStalkPerBDV: ');
+        console.logInt(endStalkPerBDV);
+        console.log('stalkReward bdv: ', bdv);
         int128 reward = endStalkPerBDV.sub(startStalkPerBDV).mul(int128(bdv));
         return uint128(reward);
     }

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -33,7 +33,7 @@ import "~/libraries/LibSafeMathSigned128.sol";
 library LibSilo {
     using SafeMath for uint256;
     using SafeMath for uint128;
-    using SafeMath for int128;
+    using LibSafeMathSigned128 for int128;
     using LibPRBMath for uint256;
     
     //////////////////////// EVENTS ////////////////////////    
@@ -181,7 +181,8 @@ library LibSilo {
         pure
         returns (uint256)
     {
-        return uint128(endStalkPerBDV-startStalkPerBDV)*bdv; //TODOSEEDS get safemath working here? endStalkPerBDV.sub(startStalkPerBDV).mul(bdv);
+        int128 reward = endStalkPerBDV.sub(startStalkPerBDV).mul(int128(bdv));
+        return uint128(reward);
     }
 
     function stalkRewardLegacy(uint256 seeds, uint32 seasons)

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -139,7 +139,7 @@ library LibTokenSilo {
         uint256 bdv
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        console.log('addDepositToAccount: ', account);
+        console.log('addDepositToAccount token: ', token);
         console.log('addDepositToAccount logging grown stalk per bdv:');
         console.logInt(grownStalkPerBdv);
         uint256 updatedAmount = s.a[account].deposits[token][grownStalkPerBdv].amount.add(amount.toUint128());
@@ -366,19 +366,18 @@ library LibTokenSilo {
     {
         AppStorage storage s = LibAppStorage.diamondStorage();
         // SiloSettings storage ss = s.ss[token]; //tried to use this, but I get `DeclarationError: Identifier not found or not unique.`
-        console.log('s.ss[address(token)].lastCumulativeGrownStalkPerBdv: ');
-        console.logInt(s.ss[address(token)].lastCumulativeGrownStalkPerBdv);
-        console.log('s.season.current: ', s.season.current);
-        console.log('s.ss[address(token)].lastUpdateSeason: ', s.ss[address(token)].lastUpdateSeason);
-        console.log('s.ss[address(token)].stalkPerBdvPerSeason: ', s.ss[address(token)].stalkPerBdvPerSeason);
+        console.log('cumulativeGrownStalkPerBdv s.ss[address(token)].lastCumulativeGrownStalkPerBdv: ', uint256(s.ss[address(token)].lastCumulativeGrownStalkPerBdv));
+        console.log('cumulativeGrownStalkPerBdv s.season.current: ', s.season.current);
+        console.log('cumulativeGrownStalkPerBdv s.ss[address(token)].lastUpdateSeason: ', s.ss[address(token)].lastUpdateSeason);
+        console.log('cumulativeGrownStalkPerBdv s.ss[address(token)].stalkPerBdvPerSeason: ', s.ss[address(token)].stalkPerBdvPerSeason);
 
         //need to take into account the lastUpdateSeason for this token here
 
 
-
-        _cumulativeGrownStalkPerBdv = s.ss[address(token)].lastCumulativeGrownStalkPerBdv.add(
-            int128(s.ss[address(token)].stalkPerBdvPerSeason.mul(s.season.current.sub(s.ss[address(token)].lastUpdateSeason)).div(1e6)) //round here
-        );
+        //replace the - here with sub to disable support for when the current season is less than the silov3 epoch season
+        _cumulativeGrownStalkPerBdv = s.ss[address(token)].lastCumulativeGrownStalkPerBdv +
+            int128(int128(s.ss[address(token)].stalkPerBdvPerSeason).mul(int128(s.season.current)-int128(s.ss[address(token)].lastUpdateSeason)).div(1e6)) //round here
+        ;
     }
 
     function grownStalkForDeposit(

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -196,10 +196,10 @@ library LibTokenSilo {
             s.a[account].deposits[token][grownStalkPerBdv].amount = uint128(updatedAmount);
             s.a[account].deposits[token][grownStalkPerBdv].bdv = uint128(updatedBDV);
 
-            uint256 updatedTotalBdv = uint256(s.a[account].deposits[token][grownStalkPerBdv].amount).sub(removedBDV);
+            uint256 updatedTotalBdvPartial = uint256(s.a[account].deposits[token][grownStalkPerBdv].amount).sub(removedBDV);
 
             //remove from the mow status bdv amount, which keeps track of total token deposited per farmer
-            s.a[account].mowStatuses[token].bdv = uint128(updatedTotalBdv); //need some kind of safety check here?
+            s.a[account].mowStatuses[token].bdv = uint128(updatedTotalBdvPartial); //need some kind of safety check here?
 
             return removedBDV;
         }
@@ -208,7 +208,7 @@ library LibTokenSilo {
         if (crateAmount > 0) delete s.a[account].deposits[token][grownStalkPerBdv];
 
         uint256 updatedTotalBdv = uint256(s.a[account].mowStatuses[token].bdv).sub(crateAmount);
-        s.a[account].mowStatuses[token].bdv = updatedTotalBdv;
+        s.a[account].mowStatuses[token].bdv = uint128(updatedTotalBdv);
 
         // Excess remove
         // This can only occur for Unripe Beans and Unripe LP Tokens, and is a
@@ -323,7 +323,6 @@ library LibTokenSilo {
         returns (uint grownStalk)
     {
         // cumulativeGrownStalkPerBdv(token) > depositGrownStalkPerBdv for all valid Deposits
-        AppStorage storage s = LibAppStorage.diamondStorage();
         int128 _cumulativeGrownStalkPerBdv = cumulativeGrownStalkPerBdv(token);
         require(grownStalkPerBdv <= _cumulativeGrownStalkPerBdv, "Silo: Invalid Deposit");
         uint deltaGrownStalkPerBdv = uint(cumulativeGrownStalkPerBdv(token).sub(grownStalkPerBdv));

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -414,6 +414,8 @@ library LibTokenSilo {
     }
 
 
+    //takes in grownStalk total by a previous deposit, and a bdv, returns
+    //what the grownStalkPerBdv index should be to have that same amount of grown stalk for the input token
     function grownStalkAndBdvToCumulativeGrownStalk(IERC20 token, uint256 grownStalk, uint256 bdv)
         internal
         view
@@ -428,6 +430,9 @@ library LibTokenSilo {
         console.log('grownStalkAndBdvToCumulativeGrownStalk grownStalkPerBdv:');
         console.logInt(grownStalkPerBdv);
         //then subtract from the current latest index, so we get the index the deposit should have happened at
-        return latestCumulativeGrownStalkPerBdvForToken.sub(grownStalkPerBdv);
+        //note that we want this to be able to "subtraction overflow" aka go below zero, because
+        //there will be many cases where you'd want to convert and need to go far back enough in the
+        //grown stalk index to need a negative index
+        return latestCumulativeGrownStalkPerBdvForToken-grownStalkPerBdv;
     }
 }

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -305,10 +305,9 @@ library LibTokenSilo {
         // cumulativeGrownStalkPerBdv(token) > depositGrownStalkPerBdv for all valid Deposits
         AppStorage storage s = LibAppStorage.diamondStorage();
         int128 _cumulativeGrownStalkPerBdv = cumulativeGrownStalkPerBdv(token);
-        int128 depositGrownStalkPerBdv = s.ss[token].lastCumulativeGrownStalkPerBdv;
-        require(depositGrownStalkPerBdv <= _cumulativeGrownStalkPerBdv, "Silo: Invalid Deposit");
-        uint deltaGrownStalkPerBdv = uint(cumulativeGrownStalkPerBdv(token).sub(depositGrownStalkPerBdv));
-        (, uint bdv) = tokenDeposit(account, token, depositGrownStalkPerBdv);
+        require(grownStalkPerBdv <= _cumulativeGrownStalkPerBdv, "Silo: Invalid Deposit");
+        uint deltaGrownStalkPerBdv = uint(cumulativeGrownStalkPerBdv(token).sub(grownStalkPerBdv));
+        (, uint bdv) = tokenDeposit(account, token, grownStalkPerBdv);
         grownStalk = deltaGrownStalkPerBdv.mul(bdv);
     }
 }

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -287,6 +287,7 @@ library LibTokenSilo {
     }
     /**
      * @dev Get the number of Stalk per BDV per Season for a whitelisted token. Formerly just seeds.
+     * Note this is stored as 1e6, i.e. 1_000_000 units of this is equal to 1 old seed.
      */
     function stalkPerBdvPerSeason(address token) internal view returns (uint256) {
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -309,7 +310,7 @@ library LibTokenSilo {
         AppStorage storage s = LibAppStorage.diamondStorage();
         // SiloSettings storage ss = s.ss[token]; //tried to use this, but I get `DeclarationError: Identifier not found or not unique.`
         _cumulativeGrownStalkPerBdv = s.ss[address(token)].lastCumulativeGrownStalkPerBdv.add(
-            int128(s.ss[address(token)].stalkPerBdvPerSeason.mul(s.season.current.sub(s.ss[address(token)].lastUpdateSeason)))
+            int128(s.ss[address(token)].stalkPerBdvPerSeason.mul(s.season.current.sub(s.ss[address(token)].lastUpdateSeason)).div(1e6)) //1e6 here becauase stalkPerBdvPerSeason stored as 1e6
         );
     }
 

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -85,7 +85,7 @@ library LibTokenSilo {
      * @dev Once the BDV received for Depositing `amount` of `token` is known, 
      * add a Deposit for `account` and update the total amount Deposited.
      *
-     * `s.ss[token].stalk` stores the number of Stalk per BDV for `token`.
+     * `s.ss[token].stalkPerBdv` stores the number of Stalk per BDV for `token`.
      *
      * FIXME(discuss): If we think of Deposits like 1155s, we might call the
      * combination of "incrementTotalDeposited" and "addDepositToAccount" as 

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -12,6 +12,7 @@ import "./LibUnripeSilo.sol";
 import "./LibLegacyTokenSilo.sol";
 import "~/libraries/LibSafeMathSigned128.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/SafeCast.sol";
+import "hardhat/console.sol";
 
 /**
  * @title LibTokenSilo
@@ -79,6 +80,11 @@ library LibTokenSilo {
         int128 grownStalkPerBdv,
         uint256 amount
     ) internal returns (uint256) {
+        console.log('deposit account: ', account);
+        console.log('token: ', token);
+        console.log('logging grown stalk per bdv:');
+        console.logInt(grownStalkPerBdv);
+        console.log('amount: ', amount);
         uint256 bdv = beanDenominatedValue(token, amount);
         return depositWithBDV(account, token, grownStalkPerBdv, amount, bdv);
     }
@@ -172,6 +178,11 @@ library LibTokenSilo {
         int128 grownStalkPerBdv,
         uint256 amount
     ) internal returns (uint256 crateBDV) {
+        console.log('account: ', account);
+        console.log('token: ', token);
+        console.log('logging grown stalk per bdv');
+        console.logInt(grownStalkPerBdv);
+        console.log('amount: ', amount);
         AppStorage storage s = LibAppStorage.diamondStorage();
         
         uint256 crateAmount;
@@ -218,6 +229,7 @@ library LibTokenSilo {
             amount -= crateAmount;
             
             uint32 season = LibLegacyTokenSilo.grownStalkPerBdvToSeason(IERC20(token), grownStalkPerBdv);
+            console.log('season: ', season);
             LibLegacyTokenSilo.removeDepositFromAccount(account, token, season, amount);
         }
     }
@@ -310,7 +322,7 @@ library LibTokenSilo {
         AppStorage storage s = LibAppStorage.diamondStorage();
         // SiloSettings storage ss = s.ss[token]; //tried to use this, but I get `DeclarationError: Identifier not found or not unique.`
         _cumulativeGrownStalkPerBdv = s.ss[address(token)].lastCumulativeGrownStalkPerBdv.add(
-            int128(s.ss[address(token)].stalkPerBdvPerSeason.mul(s.season.current.sub(s.ss[address(token)].lastUpdateSeason)).div(1e6)) //1e6 here becauase stalkPerBdvPerSeason stored as 1e6
+            int128(s.ss[address(token)].stalkPerBdvPerSeason.mul(s.season.current.sub(s.ss[address(token)].lastUpdateSeason))) //multiply by 1e6 here becauase stalkPerBdvPerSeason stored as 1e6, but then div by 1e6 to get from seed to stalk, so do nothing
         );
     }
 

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -331,7 +331,7 @@ library LibTokenSilo {
     }
 
         function grownStalkAndBdvToCumulativeGrownStalk(IERC20 token, uint256 grownStalk, uint256 bdv)
-        public
+        internal
         view
         returns (int128 cumulativeGrownStalk)
     {

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -362,6 +362,12 @@ library LibTokenSilo {
     {
         AppStorage storage s = LibAppStorage.diamondStorage();
         // SiloSettings storage ss = s.ss[token]; //tried to use this, but I get `DeclarationError: Identifier not found or not unique.`
+        console.log('s.ss[address(token)].lastCumulativeGrownStalkPerBdv: ');
+        console.logInt(s.ss[address(token)].lastCumulativeGrownStalkPerBdv);
+        console.log('s.season.current: ', s.season.current);
+        console.log('s.ss[address(token)].lastUpdateSeason: ', s.ss[address(token)].lastUpdateSeason);
+        console.log('s.ss[address(token)].stalkPerBdvPerSeason: ', s.ss[address(token)].stalkPerBdvPerSeason);
+
         _cumulativeGrownStalkPerBdv = s.ss[address(token)].lastCumulativeGrownStalkPerBdv.add(
             int128(s.ss[address(token)].stalkPerBdvPerSeason.mul(s.season.current.sub(s.ss[address(token)].lastUpdateSeason)).div(1e6)) //round here
         );

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -261,7 +261,7 @@ library LibTokenSilo {
             
             uint32 season = LibLegacyTokenSilo.grownStalkPerBdvToSeason(IERC20(token), grownStalkPerBdv);
             console.log('removeDepositFromAccount season: ', season);
-            LibLegacyTokenSilo.removeDepositFromAccount(account, token, season, amount);
+            return LibLegacyTokenSilo.removeDepositFromAccount(account, token, season, amount);
         }
     }
 
@@ -367,6 +367,10 @@ library LibTokenSilo {
         console.log('s.season.current: ', s.season.current);
         console.log('s.ss[address(token)].lastUpdateSeason: ', s.ss[address(token)].lastUpdateSeason);
         console.log('s.ss[address(token)].stalkPerBdvPerSeason: ', s.ss[address(token)].stalkPerBdvPerSeason);
+
+        //need to take into account the lastUpdateSeason for this token here
+
+
 
         _cumulativeGrownStalkPerBdv = s.ss[address(token)].lastCumulativeGrownStalkPerBdv.add(
             int128(s.ss[address(token)].stalkPerBdvPerSeason.mul(s.season.current.sub(s.ss[address(token)].lastUpdateSeason)).div(1e6)) //round here

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -136,12 +136,7 @@ library LibTokenSilo {
         s.a[account].deposits[token][grownStalkPerBdv].bdv += uint128(bdv); //need safecast here?
 
         //setup or update the MowStatus for this deposit. We should have _just_ mowed before calling this function.
-        s.a[account].mowStatuses[token].lastCumulativeGrownStalkPerBDV = grownStalkPerBdv; //maybe updating this here is not totally necessary if we just mowed?
         s.a[account].mowStatuses[token].bdv += uint128(bdv); //need safecast here?
-
-        //add to account-level total token deposited total amount inside the MowStatus
-
-
 
         emit AddDeposit(account, token, grownStalkPerBdv, amount, bdv);
     }

--- a/protocol/contracts/libraries/Silo/LibUnripeSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibUnripeSilo.sol
@@ -9,6 +9,7 @@ import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
 import "../LibAppStorage.sol";
 import "../LibSafeMath128.sol";
 import "../../C.sol";
+import "hardhat/console.sol";
 
 /**
  * @title LibUnripeSilo
@@ -98,6 +99,7 @@ library LibUnripeSilo {
     ) internal returns (uint256 bdv) {
         _removeUnripeBeanDeposit(account, season, amount);
         bdv = amount.mul(C.initialRecap()).div(1e18);
+        console.log('removeUnripeBeanDeposit: ', bdv);
     }
 
     /**
@@ -111,6 +113,7 @@ library LibUnripeSilo {
         uint256 amount
     ) private {
         AppStorage storage s = LibAppStorage.diamondStorage();
+        console.log('_removeUnripeBeanDeposit: ', amount);
         s.a[account].bean.deposits[season] = s.a[account].bean.deposits[season].sub(
             amount,
             "Silo: Crate balance too low."

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -7,6 +7,7 @@ pragma experimental ABIEncoderV2;
 
 import "../../C.sol";
 import "../LibAppStorage.sol";
+import "hardhat/console.sol";
 
 /**
  * @title LibWhitelist
@@ -56,6 +57,8 @@ library LibWhitelist {
         s.ss[token].stalkPerBdv = stalkPerBdv; //previously just called "stalk"
         s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason; //previously called "seeds"
 
+        s.ss[token].lastUpdateSeason = s.season.current; //hydrate as current season
+
         emit WhitelistToken(token, selector, stalkPerBdv, stalkPerBdvPerSeason);
     }
 
@@ -72,6 +75,10 @@ library LibWhitelist {
         s.ss[token].stalkPerBdv = stalkPerBdv; //previously just called "stalk"
         s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason; //previously called "seeds"
         s.ss[token].legacySeedsPerBdv = seeds;
+
+        s.ss[token].lastUpdateSeason = s.season.current; //hydrate as current season
+
+        console.log('seeds: ', seeds, ' for ', token);
 
         emit WhitelistToken(token, selector, stalkPerBdv, seeds);
     }

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -47,16 +47,16 @@ library LibWhitelist {
     function whitelistToken(
         address token,
         bytes4 selector,
-        uint32 stalk,
-        uint32 seeds
+        uint32 stalkPerBdv,
+        uint32 stalkPerBdvPerSeason
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         s.ss[token].selector = selector;
-        s.ss[token].stalk = stalk;
-        s.ss[token].seeds = seeds;
+        s.ss[token].stalkPerBdv = stalkPerBdv; //previously just called "stalk"
+        s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason; //previously called "seeds"
 
-        emit WhitelistToken(token, selector, stalk, seeds);
+        emit WhitelistToken(token, selector, stalkPerBdv, stalkPerBdvPerSeason);
     }
 
 

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -25,13 +25,13 @@ library LibWhitelist {
      * function bdv(uint256 amount) public view returns (uint256);
      * ```
      * 
-     * @param seeds The Seeds per BDV received from depositing `token`.
+     * @param stalkPerBdvPerSeason The Stalk per BDV per Season received from depositing `token`.
      * @param stalk The Stalk per BDV received from depositing `token`.
      */
     event WhitelistToken(
         address indexed token,
         bytes4 selector,
-        uint256 seeds,
+        uint256 stalkPerBdvPerSeason,
         uint256 stalk
     );
 

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -59,7 +59,7 @@ library LibWhitelist {
 
         s.ss[token].lastUpdateSeason = C.siloV3StartSeason(); //hydrate as current season
 
-        emit WhitelistToken(token, selector, stalkPerBdv, stalkPerBdvPerSeason);
+        emit WhitelistToken(token, selector, stalkPerBdvPerSeason, stalkPerBdv);
     }
 
     function whitelistTokenLegacy(
@@ -80,7 +80,7 @@ library LibWhitelist {
 
         console.log('seeds: ', seeds, ' for ', token);
 
-        emit WhitelistToken(token, selector, stalkPerBdv, seeds);
+        emit WhitelistToken(token, selector, stalkPerBdvPerSeason, stalkPerBdv);
     }
 
     /**

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -69,7 +69,7 @@ library LibWhitelist {
         s.ss[token].stalkPerBdv = stalkPerBdv; //previously just called "stalk"
         s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason; //previously called "seeds"
 
-        s.ss[token].lastUpdateSeason = C.siloV3StartSeason(); //TODOSEEDS hydrate as current season?
+        s.ss[token].lastUpdateSeason = s.season.current;
 
         emit WhitelistToken(token, selector, stalkPerBdvPerSeason, stalkPerBdv);
     }
@@ -87,6 +87,9 @@ library LibWhitelist {
         emit UpdatedStalkPerBdvPerSeason(token, stalkPerBdvPerSeason, s.season.current);
     }
 
+
+    //function not needed because we'll manually setup these initial values from the bip script?
+    //however it's referenced in the InitWhitelist.sol code
     function whitelistTokenLegacy(
         address token,
         bytes4 selector,
@@ -101,7 +104,7 @@ library LibWhitelist {
         s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason; //previously called "seeds"
         s.ss[token].legacySeedsPerBdv = seeds;
 
-        s.ss[token].lastUpdateSeason = C.siloV3StartSeason(); //hydrate as the constant season when we flip over 
+        s.ss[token].lastUpdateSeason = s.season.current;
 
         console.log('seeds: ', seeds, ' for ', token);
 

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -37,6 +37,18 @@ library LibWhitelist {
     );
 
     /**
+     * @notice Emitted when the stalk per bdv per season for a Silo token is updated.
+     * @param token ERC-20 token being updated in the Silo Whitelist.
+     * @param stalkPerBdvPerSeason new stalk per bdv per season value for this token.
+     * @param season the current season.
+     */
+    event UpdatedStalkPerBdvPerSeason(
+        address indexed token,
+        uint32 stalkPerBdvPerSeason,
+        uint32 season
+    );
+
+    /**
      * @notice Emitted when a token is removed from the Silo Whitelist.
      * @param token ERC-20 token being removed from the Silo Whitelist.
      */
@@ -57,9 +69,23 @@ library LibWhitelist {
         s.ss[token].stalkPerBdv = stalkPerBdv; //previously just called "stalk"
         s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason; //previously called "seeds"
 
-        s.ss[token].lastUpdateSeason = C.siloV3StartSeason(); //hydrate as current season
+        s.ss[token].lastUpdateSeason = C.siloV3StartSeason(); //TODOSEEDS hydrate as current season?
 
         emit WhitelistToken(token, selector, stalkPerBdvPerSeason, stalkPerBdv);
+    }
+    
+    /**
+     * @dev Add an ERC-20 token to the Silo Whitelist.
+     */
+    function updateStalkPerBdvPerSeasonForToken(
+        address token,
+        uint32 stalkPerBdvPerSeason
+        ) internal {
+
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason;
+
+        emit UpdatedStalkPerBdvPerSeason(token, stalkPerBdvPerSeason, s.season.current);
     }
 
     function whitelistTokenLegacy(

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -31,7 +31,7 @@ library LibWhitelist {
     event WhitelistToken(
         address indexed token,
         bytes4 selector,
-        uint256 stalkPerBdvPerSeason,
+        uint32 stalkPerBdvPerSeason,
         uint256 stalk
     );
 

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -80,8 +80,7 @@ library LibWhitelist {
     function updateStalkPerBdvPerSeasonForToken(
         address token,
         uint32 stalkPerBdvPerSeason
-        ) internal {
-
+    ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason;
 

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -59,6 +59,22 @@ library LibWhitelist {
         emit WhitelistToken(token, selector, stalkPerBdv, stalkPerBdvPerSeason);
     }
 
+    function whitelistTokenLegacy(
+        address token,
+        bytes4 selector,
+        uint32 stalkPerBdv,
+        uint32 stalkPerBdvPerSeason,
+        uint32 seeds
+    ) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        s.ss[token].selector = selector;
+        s.ss[token].stalkPerBdv = stalkPerBdv; //previously just called "stalk"
+        s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason; //previously called "seeds"
+        s.ss[token].legacySeedsPerBdv = seeds;
+
+        emit WhitelistToken(token, selector, stalkPerBdv, seeds);
+    }
 
     /**
      * @dev Remove an ERC-20 token from the Silo Whitelist.

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -57,7 +57,7 @@ library LibWhitelist {
         s.ss[token].stalkPerBdv = stalkPerBdv; //previously just called "stalk"
         s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason; //previously called "seeds"
 
-        s.ss[token].lastUpdateSeason = s.season.current; //hydrate as current season
+        s.ss[token].lastUpdateSeason = C.siloV3StartSeason(); //hydrate as current season
 
         emit WhitelistToken(token, selector, stalkPerBdv, stalkPerBdvPerSeason);
     }
@@ -76,7 +76,7 @@ library LibWhitelist {
         s.ss[token].stalkPerBdvPerSeason = stalkPerBdvPerSeason; //previously called "seeds"
         s.ss[token].legacySeedsPerBdv = seeds;
 
-        s.ss[token].lastUpdateSeason = s.season.current; //hydrate as current season
+        s.ss[token].lastUpdateSeason = C.siloV3StartSeason(); //hydrate as the constant season when we flip over 
 
         console.log('seeds: ', seeds, ' for ', token);
 

--- a/protocol/contracts/libraries/Token/LibTransfer.sol
+++ b/protocol/contracts/libraries/Token/LibTransfer.sol
@@ -12,6 +12,7 @@ pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "../../interfaces/IBean.sol";
 import "./LibBalance.sol";
+import "hardhat/console.sol";
 
 library LibTransfer {
     using SafeERC20 for IERC20;
@@ -52,6 +53,7 @@ library LibTransfer {
         address sender,
         From mode
     ) internal returns (uint256 receivedAmount) {
+        console.log('receiveToken: ', address(token));
         if (amount == 0) return 0;
         if (mode != From.EXTERNAL) {
             receivedAmount = LibBalance.decreaseInternalBalance(
@@ -63,6 +65,7 @@ library LibTransfer {
             if (amount == receivedAmount || mode == From.INTERNAL_TOLERANT)
                 return receivedAmount;
         }
+        console.log('address(this): ', address(this));
         uint256 beforeBalance = token.balanceOf(address(this));
         token.safeTransferFrom(sender, address(this), amount - receivedAmount);
         return receivedAmount.add(token.balanceOf(address(this)).sub(beforeBalance));

--- a/protocol/contracts/mocks/mockFacets/MockConvertFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockConvertFacet.sol
@@ -24,6 +24,8 @@ contract MockConvertFacet is ConvertFacet {
         uint256 maxTokens
     ) external {
         (uint256 stalkRemoved, uint256 bdvRemoved) = _withdrawTokens(token, grownStalkPerBdvs, amounts, maxTokens);
+        console.log('MockConvert stalkRemoved: ', stalkRemoved);
+        console.log('MockConvert bdvRemoved: ', bdvRemoved);
         emit MockConvert(stalkRemoved, bdvRemoved);
     }
 

--- a/protocol/contracts/mocks/mockFacets/MockConvertFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockConvertFacet.sol
@@ -19,11 +19,11 @@ contract MockConvertFacet is ConvertFacet {
 
     function withdrawForConvertE(
         address token,
-        uint32[] memory seasons,
+        int128[] memory grownStalkPerBdvs,
         uint256[] memory amounts,
         uint256 maxTokens
     ) external {
-        (uint256 stalkRemoved, uint256 bdvRemoved) = _withdrawTokens(token, seasons, amounts, maxTokens);
+        (uint256 stalkRemoved, uint256 bdvRemoved) = _withdrawTokens(token, grownStalkPerBdvs, amounts, maxTokens);
         emit MockConvert(stalkRemoved, bdvRemoved);
     }
 

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -44,7 +44,7 @@ contract MockSiloFacet is SiloFacet {
         uint256 unripeLP = getUnripeForAmount(t, amount);
         LibTokenSilo.incrementTotalDeposited(C.unripeLPAddress(), unripeLP);
         bdv = bdv.mul(C.initialRecap()).div(1e18);
-        uint256 stalk = bdv.mul(s.ss[C.unripeLPAddress()].stalk).add(LibSilo.stalkReward(grownStalkPerBdv, s.ss[address(token)].lastCumulativeGrownStalkPerBdv, bdv));
+        uint256 stalk = bdv.mul(s.ss[C.unripeLPAddress()].stalk).add(LibSilo.stalkReward(grownStalkPerBdv, s.ss[C.unripeLPAddress()].lastCumulativeGrownStalkPerBdv, bdv));
         LibSilo.mintStalk(msg.sender, stalk);
         LibTransfer.receiveToken(IERC20(C.unripeLPAddress()), unripeLP, msg.sender, LibTransfer.From.EXTERNAL);
     }
@@ -54,7 +54,7 @@ contract MockSiloFacet is SiloFacet {
         s.a[msg.sender].bean.deposits[grownStalkPerBdv] += amount;
         LibTokenSilo.incrementTotalDeposited(C.unripeBeanAddress(), amount);
         amount = amount.mul(C.initialRecap()).div(1e18);
-        uint256 stalk = amount.mul(s.ss[C.unripeBeanAddress()].stalk).add(LibSilo.stalkReward(grownStalkPerBdv, s.ss[address(token)].lastCumulativeGrownStalkPerBdv, bdv));
+        uint256 stalk = amount.mul(s.ss[C.unripeBeanAddress()].stalk).add(LibSilo.stalkReward(grownStalkPerBdv, s.ss[C.unripeLPAddress()].lastCumulativeGrownStalkPerBdv));
         LibSilo.mintStalk(msg.sender, stalk);
         LibTransfer.receiveToken(IERC20(C.unripeBeanAddress()), amount, msg.sender, LibTransfer.From.EXTERNAL);
     }

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -8,6 +8,7 @@ pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "../../beanstalk/silo/SiloFacet/SiloFacet.sol";
 import "../../libraries/Silo/LibWhitelist.sol";
+import "hardhat/console.sol";
 
 /**
  * @author Publius
@@ -59,8 +60,13 @@ contract MockSiloFacet is SiloFacet {
         s.a[msg.sender].bean.deposits[_s] += amount;
         LibTokenSilo.incrementTotalDeposited(C.unripeBeanAddress(), amount);
         amount = amount.mul(C.initialRecap()).div(1e18);
+        console.log('mockUnripeBeanDeposit amount: ', amount);
         uint256 seeds = amount.mul(s.ss[C.unripeBeanAddress()].legacySeedsPerBdv);
+        console.log('mockUnripeBeanDeposit _season(): ', _season());
+        console.log('mockUnripeBeanDeposit _s: ', _s);
+        console.log('s.ss[C.unripeBeanAddress()].stalkPerBdv: ', s.ss[C.unripeBeanAddress()].stalkPerBdv);
         uint256 stalk = amount.mul(s.ss[C.unripeBeanAddress()].stalkPerBdv).add(LibSilo.stalkRewardLegacy(seeds, _season() - _s));
+        console.log('mockUnripeBeanDeposit stalk: ', stalk);
         LibSilo.mintStalk(msg.sender, stalk);
         uint256 newBdv = s.a[msg.sender].mowStatuses[C.unripeBeanAddress()].bdv.add(amount);
         s.a[msg.sender].mowStatuses[C.unripeBeanAddress()].bdv = uint128(newBdv);

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -22,7 +22,7 @@ contract MockSiloFacet is SiloFacet {
 
     using SafeMath for uint256;
 
-    function mockWhitelistToken(address token, bytes4 selector, uint32 stalk, uint32 stalkPerBdvPerSeason) external {
+    function mockWhitelistToken(address token, bytes4 selector, uint32 stalk, int128 stalkPerBdvPerSeason) external {
        LibWhitelist.whitelistToken(token, selector, stalk, stalkPerBdvPerSeason);
     }
 
@@ -35,7 +35,7 @@ contract MockSiloFacet is SiloFacet {
     }
 
     function mockUnripeLPDeposit(uint256 t, int128 grownStalkPerBdv, uint256 amount, uint256 bdv) external {
-        _mow(msg.sender);
+        _mow(msg.sender, C.unripeLPAddress());
         if (t == 0) {
             s.a[msg.sender].lp.deposits[grownStalkPerBdv] += amount;
         }
@@ -44,7 +44,7 @@ contract MockSiloFacet is SiloFacet {
         uint256 unripeLP = getUnripeForAmount(t, amount);
         LibTokenSilo.incrementTotalDeposited(C.unripeLPAddress(), unripeLP);
         bdv = bdv.mul(C.initialRecap()).div(1e18);
-        uint256 stalk = bdv.mul(s.ss[C.unripeLPAddress()].stalk).add(LibSilo.stalkReward(grownStalkPerBdv, s.ss[C.unripeLPAddress()].lastCumulativeGrownStalkPerBdv, bdv));
+        uint256 stalk = bdv.mul(s.ss[C.unripeLPAddress()].stalkPerBdv).add(LibSilo.stalkReward(grownStalkPerBdv, s.ss[C.unripeLPAddress()].lastCumulativeGrownStalkPerBdv, bdv));
         LibSilo.mintStalk(msg.sender, stalk);
         LibTransfer.receiveToken(IERC20(C.unripeLPAddress()), unripeLP, msg.sender, LibTransfer.From.EXTERNAL);
     }

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -21,6 +21,7 @@ contract MockSiloFacet is SiloFacet {
     uint256 constant private AMOUNT_TO_BDV_BEAN_LUSD = 983108;
 
     using SafeMath for uint256;
+    using SafeMath for uint128;
 
     function mockWhitelistToken(address token, bytes4 selector, uint32 stalk, uint32 stalkPerBdvPerSeason) external {
        LibWhitelist.whitelistToken(token, selector, stalk, stalkPerBdvPerSeason);
@@ -47,19 +48,11 @@ contract MockSiloFacet is SiloFacet {
         bdv = bdv.mul(C.initialRecap()).div(1e18);
         uint256 seeds = bdv.mul(s.ss[C.unripeLPAddress()].legacySeedsPerBdv);
         uint256 stalk = bdv.mul(s.ss[C.unripeLPAddress()].stalkPerBdv).add(LibSilo.stalkRewardLegacy(seeds, _season() - _s));
-        // LibSilo.mintSeedsAndStalk(msg.sender, seeds, stalk);
+        LibSilo.mintStalk(msg.sender, stalk);
+        uint256 newBdv = s.a[msg.sender].mowStatuses[C.unripeLPAddress()].bdv.add(amount);
+        s.a[msg.sender].mowStatuses[C.unripeLPAddress()].bdv = uint128(newBdv);
         LibTransfer.receiveToken(IERC20(C.unripeLPAddress()), unripeLP, msg.sender, LibTransfer.From.EXTERNAL);
     }
-
-/*    function mockUnripeBeanDeposit(int128 grownStalkPerBdv, uint256 amount) external {
-        _mow(msg.sender, C.unripeBeanAddress());
-        s.a[msg.sender].bean.deposits[grownStalkPerBdv] += amount;
-        LibTokenSilo.incrementTotalDeposited(C.unripeBeanAddress(), amount);
-        amount = amount.mul(C.initialRecap()).div(1e18);
-        uint256 stalk = amount.mul(s.ss[C.unripeBeanAddress()].stalkPerBdv).add(LibSilo.stalkRewardLegacy(grownStalkPerBdv, s.ss[C.unripeLPAddress()].lastCumulativeGrownStalkPerBdv));
-        LibSilo.mintStalk(msg.sender, stalk);
-        LibTransfer.receiveToken(IERC20(C.unripeBeanAddress()), amount, msg.sender, LibTransfer.From.EXTERNAL);
-    }*/
 
    function mockUnripeBeanDeposit(uint32 _s, uint256 amount) external {
         _mow(msg.sender, C.unripeBeanAddress());
@@ -68,7 +61,9 @@ contract MockSiloFacet is SiloFacet {
         amount = amount.mul(C.initialRecap()).div(1e18);
         uint256 seeds = amount.mul(s.ss[C.unripeBeanAddress()].legacySeedsPerBdv);
         uint256 stalk = amount.mul(s.ss[C.unripeBeanAddress()].stalkPerBdv).add(LibSilo.stalkRewardLegacy(seeds, _season() - _s));
-        // LibSilo.mintSeedsAndStalk(msg.sender, seeds, stalk);
+        LibSilo.mintStalk(msg.sender, stalk);
+        uint256 newBdv = s.a[msg.sender].mowStatuses[C.unripeBeanAddress()].bdv.add(amount);
+        s.a[msg.sender].mowStatuses[C.unripeBeanAddress()].bdv = uint128(newBdv);
         LibTransfer.receiveToken(IERC20(C.unripeBeanAddress()), amount, msg.sender, LibTransfer.From.EXTERNAL);
     }
 

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -23,8 +23,8 @@ contract MockSiloFacet is SiloFacet {
     using SafeMath for uint256;
     using SafeMath for uint128;
 
-    function mockWhitelistToken(address token, bytes4 selector, uint32 stalk, uint32 stalkPerBdvPerSeason) external {
-       LibWhitelist.whitelistToken(token, selector, stalk, stalkPerBdvPerSeason);
+    function mockWhitelistToken(address token, bytes4 selector, uint32 stalk, uint32 stalkPerBdvPerSeason, uint32 legacySeedsPerBdv) external {
+       LibWhitelist.whitelistTokenLegacy(token, selector, stalk, stalkPerBdvPerSeason, legacySeedsPerBdv);
     }
 
     function mockBDV(uint256 amount) external pure returns (uint256) {

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -152,8 +152,8 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, __, runSuper
   paths = paths.filter((p) => !p.includes("replant"));
   paths = paths.filter((p) => !p.includes("InitWhitelist"));
   paths = paths.filter((p) => !p.includes("Root.sol"));
-  paths = paths.filter((p) => !p.includes("MockSiloFacet"));
-  paths = paths.filter((p) => !p.includes("MockConvertFacet"));
+  // paths = paths.filter((p) => !p.includes("MockSiloFacet"));
+  // paths = paths.filter((p) => !p.includes("MockConvertFacet"));
   return paths;
 });
 

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -146,7 +146,7 @@ task('marketplace', async function () {
 // Add a subtask that sets the action for the TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS task
 subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, __, runSuper) => {
   // Get the list of source paths that would normally be passed to the Solidity compiler
-  const paths = await runSuper();
+  var paths = await runSuper();
 
   // Apply a filter function to exclude paths that contain the string "replant" to ignore replant code
   paths = paths.filter((p) => !p.includes("replant"));

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -150,7 +150,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, __, runSuper
 
   // Apply a filter function to exclude paths that contain the string "replant" to ignore replant code
   paths = paths.filter((p) => !p.includes("replant"));
-  paths = paths.filter((p) => !p.includes("InitWhitelist"));
+  // paths = paths.filter((p) => !p.includes("InitWhitelist"));
   paths = paths.filter((p) => !p.includes("Root.sol"));
   // paths = paths.filter((p) => !p.includes("MockSiloFacet"));
   // paths = paths.filter((p) => !p.includes("MockConvertFacet"));

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -149,7 +149,9 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, __, runSuper
   const paths = await runSuper();
 
   // Apply a filter function to exclude paths that contain the string "replant" to ignore replant code
-  return paths.filter((p) => !p.includes("replant"));
+  paths = paths.filter((p) => !p.includes("replant"));
+  paths = paths.filter((p) => !p.includes("InitWhitelist"));
+  return paths;
 });
 
 //////////////////////// CONFIGURATION ////////////////////////

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -151,6 +151,9 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, __, runSuper
   // Apply a filter function to exclude paths that contain the string "replant" to ignore replant code
   paths = paths.filter((p) => !p.includes("replant"));
   paths = paths.filter((p) => !p.includes("InitWhitelist"));
+  paths = paths.filter((p) => !p.includes("Root.sol"));
+  paths = paths.filter((p) => !p.includes("MockSiloFacet"));
+  paths = paths.filter((p) => !p.includes("MockConvertFacet"));
   return paths;
 });
 

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -14,8 +14,9 @@ const { impersonateSigner, mintUsdc, mintBeans, getBeanMetapool, getUsdc, getBea
 const { EXTERNAL, INTERNAL, INTERNAL_EXTERNAL, INTERNAL_TOLERANT } = require('./test/utils/balances.js')
 const { BEANSTALK, PUBLIUS, BEAN_3_CURVE } = require('./test/utils/constants.js')  
 const { to6 } = require('./test/utils/helpers.js')
-const { replant } = require("./replant/replant.js")
+//const { replant } = require("./replant/replant.js")
 const { task } = require("hardhat/config")
+const { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } = require("hardhat/builtin-tasks/task-names");
 
 //////////////////////// UTILITIES ////////////////////////
 
@@ -63,10 +64,10 @@ task('sunrise', async function () {
   await beanstalkAdmin.forceSunrise()
 })
 
-task('replant', async () => {
+/*task('replant', async () => {
   const account = await impersonateSigner(PUBLIUS)
   await replant(account)
-})
+})*/
 
 task('diamondABI', 'Generates ABI file for diamond, includes all ABIs of facets', async () => {
   const basePath = '/contracts/beanstalk/';
@@ -139,6 +140,17 @@ task('marketplace', async function () {
     account: owner
   });
 })
+
+//////////////////////// SUBTASK CONFIGURATION ////////////////////////
+
+// Add a subtask that sets the action for the TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS task
+subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, __, runSuper) => {
+  // Get the list of source paths that would normally be passed to the Solidity compiler
+  const paths = await runSuper();
+
+  // Apply a filter function to exclude paths that contain the string "replant" to ignore replant code
+  return paths.filter((p) => !p.includes("replant"));
+});
 
 //////////////////////// CONFIGURATION ////////////////////////
 

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -150,10 +150,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, __, runSuper
 
   // Apply a filter function to exclude paths that contain the string "replant" to ignore replant code
   paths = paths.filter((p) => !p.includes("replant"));
-  // paths = paths.filter((p) => !p.includes("InitWhitelist"));
   paths = paths.filter((p) => !p.includes("Root.sol"));
-  // paths = paths.filter((p) => !p.includes("MockSiloFacet"));
-  // paths = paths.filter((p) => !p.includes("MockConvertFacet"));
   return paths;
 });
 

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -29,6 +29,7 @@
     "solidity-coverage": "^0.7.21"
   },
   "dependencies": {
+    "@nomicfoundation/hardhat-network-helpers": "^1.0.7",
     "@openzeppelin/contracts": "^3.4.0",
     "@openzeppelin/contracts-upgradeable": "^3.4.0",
     "@openzeppelin/contracts-upgradeable-8": "npm:@openzeppelin/contracts-upgradeable@^4.7.3",

--- a/protocol/scripts/bips.js
+++ b/protocol/scripts/bips.js
@@ -31,4 +31,24 @@ async function bip29(mock = true, account = undefined) {
       });
 }
 
+async function bipNewSilo(mock = true, account = undefined) {
+    if (account == undefined) {
+        account = await impersonateBeanstalkOwner()
+        await mintEth(account.address)
+    }
+
+    beanstalk = await getBeanstalk()
+    await upgradeWithNewFacets({
+        diamondAddress: BEANSTALK,
+        facetNames: [
+            'SiloFacet', 'ConvertFacet', 'WhitelistFacet'
+        ],
+        bip: false,
+        object: !mock, //if this is true, something would get spit out in the diamond cuts folder with all the data (due to gnosis safe deployment flow)
+        verbose: true,
+        account: account
+      });
+}
+
 exports.bip29 = bip29
+exports.bipNewSilo = bipNewSilo

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -43,16 +43,14 @@ describe('Convert', function () {
     await this.bean.connect(user2).approve(this.silo.address, '100000000000'); 
     await this.siloToken.connect(user).approve(this.silo.address, '100000000000');
     await this.siloToken.mint(userAddress, '10000');
-    console.log('start season: ', await this.season.season());
-    console.log('totalstalk 2: ', await this.silo.totalStalk());
+    await this.season.teleportSunrise(10);
     await this.season.siloSunrise(0);
-    console.log('totalstalk 3: ', await this.silo.totalStalk());
+
     await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL);
-    console.log('totalstalk 3a: ', await this.silo.totalStalk());
+
     await this.season.siloSunrise(0);
-    console.log('totalstalk 4: ', await this.silo.totalStalk());
+
     await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL); //something about this deposit adds extra stalk
-    console.log('totalstalk 5: ', await this.silo.totalStalk());
   });
 
   beforeEach(async function () {
@@ -71,8 +69,8 @@ describe('Convert', function () {
 
       it('crate balance too low', async function () {
         //params are token, grownStalkPerBdv, amounts, maxtokens
-        // await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.') //TODOSEEDS write a test that reverts with Silo: Crate balance too low.
-        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Must line up with season')
+        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.') //TODOSEEDS write a test that reverts with Silo: Crate balance too low.
+        // await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Must line up with season')
       });
 
       it('not enough removed', async function () {
@@ -283,9 +281,6 @@ describe('Convert', function () {
 
     describe('Deposit Tokens more grown', async function () {
       beforeEach(async function () {
-        //current season
-        console.log('this.season.season(): ', await this.season.season());
-        
         this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '250');
       });
 

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -55,7 +55,7 @@ describe('Convert', function () {
   describe('Withdraw For Convert', async function () {
     describe("Revert", async function () {
       it('diff lengths', async function () {
-        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2', '3'], ['100'], '100')).to.be.revertedWith('Convert: seasons, amounts are diff lengths.')
+        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2', '3'], ['100'], '100')).to.be.revertedWith('Convert: cumulativeGrownStalks, amounts are diff lengths.')
       });
 
       it('crate balance too low', async function () {
@@ -79,12 +79,12 @@ describe('Convert', function () {
       it('Decrements totals', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('100');
         expect(await this.silo.totalStalk()).to.equal('1000100');
-        expect(await this.silo.totalSeeds()).to.equal('100');
+        //expect(await this.silo.totalSeeds()).to.equal('100');
       })
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
       })
 
       it('properly removes the crate', async function () {
@@ -110,12 +110,12 @@ describe('Convert', function () {
       it('Decrements totals', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('100');
         expect(await this.silo.totalStalk()).to.equal('1000100');
-        expect(await this.silo.totalSeeds()).to.equal('100');
+        //expect(await this.silo.totalSeeds()).to.equal('100');
       })
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
       })
 
       it('properly removes the crate', async function () {
@@ -141,12 +141,12 @@ describe('Convert', function () {
       it('Decrements totals', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('50');
         expect(await this.silo.totalStalk()).to.equal('500000');
-        expect(await this.silo.totalSeeds()).to.equal('50');
+        //expect(await this.silo.totalSeeds()).to.equal('50');
       })
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
       })
 
       it('properly removes the crate', async function () {
@@ -172,12 +172,12 @@ describe('Convert', function () {
       it('Decrements totals', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('50');
         expect(await this.silo.totalStalk()).to.equal('500000');
-        expect(await this.silo.totalSeeds()).to.equal('50');
+        //expect(await this.silo.totalSeeds()).to.equal('50');
       })
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
       })
 
       it('properly removes the crate', async function () {
@@ -214,12 +214,12 @@ describe('Convert', function () {
       it('Decrements totals', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
         expect(await this.silo.totalStalk()).to.equal('3000100');
-        expect(await this.silo.totalSeeds()).to.equal('300');
+        //expect(await this.silo.totalSeeds()).to.equal('300');
       })
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000000');
-        // expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
       })
 
       it('properly removes the crate', async function () {
@@ -241,12 +241,12 @@ describe('Convert', function () {
       it('Decrements totals', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
         expect(await this.silo.totalStalk()).to.equal('3000200');
-        expect(await this.silo.totalSeeds()).to.equal('300');
+        //expect(await this.silo.totalSeeds()).to.equal('300');
       })
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000100');
-        // expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
       })
 
       it('properly removes the crate', async function () {
@@ -268,12 +268,12 @@ describe('Convert', function () {
       it('Decrements totals', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
         expect(await this.silo.totalStalk()).to.equal('3000300');
-        expect(await this.silo.totalSeeds()).to.equal('300');
+        //expect(await this.silo.totalSeeds()).to.equal('300');
       })
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000200');
-        // expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
       })
 
       it('properly removes the crate', async function () {
@@ -321,13 +321,13 @@ describe('Convert', function () {
 
     it('Decrements balances', async function () {
       expect(await this.silo.balanceOfStalk(userAddress)).to.equal('2000000');
-      // expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('200');
+      //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('200');
     })
 
     it('Decrements totals', async function () {
       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('200');
       expect(await this.silo.totalStalk()).to.equal('2000000');
-      expect(await this.silo.totalSeeds()).to.equal('200');
+      //expect(await this.silo.totalSeeds()).to.equal('200');
     })
 
     it('Emits events', async function () {

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -84,7 +84,7 @@ describe('Convert', function () {
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
       })
 
       it('properly removes the crate', async function () {
@@ -115,7 +115,7 @@ describe('Convert', function () {
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
       })
 
       it('properly removes the crate', async function () {
@@ -146,7 +146,7 @@ describe('Convert', function () {
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
       })
 
       it('properly removes the crate', async function () {
@@ -177,7 +177,7 @@ describe('Convert', function () {
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
       })
 
       it('properly removes the crate', async function () {
@@ -219,7 +219,7 @@ describe('Convert', function () {
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000000');
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+        // expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
       })
 
       it('properly removes the crate', async function () {
@@ -246,7 +246,7 @@ describe('Convert', function () {
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000100');
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+        // expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
       })
 
       it('properly removes the crate', async function () {
@@ -273,7 +273,7 @@ describe('Convert', function () {
 
       it('Decrements balances', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000200');
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+        // expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
       })
 
       it('properly removes the crate', async function () {
@@ -321,7 +321,7 @@ describe('Convert', function () {
 
     it('Decrements balances', async function () {
       expect(await this.silo.balanceOfStalk(userAddress)).to.equal('2000000');
-      expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('200');
+      // expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('200');
     })
 
     it('Decrements totals', async function () {

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -29,6 +29,7 @@ describe('Convert', function () {
       this.siloToken.address, 
       this.silo.interface.getSighash("mockBDV(uint256 amount)"), 
       '10000', 
+      1e6, //aka "1 seed"
       '1'
     );
 
@@ -58,20 +59,21 @@ describe('Convert', function () {
         await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2', '3'], ['100'], '100')).to.be.revertedWith('Convert: cumulativeGrownStalks, amounts are diff lengths.')
       });
 
-      it.only('crate balance too low', async function () {
-        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.')
+      it('crate balance too low', async function () {
+        //params are token, grownStalkPerBdv, amounts, maxtokens
+        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.')
       });
 
       it('not enough removed', async function () {
-        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['100'], '150')).to.be.revertedWith('Convert: Not enough tokens removed.')
+        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2000000'], ['100'], '150')).to.be.revertedWith('Convert: Not enough tokens removed.')
       });
     })
     describe("Withdraw 1 Crate", async function () {
       beforeEach(async function () {
-        this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['3'], ['100'], '100');
+        this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2000000'], ['100'], '100');
       })
 
-      it('Emits event', async function () {
+      it.only('Emits event', async function () {
         await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [3], ['100'], '100');
         await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
       })

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -85,7 +85,7 @@ describe('Convert', function () {
       })
 
       it('Emits event', async function () {
-        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2], ['100'], '100');
+        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2], ['100'], '100', ['100']);
         await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
       })
 
@@ -119,7 +119,7 @@ describe('Convert', function () {
       })
 
       it('Emits event', async function () {
-        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2, 1], ['100', '0'], '100');
+        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2, 1], ['100', '0'], '100',['100', '0'] );
         await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
       })
 
@@ -184,7 +184,7 @@ describe('Convert', function () {
       })
 
       it('Emits event', async function () { 
-        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100','50'], '150');
+        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100','50'], '150', ['100','50']);
         await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('100', '150');
       })
 
@@ -357,7 +357,7 @@ describe('Convert', function () {
     })
 
     it('Emits events', async function () {
-      await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '100'], '200');
+      await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '100'], '200', ['100', '100']);
       await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, this.siloToken.address, 2, '200', '200');
     })
   })

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -7,7 +7,7 @@ const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot");
 
 let user,user2,owner;
 let userAddress, ownerAddress, user2Address;
-describe.only('Convert', function () {
+describe('Convert', function () {
   before(async function () {
     [owner,user,user2] = await ethers.getSigners();
     userAddress = user.address;

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -7,7 +7,7 @@ const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot");
 
 let user,user2,owner;
 let userAddress, ownerAddress, user2Address;
-describe('Convert', function () {
+describe.only('Convert', function () {
   before(async function () {
     [owner,user,user2] = await ethers.getSigners();
     userAddress = user.address;
@@ -66,7 +66,7 @@ describe('Convert', function () {
   describe('Withdraw For Convert', async function () {
     describe("Revert", async function () {
       it('diff lengths', async function () {
-        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2', '3'], ['100'], '100')).to.be.revertedWith('Convert: cumulativeGrownStalks, amounts are diff lengths.')
+        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100'], '100')).to.be.revertedWith('Convert: grownStalkPerBdvs, amounts are diff lengths.')
       });
 
       it('crate balance too low', async function () {
@@ -296,7 +296,7 @@ describe('Convert', function () {
         await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 0, '100', '100');
       })
 
-      it.only('Decrements totals', async function () {
+      it('Decrements totals', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
         expect(await this.silo.totalStalk()).to.equal('3000300');
         //expect(await this.silo.totalSeeds()).to.equal('300');
@@ -308,7 +308,7 @@ describe('Convert', function () {
       })
 
       it('properly removes the crate', async function () {
-        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 1);
+        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 0);
         expect(deposit[0]).to.eq('100');
         expect(deposit[1]).to.eq('100');
       })
@@ -322,10 +322,10 @@ describe('Convert', function () {
           '100',
           this.siloToken.address
         ),
-        ['3'],
+        ['2'],
         ['100']
       )
-      expect(this.result.toSeason).to.be.equal(3)
+      expect(this.result.toCumulativeGrownStalk).to.be.equal(2)
       expect(this.result.toAmount).to.be.equal('100')
     })
 
@@ -335,17 +335,17 @@ describe('Convert', function () {
           '200',
           this.siloToken.address
         ),
-        ['2', '3'],
+        ['1', '2'],
         ['100', '100']
       )
     })
 
     it('removes and adds deposit', async function () {
-      let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+      let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
       expect(deposit[0]).to.eq('0');
       expect(deposit[1]).to.eq('0');
 
-      deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 3);
+      deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
       expect(deposit[0]).to.eq('200');
       expect(deposit[1]).to.eq('200');
     })
@@ -362,8 +362,8 @@ describe('Convert', function () {
     })
 
     it('Emits events', async function () {
-      await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2, 3], ['100', '100'], '200');
-      await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, this.siloToken.address, 3, '200', '200');
+      await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '100'], '200');
+      await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, this.siloToken.address, 2, '200', '200');
     })
   })
 });

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -58,7 +58,7 @@ describe('Convert', function () {
         await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2', '3'], ['100'], '100')).to.be.revertedWith('Convert: cumulativeGrownStalks, amounts are diff lengths.')
       });
 
-      it('crate balance too low', async function () {
+      it.only('crate balance too low', async function () {
         await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.')
       });
 

--- a/protocol/test/ConvertCurve.test.js
+++ b/protocol/test/ConvertCurve.test.js
@@ -139,7 +139,7 @@ describe('Curve Convert', function () {
         });
 
         it('properly updates user values', async function () {
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('600'));
+          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('600'));
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200'));
         });
 
@@ -186,7 +186,7 @@ describe('Curve Convert', function () {
         });
 
         it('properly updates user values', async function () {
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('1000'));
+          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('1000'));
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('300'));
         });
 
@@ -226,7 +226,7 @@ describe('Curve Convert', function () {
         });
 
         it('properly updates user values', async function () {
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
+          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200'));
         });
 
@@ -267,7 +267,7 @@ describe('Curve Convert', function () {
         });
 
         it('properly updates user values', async function () {
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
+          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200.08'));
         });
 
@@ -311,7 +311,7 @@ describe('Curve Convert', function () {
         });
 
         it('properly updates user values', async function () {
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
+          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200.08'));
         });
 
@@ -380,7 +380,7 @@ describe('Curve Convert', function () {
         });
 
         it('properly updates user values', async function () {
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
+          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10006181670000');
         });
 
@@ -430,7 +430,7 @@ describe('Curve Convert', function () {
         });
 
         it('properly updates user values', async function () {
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3603293346');
+          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3603293346');
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10008324310000');
         });
 
@@ -477,7 +477,7 @@ describe('Curve Convert', function () {
         });
 
         it('properly updates user values', async function () {
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
+          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10009982906334');
         });
 
@@ -523,7 +523,7 @@ describe('Curve Convert', function () {
         });
 
         it('properly updates user values', async function () {
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
+          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10007981670000');
         });
 

--- a/protocol/test/ConvertCurve.test.js
+++ b/protocol/test/ConvertCurve.test.js
@@ -134,12 +134,12 @@ describe('Curve Convert', function () {
         it('properly updates total values', async function () {
           expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq(toBean('100'));
           expect(await this.silo.getTotalDeposited(this.beanMetapool.address)).to.eq('100634476734756985505');
-          expect(await this.silo.totalSeeds()).to.eq(toBean('600'));
+          //expect(await this.silo.totalSeeds()).to.eq(toBean('600'));
           expect(await this.silo.totalStalk()).to.eq(toStalk('200'));
         });
 
         it('properly updates user values', async function () {
-          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('600'));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('600'));
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200'));
         });
 
@@ -181,12 +181,12 @@ describe('Curve Convert', function () {
         it('properly updates total values', async function () {
           expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq(toBean('100'));
           expect(await this.silo.getTotalDeposited(this.beanMetapool.address)).to.eq('200832430692705624354');
-          expect(await this.silo.totalSeeds()).to.eq(toBean('1000'));
+          //expect(await this.silo.totalSeeds()).to.eq(toBean('1000'));
           expect(await this.silo.totalStalk()).to.eq(toStalk('300'));
         });
 
         it('properly updates user values', async function () {
-          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('1000'));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('1000'));
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('300'));
         });
 
@@ -221,12 +221,12 @@ describe('Curve Convert', function () {
         it('properly updates total values', async function () {
           expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq(toBean('0'));
           expect(await this.silo.getTotalDeposited(this.beanMetapool.address)).to.eq('200832430692705624354');
-          expect(await this.silo.totalSeeds()).to.eq(toBean('800'));
+          //expect(await this.silo.totalSeeds()).to.eq(toBean('800'));
           expect(await this.silo.totalStalk()).to.eq(toStalk('200'));
         });
 
         it('properly updates user values', async function () {
-          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200'));
         });
 
@@ -262,12 +262,12 @@ describe('Curve Convert', function () {
         it('properly updates total values', async function () {
           expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq(toBean('0'));
           expect(await this.silo.getTotalDeposited(this.beanMetapool.address)).to.eq('200832430692705624354');
-          expect(await this.silo.totalSeeds()).to.eq(toBean('800'));
+          //expect(await this.silo.totalSeeds()).to.eq(toBean('800'));
           expect(await this.silo.totalStalk()).to.eq(toStalk('200.08'));
         });
 
         it('properly updates user values', async function () {
-          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200.08'));
         });
 
@@ -306,12 +306,12 @@ describe('Curve Convert', function () {
         it('properly updates total values', async function () {
           expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq(toBean('0'));
           expect(await this.silo.getTotalDeposited(this.beanMetapool.address)).to.eq('200832430692705624354');
-          expect(await this.silo.totalSeeds()).to.eq(toBean('800'));
+          //expect(await this.silo.totalSeeds()).to.eq(toBean('800'));
           expect(await this.silo.totalStalk()).to.eq(toStalk('200.08'));
         });
 
         it('properly updates user values', async function () {
-          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200.08'));
         });
 
@@ -375,12 +375,12 @@ describe('Curve Convert', function () {
         it('properly updates total values', async function () {
           expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq('100618167');
           expect(await this.silo.getTotalDeposited(this.beanMetapool.address)).to.eq(to18('900'));
-          expect(await this.silo.totalSeeds()).to.eq('3801236334');
+          //expect(await this.silo.totalSeeds()).to.eq('3801236334');
           expect(await this.silo.totalStalk()).to.eq('10006181670000');
         });
 
         it('properly updates user values', async function () {
-          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10006181670000');
         });
 
@@ -425,12 +425,12 @@ describe('Curve Convert', function () {
         it('properly updates total values', async function () {
           expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq('200018189');
           expect(await this.silo.getTotalDeposited(this.beanMetapool.address)).to.eq('800814241685186471402');
-          expect(await this.silo.totalSeeds()).to.eq('3603293346');
+          //expect(await this.silo.totalSeeds()).to.eq('3603293346');
           expect(await this.silo.totalStalk()).to.eq('10008324310000');
         });
 
         it('properly updates user values', async function () {
-          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3603293346');
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3603293346');
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10008324310000');
         });
 
@@ -472,12 +472,12 @@ describe('Curve Convert', function () {
         it('properly updates total values', async function () {
           expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq('100618167');
           expect(await this.silo.getTotalDeposited(this.beanMetapool.address)).to.eq(to18('900'));
-          expect(await this.silo.totalSeeds()).to.eq('3801236334');
+          //expect(await this.silo.totalSeeds()).to.eq('3801236334');
           expect(await this.silo.totalStalk()).to.eq('10009982906334');
         });
 
         it('properly updates user values', async function () {
-          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10009982906334');
         });
 
@@ -518,12 +518,12 @@ describe('Curve Convert', function () {
         it('properly updates total values', async function () {
           expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq('100618167');
           expect(await this.silo.getTotalDeposited(this.beanMetapool.address)).to.eq(to18('900'));
-          expect(await this.silo.totalSeeds()).to.eq('3801236334');
+          //expect(await this.silo.totalSeeds()).to.eq('3801236334');
           expect(await this.silo.totalStalk()).to.eq('10007981670000');
         });
 
         it('properly updates user values', async function () {
-          // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10007981670000');
         });
 

--- a/protocol/test/ConvertCurve.test.js
+++ b/protocol/test/ConvertCurve.test.js
@@ -164,7 +164,7 @@ describe('Curve Convert', function () {
           const grownStalkPerBdvBean = await this.silo.seasonToGrownStalkPerBdv(this.bean.address, '12');
           const grownStalkPerBdvMetapool = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '12');
           await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-            .withArgs(userAddress, this.bean.address, [grownStalkPerBdvBean], [toBean('100')], toBean('100'));
+            .withArgs(userAddress, this.bean.address, [grownStalkPerBdvBean], [toBean('100')], toBean('100'), [toBean('100')]);
           await expect(this.result).to.emit(this.silo, 'AddDeposit')
             .withArgs(userAddress, this.beanMetapool.address, grownStalkPerBdvMetapool, '100634476734756985505', toBean('100'));
         });
@@ -216,7 +216,7 @@ describe('Curve Convert', function () {
         it('emits events', async function () {
           const grownStalkPerBdvBean = await this.silo.seasonToGrownStalkPerBdv(this.bean.address, '12');
           await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-            .withArgs(userAddress, this.bean.address, [grownStalkPerBdvBean], [toBean('200')], toBean('200'));
+            .withArgs(userAddress, this.bean.address, [grownStalkPerBdvBean], [toBean('200')], toBean('200'), [toBean('200')]);
             const grownStalkPerBdvMetapool = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '12');
           await expect(this.result).to.emit(this.silo, 'AddDeposit')
             .withArgs(userAddress, this.beanMetapool.address, grownStalkPerBdvMetapool, '200832430692705624354', toBean('200'));
@@ -263,7 +263,7 @@ describe('Curve Convert', function () {
         it('emits events', async function () {
           const grownStalkPerBdvBean = await this.silo.seasonToGrownStalkPerBdv(this.bean.address, '12');
           await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-            .withArgs(userAddress, this.bean.address, [grownStalkPerBdvBean], [toBean('200')], toBean('200'));
+            .withArgs(userAddress, this.bean.address, [grownStalkPerBdvBean], [toBean('200')], toBean('200'), [toBean('200')]);
           const grownStalkPerBdvMetapool = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '12');
           await expect(this.result).to.emit(this.silo, 'AddDeposit')
             .withArgs(userAddress, this.beanMetapool.address, grownStalkPerBdvMetapool, '200832430692705624354', toBean('200'));
@@ -313,7 +313,7 @@ describe('Curve Convert', function () {
         it('emits events', async function () {
           const grownStalkPerBdvBean = await this.silo.seasonToGrownStalkPerBdv(this.bean.address, '12');
           await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-            .withArgs(userAddress, this.bean.address, [grownStalkPerBdvBean], [toBean('200')], toBean('200'));
+            .withArgs(userAddress, this.bean.address, [grownStalkPerBdvBean], [toBean('200')], toBean('200'), [toBean('200')]);
             const grownStalkPerBdvMetapool = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '13');
           await expect(this.result).to.emit(this.silo, 'AddDeposit')
             .withArgs(userAddress, this.beanMetapool.address, grownStalkPerBdvMetapool, '200832430692705624354', toBean('200'));
@@ -368,7 +368,7 @@ describe('Curve Convert', function () {
           const grownStalkPerBdvBean10 = await this.silo.seasonToGrownStalkPerBdv(this.bean.address, '10');
           const grownStalkPerBdvBean14 = await this.silo.seasonToGrownStalkPerBdv(this.bean.address, '14');
           await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-            .withArgs(userAddress, this.bean.address, [grownStalkPerBdvBean10, grownStalkPerBdvBean14], [toBean('100'), toBean('100')], toBean('200'));
+            .withArgs(userAddress, this.bean.address, [grownStalkPerBdvBean10, grownStalkPerBdvBean14], [toBean('100'), toBean('100')], toBean('200'), [toBean('100'), toBean('100')]);
           await expect(this.result).to.emit(this.silo, 'AddDeposit')
             .withArgs(userAddress, this.beanMetapool.address, 12, '200832430692705624354', toBean('200'));
         });
@@ -449,7 +449,7 @@ describe('Curve Convert', function () {
           const grownStalkPerBdvMetapool = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
           const grownStalkPerBdvBean = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
           await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-            .withArgs(userAddress, this.beanMetapool.address, [grownStalkPerBdvMetapool], [to18('100')], to18('100'));
+            .withArgs(userAddress, this.beanMetapool.address, [grownStalkPerBdvMetapool], [to18('100')], to18('100'), [toBean('100')]);
           await expect(this.result).to.emit(this.silo, 'AddDeposit')
             .withArgs(userAddress, this.bean.address, grownStalkPerBdvBean, '100618167', '100618167');
         });
@@ -505,7 +505,7 @@ describe('Curve Convert', function () {
           const grownStalkPerBdvMetapool = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
           const grownStalkPerBdvBean = await this.silo.seasonToGrownStalkPerBdv(this.bean.address, '10');
           await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-            .withArgs(userAddress, this.beanMetapool.address, [grownStalkPerBdvMetapool], ['199185758314813528598'], '199185758314813528598');
+            .withArgs(userAddress, this.beanMetapool.address, [grownStalkPerBdvMetapool], ['199185758314813528598'], '199185758314813528598', ['199185758']);
           await expect(this.result).to.emit(this.silo, 'AddDeposit')
             .withArgs(userAddress, this.bean.address, grownStalkPerBdvBean, '200018189', '200018189');
         });
@@ -558,7 +558,7 @@ describe('Curve Convert', function () {
           const grownStalkPerBdvMetapool = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
           const grownStalkPerBdvBean = await this.silo.seasonToGrownStalkPerBdv(this.bean.address, '10');
           await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-            .withArgs(userAddress, this.beanMetapool.address, [grownStalkPerBdvMetapool], [to18('100')], to18('100'));
+            .withArgs(userAddress, this.beanMetapool.address, [grownStalkPerBdvMetapool], [to18('100')], to18('100'), [toBean('100')]);
           await expect(this.result).to.emit(this.silo, 'AddDeposit')
             .withArgs(userAddress, this.bean.address, -1, '100618167', '100618167');
         });
@@ -610,7 +610,7 @@ describe('Curve Convert', function () {
           const grownStalkPerBdvMetapool11 = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '11');
 
           await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-            .withArgs(userAddress, this.beanMetapool.address, [grownStalkPerBdvMetapool10, grownStalkPerBdvMetapool11], [to18('50'), to18('50')], to18('100'));
+            .withArgs(userAddress, this.beanMetapool.address, [grownStalkPerBdvMetapool10, grownStalkPerBdvMetapool11], [to18('50'), to18('50')], to18('100'), [toBean('50'), toBean('50')]);
           await expect(this.result).to.emit(this.silo, 'AddDeposit')
             .withArgs(userAddress, this.bean.address, 1, '100618167', '100618167');
         });

--- a/protocol/test/ConvertCurve.test.js
+++ b/protocol/test/ConvertCurve.test.js
@@ -335,7 +335,7 @@ describe('Curve Convert', function () {
 
       describe('it converts', async function () {
         beforeEach(async function () {
-          console.log('0 current season: ', await this.season.season());
+          // console.log('0 current season: ', await this.season.season());
           const grownStalkPerBdvBean10 = await this.silo.seasonToGrownStalkPerBdv(this.bean.address, '10');
           const grownStalkPerBdvBean14 = await this.silo.seasonToGrownStalkPerBdv(this.bean.address, '14');
           this.result = await this.convert.connect(user).convert(ConvertEncoder.convertBeansToCurveLP(toBean('250'), to18('190'), this.beanMetapool.address), [grownStalkPerBdvBean10, grownStalkPerBdvBean14], [toBean('100'), toBean('100')])
@@ -527,7 +527,7 @@ describe('Curve Convert', function () {
 
       describe('it converts', async function () {
         beforeEach(async function () {
-          console.log('0 current season: ', await this.season.season());
+          // console.log('0 current season: ', await this.season.season());
           const grownStalkPerBdvMetapool = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
           this.result = await this.convert.connect(user).convert(ConvertEncoder.convertCurveLPToBeans(to18('100'), toBean('99'), this.beanMetapool.address), [grownStalkPerBdvMetapool], [to18('100')])
         });
@@ -565,7 +565,7 @@ describe('Curve Convert', function () {
       });
     });
 
-    describe.only('multiple crates', function () {
+    describe('multiple crates', function () {
       beforeEach(async function () {
         await this.season.teleportSunrise(10);
         await this.beanMetapool.connect(user).add_liquidity([toBean('200'), to18('0')], to18('150'));
@@ -582,25 +582,24 @@ describe('Curve Convert', function () {
       describe('it converts', async function () {
         beforeEach(async function () {
           const grownStalkPerBdvMetapool10 = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
-          const grownStalkPerBdvMetapool11 = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
+          const grownStalkPerBdvMetapool11 = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '11');
           this.result = await this.convert.connect(user).convert(ConvertEncoder.convertCurveLPToBeans(to18('100'), toBean('99'), this.beanMetapool.address), [grownStalkPerBdvMetapool10, grownStalkPerBdvMetapool11], [to18('50'), to18('50')])
         });
 
         it('properly updates total values', async function () {
           expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq('100618167');
           expect(await this.silo.getTotalDeposited(this.beanMetapool.address)).to.eq(to18('900'));
-          //expect(await this.silo.totalSeeds()).to.eq('3801236334');
-          expect(await this.silo.totalStalk()).to.eq('10007981670000');
+          expect(await this.silo.totalStalk()).to.eq('10008082288167'); //updated from 10007981670000 for season based system
         });
 
         it('properly updates user values', async function () {
-          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('3801236334');
-          expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10007981670000');
+          expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10008082288167');
         });
 
         it('properly updates user deposits', async function () {
           const grownStalkPerBdvMetapool10 = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
-          expect((await this.silo.getDeposit(userAddress, this.bean.address, 3))[0]).to.eq('100618167');
+          const grownStalkPerBdvBean10 = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
+          expect((await this.silo.getDeposit(userAddress, this.bean.address, 1))[0]).to.eq('100618167');
           const deposit = await this.silo.getDeposit(userAddress, this.beanMetapool.address, grownStalkPerBdvMetapool10);
           expect(deposit[0]).to.eq(to18('450'));
           expect(deposit[1]).to.eq(toBean('450'));
@@ -608,11 +607,12 @@ describe('Curve Convert', function () {
 
         it('emits events', async function () {
           const grownStalkPerBdvMetapool10 = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
-          const grownStalkPerBdvMetapool11 = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '10');
+          const grownStalkPerBdvMetapool11 = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, '11');
+
           await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
             .withArgs(userAddress, this.beanMetapool.address, [grownStalkPerBdvMetapool10, grownStalkPerBdvMetapool11], [to18('50'), to18('50')], to18('100'));
           await expect(this.result).to.emit(this.silo, 'AddDeposit')
-            .withArgs(userAddress, this.bean.address, grownStalkPerBdvMetapool11, '100618167', '100618167');
+            .withArgs(userAddress, this.bean.address, 1, '100618167', '100618167');
         });
       });
     });

--- a/protocol/test/ConvertUnripe.test.js
+++ b/protocol/test/ConvertUnripe.test.js
@@ -159,7 +159,7 @@ describe('Unripe Convert', function () {
 
       it('emits events', async function () {
         await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-          .withArgs(userAddress, this.unripeBean.address, [0], [to6('1000')], to6('1000'));
+          .withArgs(userAddress, this.unripeBean.address, [0], [to6('1000')], to6('1000'), [to6('100')]);
         await expect(this.result).to.emit(this.silo, 'AddDeposit')
           .withArgs(userAddress, this.unripeLP.address, 0, '1006344767', toBean('100'));
       });
@@ -203,7 +203,7 @@ describe('Unripe Convert', function () {
       it('emits events', async function () {
         const grownStalkPerBdvUnripeBean = await this.silo.seasonToGrownStalkPerBdv(this.unripeBean.address, '14');
         await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-          .withArgs(userAddress, this.unripeBean.address, [0, grownStalkPerBdvUnripeBean], [to6('1000'), to6('1000')], to6('2000'));
+          .withArgs(userAddress, this.unripeBean.address, [0, grownStalkPerBdvUnripeBean], [to6('1000'), to6('1000')], to6('2000'), [to6('100'), to6('100')]);
         await expect(this.result).to.emit(this.silo, 'AddDeposit')
           .withArgs(userAddress, this.unripeLP.address, 12, '2008324306', toBean('200'));
       });
@@ -242,7 +242,7 @@ describe('Unripe Convert', function () {
 
       it('emits events', async function () {
         await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-          .withArgs(userAddress, this.unripeBean.address, [0], [to6('500')], to6('500'));
+          .withArgs(userAddress, this.unripeBean.address, [0], [to6('500')], to6('500'), [to6('100')]);
         await expect(this.result).to.emit(this.silo, 'AddDeposit')
           .withArgs(userAddress, this.unripeLP.address, 0, '503172383', toBean('100'));
       });
@@ -279,7 +279,7 @@ describe('Unripe Convert', function () {
 
       it('emits events', async function () {
         await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-          .withArgs(userAddress, this.unripeBean.address, [0], [to6('500')], to6('500'));
+          .withArgs(userAddress, this.unripeBean.address, [0], [to6('500')], to6('500'), [to6('50')]);
         await expect(this.result).to.emit(this.silo, 'AddDeposit')
           .withArgs(userAddress, this.unripeLP.address, 0, '503761210', '97342214');
       });
@@ -357,7 +357,7 @@ describe('Unripe Convert', function () {
 
       it('emits events', async function () {
         await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
-          .withArgs(userAddress, this.unripeLP.address, [0, 8], [to6('500'), to6('500')], to6('1000'));
+          .withArgs(userAddress, this.unripeLP.address, [0, 8], [to6('500'), to6('500')], to6('1000'), [to6('50'), to6('50')]);
         await expect(this.result).to.emit(this.silo, 'AddDeposit')
           .withArgs(userAddress, this.unripeBean.address, 1, to6('1006.18167'), to6('100.618167'));
       });

--- a/protocol/test/ConvertUnripe.test.js
+++ b/protocol/test/ConvertUnripe.test.js
@@ -141,7 +141,7 @@ describe('Unripe Convert', function () {
       });
 
       it('properly updates user values', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('600'));
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('600'));
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200'));
       });
 
@@ -180,7 +180,7 @@ describe('Unripe Convert', function () {
       });
 
       it('properly updates user values', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200.08'));
       });
 
@@ -219,7 +219,7 @@ describe('Unripe Convert', function () {
       });
 
       it('properly updates user values', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('1000'));
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('1000'));
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('400'));
       });
 
@@ -257,7 +257,7 @@ describe('Unripe Convert', function () {
       });
 
       it('properly updates user values', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('689368856');
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('689368856');
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('2473422140000');
       });
 
@@ -309,7 +309,7 @@ describe('Unripe Convert', function () {
       });
 
       it('properly updates user values', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('201.236334'));
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('201.236334'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('100.618167'));
       });
     });
@@ -332,7 +332,7 @@ describe('Unripe Convert', function () {
       });
 
       it('properly updates user values', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('201236334');
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('201236334');
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('100.6382906334'));
       });
 
@@ -370,7 +370,7 @@ describe('Unripe Convert', function () {
       });
 
       it('properly updates user values', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('384.075704'));
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('384.075704'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('192.037852'));
       });
     });
@@ -394,7 +394,7 @@ describe('Unripe Convert', function () {
       });
 
       it('properly updates user values', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('600'));
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('600'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('200'));
       });
     });

--- a/protocol/test/ConvertUnripe.test.js
+++ b/protocol/test/ConvertUnripe.test.js
@@ -136,12 +136,12 @@ describe('Unripe Convert', function () {
       it('properly updates total values', async function () {
         expect(await this.silo.getTotalDeposited(this.unripeBean.address)).to.eq(to6('1000'));  
         expect(await this.silo.getTotalDeposited(this.unripeLP.address)).to.eq('1006344767');
-        expect(await this.silo.totalSeeds()).to.eq(toBean('600'));
+        //expect(await this.silo.totalSeeds()).to.eq(toBean('600'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('200'));
       });
 
       it('properly updates user values', async function () {
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('600'));
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('600'));
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200'));
       });
 
@@ -175,12 +175,12 @@ describe('Unripe Convert', function () {
       it('properly updates total values', async function () {
         expect(await this.silo.getTotalDeposited(this.unripeBean.address)).to.eq(to18('0'));
         expect(await this.silo.getTotalDeposited(this.unripeLP.address)).to.eq('2008324306');
-        expect(await this.silo.totalSeeds()).to.eq(toBean('800'));
+        //expect(await this.silo.totalSeeds()).to.eq(toBean('800'));
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200.08'));
       });
 
       it('properly updates user values', async function () {
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('800'));
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('200.08'));
       });
 
@@ -214,12 +214,12 @@ describe('Unripe Convert', function () {
       it('properly updates total values', async function () {
         expect(await this.silo.getTotalDeposited(this.unripeBean.address)).to.eq(to6('1500'));
         expect(await this.silo.getTotalDeposited(this.unripeLP.address)).to.eq('503172383');
-        expect(await this.silo.totalSeeds()).to.eq(toBean('1000'));
+        //expect(await this.silo.totalSeeds()).to.eq(toBean('1000'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('400'));
       });
 
       it('properly updates user values', async function () {
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('1000'));
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(toBean('1000'));
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('400'));
       });
 
@@ -252,12 +252,12 @@ describe('Unripe Convert', function () {
       it('properly updates total values', async function () {
         expect(await this.silo.getTotalDeposited(this.unripeBean.address)).to.eq(to6('1500'));
         expect(await this.silo.getTotalDeposited(this.unripeLP.address)).to.eq('503761210');
-        expect(await this.silo.totalSeeds()).to.eq('689368856');
+        //expect(await this.silo.totalSeeds()).to.eq('689368856');
         expect(await this.silo.totalStalk()).to.eq('2473422140000');
       });
 
       it('properly updates user values', async function () {
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('689368856');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('689368856');
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('2473422140000');
       });
 
@@ -304,12 +304,12 @@ describe('Unripe Convert', function () {
       it('properly updates total values', async function () {
         expect(await this.silo.getTotalDeposited(this.unripeBean.address)).to.eq(to6('1006.18167'));
         expect(await this.silo.getTotalDeposited(this.unripeLP.address)).to.eq(to6('0'));
-        expect(await this.silo.totalSeeds()).to.eq(to6('201.236334'));
+        //expect(await this.silo.totalSeeds()).to.eq(to6('201.236334'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('100.618167'));
       });
 
       it('properly updates user values', async function () {
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('201.236334'));
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('201.236334'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('100.618167'));
       });
     });
@@ -327,12 +327,12 @@ describe('Unripe Convert', function () {
       it('properly updates total values', async function () {
         expect(await this.silo.getTotalDeposited(this.unripeBean.address)).to.eq(to6('1006.18167'));
         expect(await this.silo.getTotalDeposited(this.unripeLP.address)).to.eq(to6('0'));
-        expect(await this.silo.totalSeeds()).to.eq('201236334');
+        //expect(await this.silo.totalSeeds()).to.eq('201236334');
         expect(await this.silo.totalStalk()).to.eq(toStalk('100.6382906334'));
       });
 
       it('properly updates user values', async function () {
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('201236334');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('201236334');
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('100.6382906334'));
       });
 
@@ -365,12 +365,12 @@ describe('Unripe Convert', function () {
       it('properly updates total values', async function () {
         expect(await this.silo.getTotalDeposited(this.unripeBean.address)).to.eq(to6('1006.18167'));
         expect(await this.silo.getTotalDeposited(this.unripeLP.address)).to.eq(to6('0'));
-        expect(await this.silo.totalSeeds()).to.eq(to6('384.075704'));
+        //expect(await this.silo.totalSeeds()).to.eq(to6('384.075704'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('192.037852'));
       });
 
       it('properly updates user values', async function () {
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('384.075704'));
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('384.075704'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('192.037852'));
       });
     });
@@ -389,12 +389,12 @@ describe('Unripe Convert', function () {
       it('properly updates total values', async function () {
         expect(await this.silo.getTotalDeposited(this.unripeBean.address)).to.eq(to6('503.090835'));
         expect(await this.silo.getTotalDeposited(this.unripeLP.address)).to.eq(to6('500'));
-        expect(await this.silo.totalSeeds()).to.eq(to6('600'));
+        //expect(await this.silo.totalSeeds()).to.eq(to6('600'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('200'));
       });
 
       it('properly updates user values', async function () {
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('600'));
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('600'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('200'));
       });
     });

--- a/protocol/test/Curve.test.js
+++ b/protocol/test/Curve.test.js
@@ -426,6 +426,7 @@ describe('Curve', function () {
 
   describe("farm LP and Deposit", async function () {
     beforeEach('add LP and Deposits', async function () {
+      await this.season.teleportSunrise(10);
       const addLiquidity = await this.curve.interface.encodeFunctionData("addLiquidity", [
         BEAN_3_CURVE,
         STABLE_FACTORY,
@@ -450,7 +451,8 @@ describe('Curve', function () {
 
     it('add lp and deposit', async function () {
       const season = await this.season.season()
-      const dep = await this.silo.getDeposit(user2Address, this.beanMetapool.address, season)
+      const grownStalkPerBdvBean = await this.silo.seasonToGrownStalkPerBdv(this.beanMetapool.address, season);
+      const dep = await this.silo.getDeposit(user2Address, this.beanMetapool.address, grownStalkPerBdvBean)
       expect(dep[0]).to.be.equal(to18('1000'))
       expect(dep[1]).to.be.equal(to6('1000'))
     })

--- a/protocol/test/Farm.test.js
+++ b/protocol/test/Farm.test.js
@@ -26,7 +26,8 @@ describe('Farm', function () {
             },
           ],
         });
-      } catch {
+      } catch(error) {
+        console.log(error);
         return
       }
       const contracts = await deploy("Test", false, true, false);
@@ -52,7 +53,7 @@ describe('Farm', function () {
       await this.bean.connect(user2).approve(this.silo.address, '100000000000');
       await this.bean.mint(userAddress, to6('10000'));
       await this.bean.mint(user2Address, to6('10000'));
-      await this.silo.mow(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool.address);
 
       this.usdt = await ethers.getContractAt('IERC20', USDT)
       this.usdc = await ethers.getContractAt('IERC20', USDC)

--- a/protocol/test/Farm.test.js
+++ b/protocol/test/Farm.test.js
@@ -52,7 +52,7 @@ describe('Farm', function () {
       await this.bean.connect(user2).approve(this.silo.address, '100000000000');
       await this.bean.mint(userAddress, to6('10000'));
       await this.bean.mint(user2Address, to6('10000'));
-      await this.silo.update(userAddress);
+      await this.silo.mow(userAddress, this.beanMetapool);
 
       this.usdt = await ethers.getContractAt('IERC20', USDT)
       this.usdc = await ethers.getContractAt('IERC20', USDC)

--- a/protocol/test/Ownership.test.js
+++ b/protocol/test/Ownership.test.js
@@ -99,6 +99,29 @@ describe('Ownership', function () {
     })
   })
 
+  describe('update stalk per bdv per season for token', async function () {
+    it('reverts if not owner', async function () {
+      await expect(this.whitelist.connect(user2).updateStalkPerBdvPerSeasonForToken(this.siloToken.address, 1)).to.be.revertedWith('LibDiamond: Must be contract or owner')
+    })
+
+    it('dewhitelists token', async function () {
+      //do initial whitelist so there's something to update
+      this.whitelist.connect(owner).whitelistToken(
+        this.siloToken.address, 
+        this.silo.interface.getSighash("mockBDV(uint256 amount)"), 
+        '10000',
+        '1')
+      this.result = this.whitelist.connect(owner).updateStalkPerBdvPerSeasonForToken(
+        this.siloToken.address, 
+        '5'
+      )
+      const settings = await this.silo.tokenSettings(this.siloToken.address)
+      expect(settings[2]).to.equal(5)
+      const currentSeason = await this.season.season()
+      await expect(this.result).to.emit(this.whitelist, 'UpdatedStalkPerBdvPerSeason').withArgs(this.siloToken.address, 5, currentSeason)
+    })
+  })
+
   describe('dewhitelist', async function () {
     it('reverts if not owner', async function () {
       await expect(this.whitelist.connect(user2).dewhitelistToken(this.siloToken.address)).to.be.revertedWith('LibDiamond: Must be contract or owner')

--- a/protocol/test/Ownership.test.js
+++ b/protocol/test/Ownership.test.js
@@ -60,6 +60,7 @@ describe('Ownership', function () {
       it('claims ownership', async function () {
         await this.ownership.connect(owner).transferOwnership(user2Address)
         this.result = this.ownership.connect(user2).claimOwnership()
+        console.log('await this.ownership.ownerCandidate(): ', await this.ownership.ownerCandidate());
         expect(await this.ownership.ownerCandidate()).to.be.equal(ZERO_ADDRESS)
         expect(await this.ownership.owner()).to.be.equal(user2Address)
         await expect(this.result).to.emit(this.ownership, 'OwnershipTransferred').withArgs(ownerAddress, user2Address)
@@ -84,9 +85,12 @@ describe('Ownership', function () {
         '10000',
         '1')
       const settings = await this.silo.tokenSettings(this.siloToken.address)
+      console.log('settings[0]: ', settings[0]);
       expect(settings[0]).to.equal(this.silo.interface.getSighash("mockBDV(uint256 amount)"))
       expect(settings[1]).to.equal(1)
+      console.log('settings[1]: ', settings[1]);
       expect(settings[2]).to.equal(10000)
+      console.log('settings[2]: ', settings[2]);
       await expect(this.result).to.emit(this.whitelist, 'WhitelistToken').withArgs(this.siloToken.address, 
         this.silo.interface.getSighash("mockBDV(uint256 amount)"), 
         10000,

--- a/protocol/test/Ownership.test.js
+++ b/protocol/test/Ownership.test.js
@@ -85,16 +85,17 @@ describe('Ownership', function () {
         '10000',
         '1')
       const settings = await this.silo.tokenSettings(this.siloToken.address)
+      console.log('settings: ', settings);
       console.log('settings[0]: ', settings[0]);
       expect(settings[0]).to.equal(this.silo.interface.getSighash("mockBDV(uint256 amount)"))
-      expect(settings[1]).to.equal(1)
       console.log('settings[1]: ', settings[1]);
-      expect(settings[2]).to.equal(10000)
+      expect(settings[1]).to.equal(10000)
       console.log('settings[2]: ', settings[2]);
+      expect(settings[2]).to.equal(1)
       await expect(this.result).to.emit(this.whitelist, 'WhitelistToken').withArgs(this.siloToken.address, 
         this.silo.interface.getSighash("mockBDV(uint256 amount)"), 
-        10000,
-        1)
+        1,
+        10000)
     })
   })
 

--- a/protocol/test/Root.test.js
+++ b/protocol/test/Root.test.js
@@ -1,3 +1,5 @@
+/*
+//commenting out these tests for Silo v3 (grownStalkPerBdv transition), Root team working on new version of root token on another repo.
 const { expect } = require("chai");
 const { deploy } = require("../scripts/deploy.js");
 const {
@@ -4480,3 +4482,5 @@ describe("Root", function () {
     });
   });
 });
+
+*/

--- a/protocol/test/Root.test.js
+++ b/protocol/test/Root.test.js
@@ -911,9 +911,9 @@ describe("Root", function () {
           });
 
           it("properly updates the root total balances", async function () {
-            expect(
-              await this.silo.balanceOfSeeds(this.rootToken.address)
-            ).to.eq("0");
+            // expect(
+            //   await this.silo.balanceOfSeeds(this.rootToken.address)
+            // ).to.eq("0");
             expect(
               await this.silo.balanceOfStalk(this.rootToken.address)
             ).to.eq("0");
@@ -928,7 +928,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq("0");
           });
@@ -986,9 +986,9 @@ describe("Root", function () {
           });
 
           it("properly updates the total balances", async function () {
-            expect(
-              await this.silo.balanceOfSeeds(this.rootToken.address)
-            ).to.eq("0");
+            // expect(
+            //   await this.silo.balanceOfSeeds(this.rootToken.address)
+            // ).to.eq("0");
             expect(
               await this.silo.balanceOfStalk(this.rootToken.address)
             ).to.eq("0");

--- a/protocol/test/Root.test.js
+++ b/protocol/test/Root.test.js
@@ -928,7 +928,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            // expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq("0");
           });
@@ -1003,7 +1003,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10000000"
             );
@@ -1090,7 +1090,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10000000"
             );
@@ -1158,7 +1158,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10000000"
             );
@@ -1223,7 +1223,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10010000"
             );
@@ -1311,11 +1311,11 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10100000"
             );
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq(
               "0"
             );
@@ -1407,11 +1407,11 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "0"
             );
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq(
               "10000000"
             );
@@ -1498,7 +1498,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("2000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("2000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "20100000"
             );
@@ -1578,7 +1578,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10100000"
             );
@@ -1660,7 +1660,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("2000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("2000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "20100000"
             );
@@ -1846,7 +1846,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10000000"
             );
@@ -1904,7 +1904,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(
               await this.tokenFacet.getInternalBalance(
@@ -1959,7 +1959,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
@@ -2003,7 +2003,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("100");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("100");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "1000000"
             );
@@ -2055,7 +2055,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10002500"
             );
@@ -2116,13 +2116,13 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000000000000000"
@@ -2183,13 +2183,13 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1001000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "999999999999999"
@@ -2250,13 +2250,13 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000000000000000"
@@ -2334,19 +2334,19 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user3Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user3Address)).to.eq(
               "1000000000000000"
@@ -2424,19 +2424,19 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1002000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000999999999999"
             );
 
-            expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user3Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user3Address)).to.eq(
               "999999999999999"
@@ -2812,7 +2812,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
@@ -2864,7 +2864,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("100");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("100");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "1000000"
             );
@@ -2924,7 +2924,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10002500"
             );
@@ -3002,13 +3002,13 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000000000000000"
@@ -3085,13 +3085,13 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1001000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "999999999999999"
@@ -3167,13 +3167,13 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000000000000000"
@@ -3275,19 +3275,19 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user3Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user3Address)).to.eq(
               "1000000000000000"
@@ -3389,19 +3389,19 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1002000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000999999999999"
             );
 
-            expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user3Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user3Address)).to.eq(
               "999999999999999"
@@ -3773,7 +3773,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10000000"
             );
@@ -3843,7 +3843,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000000000"
@@ -3901,7 +3901,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("100");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("100");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "1000000"
             );
@@ -3963,7 +3963,7 @@ describe("Root", function () {
           });
 
           it("properly updates the user balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("1000");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq(
               "10002500"
             );
@@ -4048,13 +4048,13 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000000000000000"
@@ -4135,13 +4135,13 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1001000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "999999999999999"
@@ -4221,13 +4221,13 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000000000000000"
@@ -4335,19 +4335,19 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user3Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user3Address)).to.eq(
               "1000000000000000"
@@ -4455,19 +4455,19 @@ describe("Root", function () {
           });
 
           it("properly updates the users balance", async function () {
-            expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq("0");
             expect(await this.silo.balanceOfStalk(userAddress)).to.eq("0");
             expect(await this.rootToken.balanceOf(userAddress)).to.eq(
               "1002000000000000"
             );
 
-            expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user2Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user2Address)).to.eq(
               "1000999999999999"
             );
 
-            expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
+            //expect(await this.silo.balanceOfSeeds(user3Address)).to.eq("0");
             expect(await this.silo.balanceOfStalk(user3Address)).to.eq("0");
             expect(await this.rootToken.balanceOf(user3Address)).to.eq(
               "999999999999999"

--- a/protocol/test/Root.test.js
+++ b/protocol/test/Root.test.js
@@ -397,6 +397,7 @@ describe("Root", function () {
           this.siloToken.address,
           this.silo.interface.getSighash("mockBDVIncrease(uint256 amount)"),
           "10000",
+          1e6, //aka "1 seed"
           "1"
         );
         await this.rootToken.updateBdv(this.siloToken.address, 2);
@@ -410,6 +411,7 @@ describe("Root", function () {
           this.siloToken.address,
           this.silo.interface.getSighash("mockBDVIncrease(uint256 amount)"),
           "10000",
+          1e6, //aka "1 seed"
           "1"
         );
         await this.silo

--- a/protocol/test/Silo.test.js
+++ b/protocol/test/Silo.test.js
@@ -11,6 +11,7 @@ let userAddress, ownerAddress, user2Address;
 
 describe('Silo', function () {
   before(async function () {
+
     [owner,user,user2] = await ethers.getSigners();
     userAddress = user.address;
     user2Address = user2.address;
@@ -18,6 +19,7 @@ describe('Silo', function () {
     ownerAddress = contracts.account;
     this.diamond = contracts.beanstalkDiamond;
     this.season = await ethers.getContractAt('MockSeasonFacet', this.diamond.address);
+    await this.season.teleportSunrise(10);
     this.silo = await ethers.getContractAt('MockSiloFacet', this.diamond.address);
     this.bean = await ethers.getContractAt('Bean', BEAN);
     await this.season.lightSunrise();

--- a/protocol/test/Silo.test.js
+++ b/protocol/test/Silo.test.js
@@ -26,7 +26,7 @@ describe('Silo', function () {
     await this.bean.connect(user2).approve(this.silo.address, '100000000000'); 
     await this.bean.mint(userAddress, to6('10000'));
     await this.bean.mint(user2Address, to6('10000'));
-    await this.silo.update(userAddress);
+    await this.silo.update(userAddress, this.beanMetapool);
     this.result = await this.silo.connect(user).deposit(this.bean.address, to6('1000'), EXTERNAL)
     this.result = await this.silo.connect(user2).deposit(this.bean.address, to6('1000'), EXTERNAL)
   });
@@ -41,13 +41,13 @@ describe('Silo', function () {
 
   describe('Silo Balances After Deposits', function () {
     it('properly updates the user balances', async function () {
-      expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('2000'));
+      //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('2000'));
       expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('1000'));
       expect(await this.silo.balanceOfRoots(userAddress)).to.eq(toStalk('1000000000000000'));
     });
 
     it('properly updates the total balances', async function () {
-      expect(await this.silo.totalSeeds()).to.eq(to6('4000'));
+      //expect(await this.silo.totalSeeds()).to.eq(to6('4000'));
       expect(await this.silo.totalStalk()).to.eq(toStalk('2000'));
       expect(await this.silo.totalRoots()).to.eq(toStalk('2000000000000000'));
     });
@@ -59,13 +59,13 @@ describe('Silo', function () {
     })
 
     it('properly updates the total balances', async function () {
-      expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('1000'));
+      //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('1000'));
       expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('500'));
       expect(await this.silo.balanceOfRoots(userAddress)).to.eq(toStalk('500000000000000'));
     });
 
     it('properly updates the total balances', async function () {
-      expect(await this.silo.totalSeeds()).to.eq(to6('3000'));
+      //expect(await this.silo.totalSeeds()).to.eq(to6('3000'));
       expect(await this.silo.totalStalk()).to.eq(toStalk('1500'));
       expect(await this.silo.totalRoots()).to.eq(toStalk('1500000000000000'));
     });
@@ -88,13 +88,13 @@ describe('Silo', function () {
       });
 
       it('properly updates the total balances', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('2000'));
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('2000'));
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('1050'));
         expect(await this.silo.balanceOfRoots(userAddress)).to.eq(toStalk('1000000000000000'));
       });
   
       it('properly updates the total balances', async function () {
-        expect(await this.silo.totalSeeds()).to.eq(to6('4000'));
+        //expect(await this.silo.totalSeeds()).to.eq(to6('4000'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('2100'));
         expect(await this.silo.totalRoots()).to.eq(toStalk('2000000000000000'));
       });
@@ -105,7 +105,7 @@ describe('Silo', function () {
     beforeEach(async function () {
       await this.season.siloSunrise(to6('100'))
       await time.increase(3600); // wait until end of season to get earned
-      await this.silo.update(user2Address)
+      await this.silo.update(user2Address, this.beanMetapool)
       this.result = await this.silo.connect(user).plant()
     })
 
@@ -118,13 +118,13 @@ describe('Silo', function () {
     });
 
     it('properly updates the total balances', async function () {
-      expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('2100'));
+      //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('2100'));
       expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('1050.2'));
       expect(await this.silo.balanceOfRoots(userAddress)).to.eq('10001904761904761904761904');
     });
 
     it('properly updates the total balances', async function () {
-      expect(await this.silo.totalSeeds()).to.eq(to6('4100'));
+      //expect(await this.silo.totalSeeds()).to.eq(to6('4100'));
       expect(await this.silo.totalStalk()).to.eq(to6('21004000'));
       expect(await this.silo.totalRoots()).to.eq('20003809523809523809523808');
     });

--- a/protocol/test/Silo.test.js
+++ b/protocol/test/Silo.test.js
@@ -30,9 +30,6 @@ describe('Silo', function () {
     await this.silo.mow(userAddress, this.bean.address);
     this.result = await this.silo.connect(user).deposit(this.bean.address, to6('1000'), EXTERNAL)
     this.result = await this.silo.connect(user2).deposit(this.bean.address, to6('1000'), EXTERNAL)
-
-    console.log('current season: ', await this.season.season());
-    console.log('deposited in cumulativeGrownStalkPerBdv: ', await this.silo.cumulativeGrownStalkPerBdv(this.bean.address));
   });
 
   beforeEach(async function () {

--- a/protocol/test/Silo.test.js
+++ b/protocol/test/Silo.test.js
@@ -2,9 +2,12 @@ const { expect } = require('chai');
 const { deploy } = require('../scripts/deploy.js')
 const { EXTERNAL, INTERNAL, INTERNAL_EXTERNAL, INTERNAL_TOLERANT } = require('./utils/balances.js')
 const { to18, to6, toStalk } = require('./utils/helpers.js')
-const { BEAN } = require('./utils/constants')
+const { impersonateBeanstalkOwner, impersonateSigner } = require('../utils/signer.js')
+const { mintEth } = require('../utils/mint.js')
+const { BEAN, BEANSTALK, BCM } = require('./utils/constants')
 const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot");
 const { time } = require("@nomicfoundation/hardhat-network-helpers");
+const { upgradeWithNewFacets } = require("../scripts/diamond");
 
 let user,user2,owner;
 let userAddress, ownerAddress, user2Address;
@@ -302,5 +305,115 @@ describe('Silo', function () {
         expect((await this.silo.getDeposit(userAddress, this.bean.address, season))[0]).to.eq(100e6);
       });
     })
+  });
+});
+
+describe.only('Silo V3: Grown Stalk Per Bdv', function () {
+  before(async function () {
+
+    try {
+      await network.provider.request({
+        method: "hardhat_reset",
+        params: [
+          {
+            forking: {
+              jsonRpcUrl: process.env.FORKING_RPC,
+              blockNumber: 16664100 //a random semi-recent block
+            },
+          },
+        ],
+      });
+    } catch(error) {
+      console.log('forking error in Silo V3: Grown Stalk Per Bdv:');
+      console.log(error);
+      return
+    }
+    console.log('here 1');
+    const signer = await impersonateBeanstalkOwner()
+    await mintEth(signer.address);
+    await upgradeWithNewFacets({
+      diamondAddress: BEANSTALK,
+      facetNames: ['SiloFacet', 'ConvertFacet', 'WhitelistFacet', 'MockAdminFacet'],
+      libraryNames: ['LibLegacyTokenSilo'],
+      initFacetName: 'InitBipNewSilo',
+      bip: false,
+      object: false,
+      verbose: false,
+      account: signer
+    });
+    console.log('here 2');
+    const latestBlock = await hre.ethers.provider.getBlock("latest");
+    console.log('latestBlock: ', latestBlock.number);
+
+    [owner,user,user2] = await ethers.getSigners();
+    userAddress = user.address;
+    user2Address = user2.address;
+    console.log('here 3');
+    // const contracts = await deploy("Test", false);
+    // ownerAddress = contracts.account;
+    this.diamond = BEANSTALK;
+    console.log('here 3a');
+    this.season = await ethers.getContractAt('MockSeasonFacet', this.diamond);
+
+    console.log('here 4');
+    this.silo = await ethers.getContractAt('MockSiloFacet', this.diamond);
+    console.log('this.silo: ', this.silo.address);
+    this.bean = await ethers.getContractAt('Bean', BEAN);
+
+    console.log('here 5');
+    await this.bean.connect(user).approve(this.silo.address, '100000000000');
+    await this.bean.connect(user2).approve(this.silo.address, '100000000000');
+    await this.bean.connect(signer);
+    console.log('here 6');
+    
+
+    // const beanSigner = await impersonateSigner(this.bean.address);
+    // console.log('beanSigner: ', beanSigner.address);
+    // await mintEth(beanSigner.address);
+
+    await this.bean.connect(signer).mint(userAddress, to6('10000'));
+    console.log('here 7');
+    
+    //this.beanstalk.mintBeans to use the MockAdminFacet
+    await this.bean.mint(userAddress, to6('10000'));
+    await this.bean.mint(user2Address, to6('10000'));
+    await this.silo.mow(userAddress, this.bean.address);
+
+    console.log('here 7a');
+    console.log('current season: ', await this.season.season());
+    console.log('cumulativeGrownStalkPerBdv for bean: ', await this.silo.cumulativeGrownStalkPerBdv(this.bean.address));
+    console.log('this.bean.address: ', this.bean.address);
+    console.log('here 8');
+    this.result = await this.silo.connect(user).deposit(this.bean.address, to6('1000'), EXTERNAL)
+    console.log('here 8a');
+    this.result = await this.silo.connect(user2).deposit(this.bean.address, to6('1000'), EXTERNAL)
+    console.log('here 9');
+
+
+    //test function to migrate (init Mow statuses thing)
+
+    
+  });
+
+  beforeEach(async function () {
+    snapshotId = await takeSnapshot();
+  });
+
+  afterEach(async function () {
+    await revertToSnapshot(snapshotId);
+  });
+
+  describe('Silo Balances After Deposits', function () {
+    it('properly updates the user balances', async function () {
+      //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('2000'));
+      expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('1000'));
+      expect(await this.silo.balanceOfRoots(userAddress)).to.eq(toStalk('1000000000000000'));
+    });
+
+    it('properly updates the total balances', async function () {
+      //expect(await this.silo.totalSeeds()).to.eq(to6('4000'));
+      expect(await this.silo.totalStalk()).to.eq(toStalk('2000'));
+      expect(await this.silo.totalRoots()).to.eq(toStalk('2000000000000000'));
+    });
   });
 });

--- a/protocol/test/SiloToken.test.js
+++ b/protocol/test/SiloToken.test.js
@@ -127,12 +127,12 @@ describe('Silo Token', function () {
   
       it('properly updates the total balances', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.eq('1000');
-        expect(await this.silo.totalSeeds()).to.eq('1000');
+        //expect(await this.silo.totalSeeds()).to.eq('1000');
         expect(await this.silo.totalStalk()).to.eq('10000000');
       });
   
       it('properly updates the user balance', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('1000');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('1000');
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10000000');
       });
   
@@ -155,12 +155,12 @@ describe('Silo Token', function () {
   
       it('properly updates the total balances', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.eq('2000');
-        expect(await this.silo.totalSeeds()).to.eq('2000');
+        //expect(await this.silo.totalSeeds()).to.eq('2000');
         expect(await this.silo.totalStalk()).to.eq('20000000');
       });
   
       it('properly updates the user balance', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('2000');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('2000');
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('20000000');
       });
   
@@ -179,16 +179,16 @@ describe('Silo Token', function () {
   
       it('properly updates the total balances', async function () {
         expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.eq('2000');
-        expect(await this.silo.totalSeeds()).to.eq('2000');
+        //expect(await this.silo.totalSeeds()).to.eq('2000');
         expect(await this.silo.totalStalk()).to.eq('20000000');
       });
   
       it('properly updates the user balance', async function () {
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('1000');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('1000');
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('10000000');
       });
       it('properly updates the user2 balance', async function () {
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.eq('1000');
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.eq('1000');
         expect(await this.silo.balanceOfStalk(user2Address)).to.eq('10000000');
       });
   
@@ -227,12 +227,12 @@ describe('Silo Token', function () {
         it('properly updates the total balances', async function () {
           expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.eq('0');
           expect(await this.silo.totalStalk()).to.eq('0');
-          expect(await this.silo.totalSeeds()).to.eq('0');
+          //expect(await this.silo.totalSeeds()).to.eq('0');
         });
 
         it('properly updates the user balance', async function () {
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('0');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('0');
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('0');
           expect((await this.siloToken.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq('1000');
         });
 
@@ -261,11 +261,11 @@ describe('Silo Token', function () {
         it('properly updates the total balances', async function () {
           expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.eq('500');
           expect(await this.silo.totalStalk()).to.eq('5000000');
-          expect(await this.silo.totalSeeds()).to.eq('500');
+          //expect(await this.silo.totalSeeds()).to.eq('500');
         });
         it('properly updates the user balance', async function () {
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('5000000');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('500');
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('500');
           expect((await this.siloToken.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq('500');
         });
 
@@ -297,11 +297,11 @@ describe('Silo Token', function () {
         it('properly updates the total balances', async function () {
           expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.eq('500');
           expect(await this.silo.totalStalk()).to.eq('5000500');
-          expect(await this.silo.totalSeeds()).to.eq('500');
+          //expect(await this.silo.totalSeeds()).to.eq('500');
         });
         it('properly updates the user balance', async function () {
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('5000500');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('500');
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('500');
           expect((await this.siloToken.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq('1500');
 
         });
@@ -328,11 +328,11 @@ describe('Silo Token', function () {
         it('properly updates the total balances', async function () {
           expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.eq('0');
           expect(await this.silo.totalStalk()).to.eq('0');
-          expect(await this.silo.totalSeeds()).to.eq('0');
+          //expect(await this.silo.totalSeeds()).to.eq('0');
         });
         it('properly updates the user balance', async function () {
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq('0');
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('0');
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('0');
           expect((await this.siloToken.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq('2000');
         });
         it('properly removes the crate', async function () {
@@ -389,7 +389,7 @@ describe('Silo Token', function () {
       it("Check mock works", async function () {
         expect(await this.silo.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6('10'));
         expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('10')));
-        expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10')));
+        //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10')));
       })
 
       it('get Deposit', async function () {
@@ -411,11 +411,11 @@ describe('Silo Token', function () {
         it('properly updates the total balances', async function () {
           expect(await this.silo.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6('9'));
           expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('9')));
-          expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('9')));
+          //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('9')));
         });
         it('properly updates the user balance', async function () {
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(pruneToStalk(to6('9')));
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('9')));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('9')));
           expect((await this.unripeBeans.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq(to6('1'));
         });
         
@@ -438,7 +438,7 @@ describe('Silo Token', function () {
       it("Check mock works", async function () {
         expect(await this.silo.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6('20'));
         expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('10')).add(pruneToStalk(to6('10'))));
-        expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10')).add(pruneToSeeds(to6('10'))));
+        //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10')).add(pruneToSeeds(to6('10'))));
       })
 
       it('get Deposit', async function () {
@@ -460,11 +460,11 @@ describe('Silo Token', function () {
         it('properly updates the total balances', async function () {
           expect(await this.silo.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6('9'));
           expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('9')));
-          expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('9')));
+          //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('9')));
         });
         it('properly updates the user balance', async function () {
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(pruneToStalk(to6('9')));
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('9')));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('9')));
           expect((await this.unripeBeans.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq(to6('11'));
         });
         it('properly removes the crate', async function () {
@@ -488,7 +488,7 @@ describe('Silo Token', function () {
       it("Check mock works", async function () {
         expect(await this.silo.getTotalDeposited(UNRIPE_LP)).to.eq(to6('10'));
         expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('10')));
-        expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10'), 4));
+        //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10'), 4));
       })
 
       it('get Deposit', async function () {
@@ -510,12 +510,12 @@ describe('Silo Token', function () {
         it('properly updates the total balances', async function () {
           expect(await this.silo.getTotalDeposited(UNRIPE_LP)).to.eq(to6('9'));
           expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('9')));
-          expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('9'), 4));
+          //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('9'), 4));
         });
 
         it('properly updates the user balance', async function () {
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(pruneToStalk(to6('9')));
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('9'), 4));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('9'), 4));
           expect((await this.unripeLP.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq(to6('1'));
         });
 
@@ -539,7 +539,7 @@ describe('Silo Token', function () {
       it("Check mock works", async function () {
         expect(await this.silo.getTotalDeposited(UNRIPE_LP)).to.eq(to6('10'));
         expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('10')));
-        expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10'), 4));
+        //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10'), 4));
       })
 
       it('get Deposit', async function () {
@@ -561,12 +561,12 @@ describe('Silo Token', function () {
         it('properly updates the total balances', async function () {
           expect(await this.silo.getTotalDeposited(UNRIPE_LP)).to.eq(to6('9'));
           expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('9')));
-          expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('9'), 4));
+          //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('9'), 4));
         });
 
         it('properly updates the user balance', async function () {
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(pruneToStalk(to6('9')));
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('9'), 4));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('9'), 4));
           expect((await this.unripeLP.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq(to6('1'));
         });
 
@@ -590,7 +590,7 @@ describe('Silo Token', function () {
       it("Check mock works", async function () {
         expect(await this.silo.getTotalDeposited(UNRIPE_LP)).to.eq(to6('10'));
         expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('10')));
-        expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10'), 4));
+        //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10'), 4));
       })
 
       it('get Deposit', async function () {
@@ -612,12 +612,12 @@ describe('Silo Token', function () {
         it('properly updates the total balances', async function () {
           expect(await this.silo.getTotalDeposited(UNRIPE_LP)).to.eq(to6('9'));
           expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('9')));
-          expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('9'), 4));
+          //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('9'), 4));
         });
 
         it('properly updates the user balance', async function () {
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(pruneToStalk(to6('9')));
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('9'), 4));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('9'), 4));
           expect((await this.unripeLP.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq(to6('1'));
 
         });
@@ -645,7 +645,7 @@ describe('Silo Token', function () {
       it("Check mock works", async function () {
         expect(await this.silo.getTotalDeposited(UNRIPE_LP)).to.eq(to6('10'));
         expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('2.5')).mul(toBN('4')).sub(toBN('10000')));
-        expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('2.5'), 4).mul(toBN('4')).sub(toBN('4')));
+        //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('2.5'), 4).mul(toBN('4')).sub(toBN('4')));
       })
 
       it('get Deposit', async function () {
@@ -667,12 +667,12 @@ describe('Silo Token', function () {
         it('properly updates the total balances', async function () {
           expect(await this.silo.getTotalDeposited(UNRIPE_LP)).to.eq(to6('1'));
           expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('1')).sub(toBN('10000')));
-          expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('1'), 4).sub(toBN('4')));
+          //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('1'), 4).sub(toBN('4')));
         });
 
         it('properly updates the user balance', async function () {
           expect(await this.silo.balanceOfStalk(userAddress)).to.eq(pruneToStalk(to6('1')).sub(toBN('10000')));
-          expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('1'), 4).sub(toBN('4')));
+          //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('1'), 4).sub(toBN('4')));
           expect((await this.unripeLP.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq(to6('9'));
         });
 
@@ -726,7 +726,7 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.be.equal('500000')
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('50')
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('50')
       })
 
       it('add the deposit to the recipient', async function () {
@@ -737,12 +737,12 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.be.equal('500000')
-        // expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('50')
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('50')
       })
 
       it('updates total stalk and seeds', async function () {
         expect(await this.silo.totalStalk()).to.be.equal('1000000')
-        // expect(await this.silo.totalSeeds()).to.be.equal('100')
+        // //expect(await this.silo.totalSeeds()).to.be.equal('100')
       })
     })
 
@@ -760,7 +760,7 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.be.equal('0')
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('0')
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('0')
       })
 
       it('add the deposit to the recipient', async function () {
@@ -771,12 +771,12 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.be.equal('1000000')
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('100')
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('100')
       })
 
       it('updates total stalk and seeds', async function () {
         expect(await this.silo.totalStalk()).to.be.equal('1000000')
-        expect(await this.silo.totalSeeds()).to.be.equal('100')
+        //expect(await this.silo.totalSeeds()).to.be.equal('100')
       })
     })
 
@@ -806,7 +806,7 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.be.equal('1250050')
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('125')
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('125')
       })
 
       it('add the deposit to the recipient', async function () {
@@ -820,12 +820,12 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.be.equal('750050')
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('75')
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('75')
       })
 
       it('updates total stalk and seeds', async function () {
         expect(await this.silo.totalStalk()).to.be.equal('2000100')
-        expect(await this.silo.totalSeeds()).to.be.equal('200')
+        //expect(await this.silo.totalSeeds()).to.be.equal('200')
       })
     })
 
@@ -844,7 +844,7 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.be.equal('500000')
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('50')
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('50')
       })
 
       it('add the deposit to the recipient', async function () {
@@ -855,12 +855,12 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.be.equal('500000')
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('50')
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('50')
       })
 
       it('updates total stalk and seeds', async function () {
         expect(await this.silo.totalStalk()).to.be.equal('1000000')
-        expect(await this.silo.totalSeeds()).to.be.equal('100')
+        //expect(await this.silo.totalSeeds()).to.be.equal('100')
       })
 
       it('properly updates users token allowance', async function () {
@@ -893,7 +893,7 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.be.equal('0')
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('0')
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('0')
       })
 
       it('add the deposit to the recipient', async function () {
@@ -904,12 +904,12 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.be.equal('1000000')
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('100')
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('100')
       })
 
       it('updates total stalk and seeds', async function () {
         expect(await this.silo.totalStalk()).to.be.equal('1000000')
-        expect(await this.silo.totalSeeds()).to.be.equal('100')
+        //expect(await this.silo.totalSeeds()).to.be.equal('100')
       })
 
       it('properly updates users token allowance', async function () {
@@ -937,7 +937,7 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.be.equal('1250050')
-        // expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('125')
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('125')
       })
 
       it('add the deposit to the recipient', async function () {
@@ -951,12 +951,12 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.be.equal('750050')
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('75')
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('75')
       })
 
       it('updates total stalk and seeds', async function () {
         expect(await this.silo.totalStalk()).to.be.equal('2000100')
-        // expect(await this.silo.totalSeeds()).to.be.equal('200')
+        // //expect(await this.silo.totalSeeds()).to.be.equal('200')
       })
 
       it('properly updates users token allowance', async function () {
@@ -993,12 +993,12 @@ describe('Silo Token', function () {
       it('properly updates the total balances', async function () {
         expect(await this.silo.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6('10'));
         expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('10')).add(toStalk('0.5')));
-        expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10')).add(to6('1')));
+        //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10')).add(to6('1')));
       });
 
       it('properly updates the user balance', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(pruneToStalk(to6('10')).add(toStalk('0.5')));
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('10')).add(to6('1')));
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(pruneToSeeds(to6('10')).add(to6('1')));
       });
 
       it('properly removes the crate', async function () {
@@ -1031,12 +1031,12 @@ describe('Silo Token', function () {
       it('properly updates the total balances', async function () {
         expect(await this.silo.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6('10'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('5.001'));
-        expect(await this.silo.totalSeeds()).to.eq(to6('10'));
+        //expect(await this.silo.totalSeeds()).to.eq(to6('10'));
       });
 
       it('properly updates the user balance', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('5.001'));
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('10'));
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('10'));
       });
 
       it('properly removes the crate', async function () {
@@ -1070,12 +1070,12 @@ describe('Silo Token', function () {
       it('properly updates the total balances', async function () {
         expect(await this.silo.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6('10'));
         expect(await this.silo.totalStalk()).to.eq(toStalk('5.0005'));
-        expect(await this.silo.totalSeeds()).to.eq(to6('10'));
+        //expect(await this.silo.totalSeeds()).to.eq(to6('10'));
       });
 
       it('properly updates the user balance', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('5.0005'));
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('10'));
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq(to6('10'));
       });
 
       it('properly removes the crate', async function () {

--- a/protocol/test/SiloToken.test.js
+++ b/protocol/test/SiloToken.test.js
@@ -1109,7 +1109,7 @@ describe('Silo Token', function () {
   })
 
   describe("Update Unripe Deposit", async function () {
-    describe.only("1 deposit, some", async function () {
+    describe("1 deposit, some", async function () {
       beforeEach(async function () {
         await this.season.teleportSunrise(10);
         await this.silo.connect(user).deposit(UNRIPE_BEAN, to6('5'), EXTERNAL)
@@ -1148,10 +1148,11 @@ describe('Silo Token', function () {
       });
     });
 
-    describe("1 deposit after 1 sesaon, all", async function () {
+    describe("1 deposit after 1 season, all", async function () {
       beforeEach(async function () {
+        await this.season.teleportSunrise(10);
         await this.silo.connect(user).deposit(UNRIPE_BEAN, to6('5'), EXTERNAL)
-        await this.silo.connect(user).mockUnripeBeanDeposit('2', to6('5'))
+        await this.silo.connect(user).mockUnripeBeanDeposit('10', to6('5'))
         
         await this.season.lightSunrise()
 
@@ -1160,7 +1161,9 @@ describe('Silo Token', function () {
           to6('5000').sub(to6('10000').mul(toBN(pru)).div(to18('1')))
         )
 
-        this.result = await this.silo.connect(user).enrootDeposit(UNRIPE_BEAN, '2', to6('10'));
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_BEAN, '10');
+        console.log('grownStalkPerBdv10: ', grownStalkPerBdv10);
+        this.result = await this.silo.connect(user).enrootDeposit(UNRIPE_BEAN, grownStalkPerBdv10, to6('10'));
       })
 
       it('properly updates the total balances', async function () {
@@ -1175,18 +1178,20 @@ describe('Silo Token', function () {
       });
 
       it('properly removes the crate', async function () {
-        let dep = await this.silo.getDeposit(userAddress, UNRIPE_BEAN, 2);
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_BEAN, '10');
+        let dep = await this.silo.getDeposit(userAddress, UNRIPE_BEAN, grownStalkPerBdv10);
         expect(dep[0]).to.equal(to6('10'))
         expect(dep[1]).to.equal(to6('5'))
       });
 
       it('emits Remove and Add Deposit event', async function () {
-        await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, 2, to6('10'));
-        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, UNRIPE_BEAN, 2, to6('10'), to6('5'));
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_BEAN, '10');
+        await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('10'));
+        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('10'), to6('5'));
       });
     });
 
-    describe("2 deposit, all", async function () {
+    describe.only("2 deposit, all", async function () {
       beforeEach(async function () {
         await this.silo.connect(user).mockUnripeBeanDeposit('2', to6('5'))
 

--- a/protocol/test/SiloToken.test.js
+++ b/protocol/test/SiloToken.test.js
@@ -769,9 +769,10 @@ describe('Silo Token', function () {
     })
   })
 
-  describe.only("Transfer", async function () {
+  describe("Transfer", async function () {
     describe("reverts", async function() {
       beforeEach(async function () {
+        await this.season.teleportSunrise(10);
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
         await this.season.siloSunrise('0')
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
@@ -786,20 +787,26 @@ describe('Silo Token', function () {
       })
     })
     describe("Single", async function () {
+      beforeEach(async function () {
+        await this.season.teleportSunrise(10);
+      })
       
       it('returns the correct value', async function () {
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
-        this.result = await this.silo.connect(user).callStatic.transferDeposit(userAddress, user2Address, this.siloToken.address, '2', '50')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        this.result = await this.silo.connect(user).callStatic.transferDeposit(userAddress, user2Address, this.siloToken.address, grownStalkPerBdv, '50')
         expect(this.result).to.be.equal('50')
       })
 
       beforeEach(async function () {
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
-        this.result = await this.silo.connect(user).transferDeposit(userAddress, user2Address, this.siloToken.address, '2', '50')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        this.result = await this.silo.connect(user).transferDeposit(userAddress, user2Address, this.siloToken.address, grownStalkPerBdv, '50')
       })
 
       it('removes the deposit from the sender', async function () {
-        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, '2')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, grownStalkPerBdv)
         expect(deposit[0]).to.equal('50');
         expect(deposit[0]).to.equal('50');
       })
@@ -810,7 +817,8 @@ describe('Silo Token', function () {
       })
 
       it('add the deposit to the recipient', async function () {
-        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, '2')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, grownStalkPerBdv)
         expect(deposit[0]).to.equal('50');
         expect(deposit[0]).to.equal('50');
       })
@@ -828,12 +836,15 @@ describe('Silo Token', function () {
 
     describe("Single all", async function () {
       beforeEach(async function () {
+        await this.season.teleportSunrise(10);
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
-        await this.silo.connect(user).transferDeposit(userAddress, user2Address, this.siloToken.address, '2', '100')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        await this.silo.connect(user).transferDeposit(userAddress, user2Address, this.siloToken.address, grownStalkPerBdv, '100')
       })
 
       it('removes the deposit from the sender', async function () {
-        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, '2')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, grownStalkPerBdv)
         expect(deposit[0]).to.equal('0');
         expect(deposit[0]).to.equal('0');
       })
@@ -844,7 +855,8 @@ describe('Silo Token', function () {
       })
 
       it('add the deposit to the recipient', async function () {
-        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, '2')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, grownStalkPerBdv)
         expect(deposit[0]).to.equal('100');
         expect(deposit[0]).to.equal('100');
       })
@@ -862,24 +874,41 @@ describe('Silo Token', function () {
 
     describe("Multiple", async function () {
       it('returns the correct value', async function () {
-        await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
-        await this.season.siloSunrise('0')
-        await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
-        this.result = await this.silo.connect(user).callStatic.transferDeposits(userAddress, user2Address, this.siloToken.address, ['2', '3'], ['50','25'])
+        
+        // await this.season.teleportSunrise(10);
+        // await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
+        // await this.season.siloSunrise('0')
+        // await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
+
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const grownStalkPerBdv11 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '11');
+        this.result = await this.silo.connect(user).callStatic.transferDeposits(userAddress, user2Address, this.siloToken.address, [grownStalkPerBdv10, grownStalkPerBdv11], ['50','25'])
       })
 
       beforeEach(async function () {
+        await this.season.teleportSunrise(10);
+
+        console.log('1 current season: ', await this.season.season());
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
         await this.season.siloSunrise('0')
+
+        console.log('2 current season: ', await this.season.season());
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
-        this.result = await this.silo.connect(user).transferDeposits(userAddress, user2Address, this.siloToken.address, ['2', '3'], ['50','25'])
+
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const grownStalkPerBdv11 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '11');
+        
+        this.result = await this.silo.connect(user).transferDeposits(userAddress, user2Address, this.siloToken.address, [grownStalkPerBdv10, grownStalkPerBdv11], ['50','25'])
       })
 
       it('removes the deposit from the sender', async function () {
-        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, '2')
+
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, grownStalkPerBdv10)
         expect(deposit[0]).to.equal('50');
         expect(deposit[0]).to.equal('50');
-        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, '3')
+        const grownStalkPerBdv11 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '11');
+        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, grownStalkPerBdv11)
         expect(deposit[0]).to.equal('75');
         expect(deposit[0]).to.equal('75');
       })
@@ -890,10 +919,12 @@ describe('Silo Token', function () {
       })
 
       it('add the deposit to the recipient', async function () {
-        let deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, '2')
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        let deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, grownStalkPerBdv10)
         expect(deposit[0]).to.equal('50');
         expect(deposit[0]).to.equal('50');
-        deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, '3')
+        const grownStalkPerBdv11 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '11');
+        deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, grownStalkPerBdv11)
         expect(deposit[0]).to.equal('25');
         expect(deposit[0]).to.equal('25');
       })
@@ -911,13 +942,16 @@ describe('Silo Token', function () {
 
     describe("Single with allowance", async function () {
       beforeEach(async function () {
+        await this.season.teleportSunrise(10);
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
         await this.silo.connect(user).approveDeposit(ownerAddress, this.siloToken.address, '100');
-        await this.silo.connect(owner).transferDeposit(userAddress, user2Address, this.siloToken.address, '2', '50')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        await this.silo.connect(owner).transferDeposit(userAddress, user2Address, this.siloToken.address, grownStalkPerBdv, '50')
       })
 
       it('removes the deposit from the sender', async function () {
-        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, '2')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, grownStalkPerBdv)
         expect(deposit[0]).to.equal('50');
         expect(deposit[0]).to.equal('50');
       })
@@ -928,7 +962,8 @@ describe('Silo Token', function () {
       })
 
       it('add the deposit to the recipient', async function () {
-        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, '2')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, grownStalkPerBdv)
         expect(deposit[0]).to.equal('50');
         expect(deposit[0]).to.equal('50');
       })
@@ -950,23 +985,28 @@ describe('Silo Token', function () {
 
     describe("Single with no allowance", async function () {
       beforeEach(async function () {
+        await this.season.teleportSunrise(10);
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
       })
 
       it('reverts with no allowance', async function () {
-        await expect(this.silo.connect(owner).transferDeposit(userAddress, user2Address, this.siloToken.address, '2', '50')).to.revertedWith('Silo: insufficient allowance');
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        await expect(this.silo.connect(owner).transferDeposit(userAddress, user2Address, this.siloToken.address, grownStalkPerBdv, '50')).to.revertedWith('Silo: insufficient allowance');
       })
     })
 
     describe("Single all with allowance", async function () {
       beforeEach(async function () {
+        await this.season.teleportSunrise(10);
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
         await this.silo.connect(user).approveDeposit(ownerAddress, this.siloToken.address, '100');
-        await this.silo.connect(owner).transferDeposit(userAddress, user2Address, this.siloToken.address, '2', '100');
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        await this.silo.connect(owner).transferDeposit(userAddress, user2Address, this.siloToken.address, grownStalkPerBdv, '100');
       })
 
       it('removes the deposit from the sender', async function () {
-        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, '2')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, grownStalkPerBdv)
         expect(deposit[0]).to.equal('0');
         expect(deposit[0]).to.equal('0');
       })
@@ -977,7 +1017,8 @@ describe('Silo Token', function () {
       })
 
       it('add the deposit to the recipient', async function () {
-        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, '2')
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, grownStalkPerBdv)
         expect(deposit[0]).to.equal('100');
         expect(deposit[0]).to.equal('100');
       })
@@ -999,18 +1040,23 @@ describe('Silo Token', function () {
 
     describe("Multiple with allowance", async function () {
       beforeEach(async function () {
+        await this.season.teleportSunrise(10);
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
         await this.season.siloSunrise('0')
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
         await this.silo.connect(user).approveDeposit(ownerAddress, this.siloToken.address, '200');
-        await this.silo.connect(owner).transferDeposits(userAddress, user2Address, this.siloToken.address, ['2', '3'], ['50','25'])
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const grownStalkPerBdv11 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '11');
+        await this.silo.connect(owner).transferDeposits(userAddress, user2Address, this.siloToken.address, [grownStalkPerBdv10, grownStalkPerBdv11], ['50','25'])
       })
 
       it('removes the deposit from the sender', async function () {
-        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, '2')
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, grownStalkPerBdv10)
         expect(deposit[0]).to.equal('50');
         expect(deposit[0]).to.equal('50');
-        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, '3')
+        const grownStalkPerBdv11 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '11');
+        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, grownStalkPerBdv11)
         expect(deposit[0]).to.equal('75');
         expect(deposit[0]).to.equal('75');
       })
@@ -1021,10 +1067,12 @@ describe('Silo Token', function () {
       })
 
       it('add the deposit to the recipient', async function () {
-        let deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, '2')
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        let deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, grownStalkPerBdv10)
         expect(deposit[0]).to.equal('50');
         expect(deposit[0]).to.equal('50');
-        deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, '3')
+        const grownStalkPerBdv11 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '11');
+        deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, grownStalkPerBdv11)
         expect(deposit[0]).to.equal('25');
         expect(deposit[0]).to.equal('25');
       })
@@ -1046,28 +1094,33 @@ describe('Silo Token', function () {
 
     describe("Multiple with no allowance", async function () {
       beforeEach(async function () {
+        await this.season.teleportSunrise(10);
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
         await this.season.siloSunrise('0')
         await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL)
       })
 
       it('reverts with no allowance', async function () {
-        await expect(this.silo.connect(owner).transferDeposits(userAddress, user2Address, this.siloToken.address, ['2', '3'], ['50','25'])).to.revertedWith('Silo: insufficient allowance');
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        const grownStalkPerBdv11 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '11');
+        await expect(this.silo.connect(owner).transferDeposits(userAddress, user2Address, this.siloToken.address, [grownStalkPerBdv10, grownStalkPerBdv11], ['50','25'])).to.revertedWith('Silo: insufficient allowance');
       })
     })
   })
 
   describe("Update Unripe Deposit", async function () {
-    describe("1 deposit, some", async function () {
+    describe.only("1 deposit, some", async function () {
       beforeEach(async function () {
+        await this.season.teleportSunrise(10);
         await this.silo.connect(user).deposit(UNRIPE_BEAN, to6('5'), EXTERNAL)
-        await this.silo.connect(user).mockUnripeBeanDeposit('2', to6('5'))
+        await this.silo.connect(user).mockUnripeBeanDeposit(10, to6('5'))
         await this.unripe.connect(owner).addUnderlying(
           UNRIPE_BEAN,
           to6('1000')
         )
 
-        this.result = await this.silo.connect(user).enrootDeposit(UNRIPE_BEAN, '2', to6('5'));
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        this.result = await this.silo.connect(user).enrootDeposit(UNRIPE_BEAN, grownStalkPerBdv10, to6('5'));
       })
 
       it('properly updates the total balances', async function () {
@@ -1082,14 +1135,16 @@ describe('Silo Token', function () {
       });
 
       it('properly removes the crate', async function () {
-        let dep = await this.silo.getDeposit(userAddress, UNRIPE_BEAN, 2);
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        let dep = await this.silo.getDeposit(userAddress, UNRIPE_BEAN, grownStalkPerBdv10);
         expect(dep[0]).to.equal(to6('10'))
         expect(dep[1]).to.equal(prune(to6('10')).add(to6('0.5')))
       });
 
       it('emits Remove and Add Deposit event', async function () {
-        await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, 2, to6('5'));
-        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, UNRIPE_BEAN, 2, to6('5'), prune(to6('5')).add(to6('0.5')));
+        const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
+        await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('5'));
+        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('5'), prune(to6('5')).add(to6('0.5')));
       });
     });
 

--- a/protocol/test/SiloToken.test.js
+++ b/protocol/test/SiloToken.test.js
@@ -58,6 +58,7 @@ describe('Silo Token', function () {
       this.siloToken.address, 
       this.silo.interface.getSighash("mockBDV(uint256 amount)"), 
       '10000',
+      1e6, //aka "1 seed"
       '1');
 
     await this.season.siloSunrise(0);

--- a/protocol/test/SiloToken.test.js
+++ b/protocol/test/SiloToken.test.js
@@ -261,7 +261,7 @@ describe('Silo Token', function () {
     
         it('emits RemoveDeposit event', async function () {
           const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, this.siloToken.address, grownStalkPerBdv, '1000');
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, this.siloToken.address, grownStalkPerBdv, '1000', '1000');
         });
       });
       
@@ -295,7 +295,7 @@ describe('Silo Token', function () {
 
         it('emits RemoveDeposit event', async function () {
           const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, this.siloToken.address, grownStalkPerBdv, '500');
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, this.siloToken.address, grownStalkPerBdv, '500', '500');
         });
       });
     });
@@ -330,7 +330,7 @@ describe('Silo Token', function () {
           expect(dep[1]).to.equal('0')
         });
         it('emits RemoveDeposits event', async function () {
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [0,1], ['500', '1000'], '1500');
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [0,1], ['500', '1000'], '1500', ['500', '1000']);
         });
       });
       describe('2 token crates', function () {
@@ -361,7 +361,7 @@ describe('Silo Token', function () {
           expect(dep[1]).to.equal('0')
         });
         it('emits RemoveDeposits event', async function () {
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [0,1], ['1000', '1000'], '2000');
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [0,1], ['1000', '1000'], '2000', ['1000', '1000']);
         });
       });
     });
@@ -434,15 +434,11 @@ describe('Silo Token', function () {
 
           const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_BEAN, '10');
 
-
-
           this.result = await this.silo.connect(user).withdrawDeposit(UNRIPE_BEAN, grownStalkPerBdv, to6('1'), EXTERNAL)
         })
 
         it('properly updates the total balances', async function () {
-
           expect(await this.silo.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6('9'));
-
           expect(await this.silo.totalStalk()).to.eq(pruneToStalk(to6('9')));
         });
         it('properly updates the user balance', async function () {
@@ -460,7 +456,7 @@ describe('Silo Token', function () {
         it('emits RemoveDeposit event', async function () {
           const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_BEAN, '10');
 
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv, to6('1'));
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv, to6('1'), '185564');
         });
       })
     })
@@ -524,7 +520,7 @@ describe('Silo Token', function () {
         });
         it('emits RemoveDeposit event', async function () {
           const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_BEAN, '10');
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv, to6('11'));
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv, to6('11'), '2041210');
         });
       })
     })
@@ -583,7 +579,7 @@ describe('Silo Token', function () {
 
         it('emits RemoveDeposit event', async function () {
           const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_LP, '10');
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_LP, grownStalkPerBdv, to6('1'));
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_LP, grownStalkPerBdv, to6('1'), '185564');
         });
       })
     })
@@ -640,7 +636,7 @@ describe('Silo Token', function () {
 
         it('emits RemoveDeposit event', async function () {
           const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_LP, '10');
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_LP, grownStalkPerBdv, to6('1'));
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_LP, grownStalkPerBdv, to6('1'), '185564');
         });
       })
     })
@@ -698,7 +694,7 @@ describe('Silo Token', function () {
 
         it('emits RemoveDeposit event', async function () {
           const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_LP, '10');
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_LP, grownStalkPerBdv, to6('1'));
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_LP, grownStalkPerBdv, to6('1'), '185564');
         });
       })
     })
@@ -758,7 +754,7 @@ describe('Silo Token', function () {
 
         it('emits RemoveDeposit event', async function () {
           const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_LP, '10');
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_LP, grownStalkPerBdv, to6('9'));
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_LP, grownStalkPerBdv, to6('9'), '1670080');
         });
       })
     })
@@ -1134,7 +1130,7 @@ describe('Silo Token', function () {
 
       it('emits Remove and Add Deposit event', async function () {
         const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(this.siloToken.address, '10');
-        await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('5'));
+        await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('5'), '927823');
         await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('5'), prune(to6('5')).add(to6('0.5')));
       });
     });
@@ -1177,7 +1173,7 @@ describe('Silo Token', function () {
 
       it('emits Remove and Add Deposit event', async function () {
         const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_BEAN, '10');
-        await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('10'));
+        await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('10'), '1855646');
         await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('10'), to6('5'));
       });
     });
@@ -1223,7 +1219,7 @@ describe('Silo Token', function () {
       it('emits Remove and Add Deposits event', async function () {
         const grownStalkPerBdv10 = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_BEAN, '10');
         const grownStalkPerBdv11 = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_BEAN, '11');
-        await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, UNRIPE_BEAN, [grownStalkPerBdv10,grownStalkPerBdv11], [to6('5'), to6('5')], to6('10'));
+        await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, UNRIPE_BEAN, [grownStalkPerBdv10,grownStalkPerBdv11], [to6('5'), to6('5')], to6('10'), ['927823', '927823']);
         await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv10, to6('5'), to6('2.5'));
         await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, UNRIPE_BEAN, grownStalkPerBdv11, to6('5'), to6('2.5'));
       });

--- a/protocol/test/SiloToken.test.js
+++ b/protocol/test/SiloToken.test.js
@@ -726,7 +726,7 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.be.equal('500000')
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('50')
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('50')
       })
 
       it('add the deposit to the recipient', async function () {
@@ -737,12 +737,12 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(user2Address)).to.be.equal('500000')
-        expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('50')
+        // expect(await this.silo.balanceOfSeeds(user2Address)).to.be.equal('50')
       })
 
       it('updates total stalk and seeds', async function () {
         expect(await this.silo.totalStalk()).to.be.equal('1000000')
-        expect(await this.silo.totalSeeds()).to.be.equal('100')
+        // expect(await this.silo.totalSeeds()).to.be.equal('100')
       })
     })
 
@@ -937,7 +937,7 @@ describe('Silo Token', function () {
 
       it('updates users stalk and seeds', async function () {
         expect(await this.silo.balanceOfStalk(userAddress)).to.be.equal('1250050')
-        expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('125')
+        // expect(await this.silo.balanceOfSeeds(userAddress)).to.be.equal('125')
       })
 
       it('add the deposit to the recipient', async function () {
@@ -956,7 +956,7 @@ describe('Silo Token', function () {
 
       it('updates total stalk and seeds', async function () {
         expect(await this.silo.totalStalk()).to.be.equal('2000100')
-        expect(await this.silo.totalSeeds()).to.be.equal('200')
+        // expect(await this.silo.totalSeeds()).to.be.equal('200')
       })
 
       it('properly updates users token allowance', async function () {

--- a/protocol/test/SiloToken.test.js
+++ b/protocol/test/SiloToken.test.js
@@ -123,6 +123,9 @@ describe('Silo Token', function () {
 
     describe('single deposit', function () {
       beforeEach(async function () {
+
+        console.log('current season: ', await this.season.season());
+        console.log('deposited in cumulativeGrownStalkPerBdv: ', await this.silo.cumulativeGrownStalkPerBdv(this.siloToken.address));
         this.result = await this.silo.connect(user).deposit(this.siloToken.address, '1000', EXTERNAL)
       });
   
@@ -138,17 +141,18 @@ describe('Silo Token', function () {
       });
   
       it('properly adds the crate', async function () {
-        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+        console.log('deposit: ', deposit);
         expect(deposit[0]).to.eq('1000');
         expect(deposit[1]).to.eq('1000');
       })
 
       it('emits Deposit event', async function () {
-        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, this.siloToken.address, 2, '1000', '1000');
+        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, this.siloToken.address, 1, '1000', '1000');
       });
     });
   
-    describe('2 deposits same season', function () {
+    describe('2 deposits same grown stalk per bdv', function () {
       beforeEach(async function () {
         this.result = await this.silo.connect(user).deposit(this.siloToken.address, '1000', EXTERNAL)
         this.result = await this.silo.connect(user).deposit(this.siloToken.address, '1000', EXTERNAL)
@@ -166,7 +170,7 @@ describe('Silo Token', function () {
       });
   
       it('properly adds the crate', async function () {
-        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+        const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
         expect(deposit[0]).to.eq('2000');
         expect(deposit[1]).to.eq('2000');
       })
@@ -194,10 +198,10 @@ describe('Silo Token', function () {
       });
   
       it('properly adds the crate', async function () {
-        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
         expect(deposit[0]).to.eq('1000');
         expect(deposit[1]).to.eq('1000');
-        deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 2);
+        deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 1);
         expect(deposit[0]).to.eq('1000');
         expect(deposit[1]).to.eq('1000');
       });
@@ -210,11 +214,11 @@ describe('Silo Token', function () {
     })
     describe('reverts', function () {
       it('reverts if amount is 0', async function () {
-        await expect(this.silo.connect(user).withdrawDeposit(this.siloToken.address, '2', '1001', EXTERNAL)).to.revertedWith('Silo: Crate balance too low.');
+        await expect(this.silo.connect(user).withdrawDeposit(this.siloToken.address, '1', '1001', EXTERNAL)).to.revertedWith('Silo: Crate balance too low.');
       });
 
       it('reverts if deposits + withdrawals is a different length', async function () {
-        await expect(this.silo.connect(user).withdrawDeposits(this.siloToken.address, ['2', '3'], ['1001'], EXTERNAL)).to.revertedWith('Silo: Crates, amounts are diff lengths.');
+        await expect(this.silo.connect(user).withdrawDeposits(this.siloToken.address, ['1', '2'], ['1001'], EXTERNAL)).to.revertedWith('Silo: Crates, amounts are diff lengths.');
       });
     });
 
@@ -222,7 +226,7 @@ describe('Silo Token', function () {
       describe('withdraw 1 Bean crate', async function () {
         beforeEach(async function () {
           userBalanceBefore = await this.siloToken.balanceOf(userAddress);
-          this.result = await this.silo.connect(user).withdrawDeposit(this.siloToken.address, 2, '1000', EXTERNAL);
+          this.result = await this.silo.connect(user).withdrawDeposit(this.siloToken.address, 1, '1000', EXTERNAL);
         });
     
         it('properly updates the total balances', async function () {
@@ -240,7 +244,7 @@ describe('Silo Token', function () {
         
 
         it('properly removes the deposit', async function () {
-          const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+          const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
           expect(deposit[0]).to.eq('0');
           expect(deposit[1]).to.eq('0');
         });
@@ -250,13 +254,13 @@ describe('Silo Token', function () {
         // });
     
         it('emits RemoveDeposit event', async function () {
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, this.siloToken.address, 2, '1000');
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, this.siloToken.address, 1, '1000');
         });
       });
       
       describe('withdraw part of a bean crate', function () {
         beforeEach(async function () {
-          this.result = await this.silo.connect(user).withdrawDeposit(this.siloToken.address, 2, '500', EXTERNAL);
+          this.result = await this.silo.connect(user).withdrawDeposit(this.siloToken.address, 1, '500', EXTERNAL);
         });
     
         it('properly updates the total balances', async function () {
@@ -271,7 +275,7 @@ describe('Silo Token', function () {
         });
 
         it('properly removes the deposit', async function () {
-          const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+          const deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
           expect(deposit[0]).to.eq('500');
           expect(deposit[1]).to.eq('500');
         });
@@ -281,7 +285,7 @@ describe('Silo Token', function () {
         // });
 
         it('emits RemoveDeposit event', async function () {
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, this.siloToken.address, 2, '500');
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposit').withArgs(userAddress, this.siloToken.address, 1, '500');
         });
       });
     });
@@ -292,7 +296,7 @@ describe('Silo Token', function () {
           await this.season.siloSunrise(0);
           await this.silo.connect(user).deposit(this.siloToken.address, '1000', EXTERNAL);
           userBalanceBefore = await this.siloToken.balanceOf(userAddress);
-          this.result = await this.silo.connect(user).withdrawDeposits(this.siloToken.address, [2,3],['500','1000'], EXTERNAL);
+          this.result = await this.silo.connect(user).withdrawDeposits(this.siloToken.address, [1,2],['500','1000'], EXTERNAL);
         });
     
         it('properly updates the total balances', async function () {
@@ -307,15 +311,15 @@ describe('Silo Token', function () {
 
         });
         it('properly removes the crate', async function () {
-          let dep = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+          let dep = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
           expect(dep[0]).to.equal('500')
           expect(dep[1]).to.equal('500')
-          dep = await this.silo.getDeposit(userAddress, this.siloToken.address, 3);
+          dep = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
           expect(dep[0]).to.equal('0')
           expect(dep[1]).to.equal('0')
         });
         it('emits RemoveDeposits event', async function () {
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2,3], ['500', '1000'], '1500');
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1,2], ['500', '1000'], '1500');
         });
       });
       describe('2 token crates', function () {
@@ -323,7 +327,7 @@ describe('Silo Token', function () {
           await this.season.siloSunrise(0);
           await this.silo.connect(user).deposit(this.siloToken.address, '1000', EXTERNAL);
           userBalanceBefore = await this.siloToken.balanceOf(userAddress);
-          this.result = await this.silo.connect(user).withdrawDeposits(this.siloToken.address, [2,3],['1000','1000'], EXTERNAL);
+          this.result = await this.silo.connect(user).withdrawDeposits(this.siloToken.address, [1,2],['1000','1000'], EXTERNAL);
         });
     
         it('properly updates the total balances', async function () {
@@ -337,15 +341,15 @@ describe('Silo Token', function () {
           expect((await this.siloToken.balanceOf(userAddress)).sub(userBalanceBefore)).to.eq('2000');
         });
         it('properly removes the crate', async function () {
-          let dep = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+          let dep = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
           expect(dep[0]).to.equal('0')
           expect(dep[1]).to.equal('0')
-          dep = await this.silo.getDeposit(userAddress, this.siloToken.address, 3);
+          dep = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
           expect(dep[0]).to.equal('0')
           expect(dep[1]).to.equal('0')
         });
         it('emits RemoveDeposits event', async function () {
-          await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2,3], ['1000', '1000'], '2000');
+          await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1,2], ['1000', '1000'], '2000');
         });
       });
     });
@@ -393,7 +397,7 @@ describe('Silo Token', function () {
         //expect(await this.silo.totalSeeds()).to.eq(pruneToSeeds(to6('10')));
       })
 
-      it('get Deposit', async function () {
+      it.only('get Deposit', async function () {
         const deposit = await this.silo.getDeposit(user.address, UNRIPE_BEAN, '2')
         expect(deposit[0]).to.equal(to6('10'))
         expect(deposit[1]).to.equal(prune(to6('10')))

--- a/protocol/test/SiloToken.test.js
+++ b/protocol/test/SiloToken.test.js
@@ -388,7 +388,11 @@ describe('Silo Token', function () {
   describe('Withdraw Unripe Beans', async function () {
     describe("Just legacy Bean Deposit", async function () {
       beforeEach(async function () {
-        await this.silo.connect(user).mockUnripeBeanDeposit('2', to6('10'))
+        //fast forward to season 10 because that's the zero point for our grownStalkPerBdv index
+        await this.season.teleportSunrise(10);
+
+        await this.silo.connect(user).mockUnripeBeanDeposit('2', to6('10')) //deposit in season 2
+        
       })
 
       it("Check mock works", async function () {
@@ -398,7 +402,21 @@ describe('Silo Token', function () {
       })
 
       it.only('get Deposit', async function () {
-        const deposit = await this.silo.getDeposit(user.address, UNRIPE_BEAN, '2')
+
+        //get current grown stalk per bdv for unripe bean token
+        const cumulative = await this.silo.cumulativeGrownStalkPerBdv(UNRIPE_BEAN);
+        console.log('cumulative: ', cumulative);
+
+
+
+        //if the deposit season was 2, what should the grownStalkPerBdv be?
+        //call silo.grownStalkPerBdvToSeason()
+        console.log('going to call seasonToGrownStalkPerBdv');
+        const grownStalkPerBdv = await this.silo.seasonToGrownStalkPerBdv(UNRIPE_BEAN, '2');
+        console.log('seasonToGrownStalkPerBdv: ', grownStalkPerBdv);
+
+        const deposit = await this.silo.getDeposit(user.address, UNRIPE_BEAN, grownStalkPerBdv)
+        console.log('deposit: ', deposit);
         expect(deposit[0]).to.equal(to6('10'))
         expect(deposit[1]).to.equal(prune(to6('10')))
       })

--- a/protocol/test/Sop.test.js
+++ b/protocol/test/Sop.test.js
@@ -61,7 +61,7 @@ describe('Sop', function () {
     it("Raining", async function () {
       await this.field.incrementTotalPodsE(to18('100'))
       await this.season.rainSunrise()
-      await this.silo.update(userAddress);
+      await this.silo.update(userAddress, this.beanMetapool);
       const rain = await this.season.rain()
       const season = await this.season.time()
       expect(season.rainStart).to.be.equal(season.current)
@@ -76,9 +76,9 @@ describe('Sop', function () {
     it("Stops raining", async function () {
       await this.field.incrementTotalPodsE(to18('100'))
       await this.season.rainSunrise()
-      await this.silo.update(userAddress);
+      await this.silo.update(userAddress, this.beanMetapool);
       await this.season.droughtSunrise()
-      await this.silo.update(userAddress);
+      await this.silo.update(userAddress, this.beanMetapool);
       const season = await this.season.time()
       expect(season.rainStart).to.be.equal(season.current - 1)
       const userRain = await this.silo.balanceOfSop(userAddress);
@@ -128,7 +128,7 @@ describe('Sop', function () {
     })
 
     it('tracks user plenty after update', async function () {
-      await this.silo.update(userAddress);
+      await this.silo.update(userAddress, this.beanMetapool);
       const userSop = await this.silo.balanceOfSop(userAddress);
       expect(userSop.lastRain).to.be.equal(3)
       expect(userSop.lastSop).to.be.equal(3)
@@ -185,7 +185,7 @@ describe('Sop', function () {
     })
 
     it('tracks user plenty after update', async function () {
-      await this.silo.update(userAddress);
+      await this.silo.update(userAddress, this.beanMetapool);
       const userSop = await this.silo.balanceOfSop(userAddress);
       expect(userSop.lastRain).to.be.equal(29)
       expect(userSop.lastSop).to.be.equal(29)

--- a/protocol/test/Sop.test.js
+++ b/protocol/test/Sop.test.js
@@ -61,7 +61,7 @@ describe('Sop', function () {
     it("Raining", async function () {
       await this.field.incrementTotalPodsE(to18('100'))
       await this.season.rainSunrise()
-      await this.silo.update(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool);
       const rain = await this.season.rain()
       const season = await this.season.time()
       expect(season.rainStart).to.be.equal(season.current)
@@ -76,9 +76,9 @@ describe('Sop', function () {
     it("Stops raining", async function () {
       await this.field.incrementTotalPodsE(to18('100'))
       await this.season.rainSunrise()
-      await this.silo.update(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool);
       await this.season.droughtSunrise()
-      await this.silo.update(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool);
       const season = await this.season.time()
       expect(season.rainStart).to.be.equal(season.current - 1)
       const userRain = await this.silo.balanceOfSop(userAddress);
@@ -109,7 +109,7 @@ describe('Sop', function () {
     beforeEach(async function () {
       await this.beanMetapool.connect(user).add_liquidity([to6('0'), to18('200')], to18('50'))
       await this.season.rainSunrise();
-      await this.silo.update(user2Address);
+      await this.silo.mow(user2Address);
       await this.season.rainSunrises(24);
     })
 
@@ -128,7 +128,7 @@ describe('Sop', function () {
     })
 
     it('tracks user plenty after update', async function () {
-      await this.silo.update(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool);
       const userSop = await this.silo.balanceOfSop(userAddress);
       expect(userSop.lastRain).to.be.equal(3)
       expect(userSop.lastSop).to.be.equal(3)
@@ -142,7 +142,7 @@ describe('Sop', function () {
     })
 
     it('tracks user2 plenty after update', async function () {
-      await this.silo.update(user2Address);
+      await this.silo.mow(user2Address);
       const userSop = await this.silo.balanceOfSop(user2Address);
       expect(userSop.lastRain).to.be.equal(3)
       expect(userSop.lastSop).to.be.equal(3)
@@ -152,7 +152,7 @@ describe('Sop', function () {
     })
 
     it('claims user plenty', async function () {
-      await this.silo.update(user2Address);
+      await this.silo.mow(user2Address);
       await this.silo.connect(user2).claimPlenty();
       expect(await this.silo.balanceOfPlenty(user2Address)).to.be.equal('0')
       expect(await this.threeCurve.balanceOf(user2Address)).to.be.equal('50208107346352812150')
@@ -163,7 +163,7 @@ describe('Sop', function () {
     beforeEach(async function () {
       await this.beanMetapool.connect(user).add_liquidity([to6('0'), to18('200')], to18('50'))
       await this.season.rainSunrise();
-      await this.silo.update(user2Address);
+      await this.silo.mow(user2Address);
       await this.season.rainSunrises(24);
       await this.season.droughtSunrise();
       await this.beanMetapool.connect(user).add_liquidity([to6('0'), to18('200')], to18('50'))
@@ -185,7 +185,7 @@ describe('Sop', function () {
     })
 
     it('tracks user plenty after update', async function () {
-      await this.silo.update(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool);
       const userSop = await this.silo.balanceOfSop(userAddress);
       expect(userSop.lastRain).to.be.equal(29)
       expect(userSop.lastSop).to.be.equal(29)
@@ -199,7 +199,7 @@ describe('Sop', function () {
     })
 
     it('tracks user2 plenty after update', async function () {
-      await this.silo.update(user2Address);
+      await this.silo.mow(user2Address);
       const userSop = await this.silo.balanceOfSop(user2Address);
       expect(userSop.lastRain).to.be.equal(29)
       expect(userSop.lastSop).to.be.equal(29)

--- a/protocol/test/Sop.test.js
+++ b/protocol/test/Sop.test.js
@@ -61,7 +61,7 @@ describe('Sop', function () {
     it("Raining", async function () {
       await this.field.incrementTotalPodsE(to18('100'))
       await this.season.rainSunrise()
-      await this.silo.mow(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool.address);
       const rain = await this.season.rain()
       const season = await this.season.time()
       expect(season.rainStart).to.be.equal(season.current)
@@ -76,9 +76,9 @@ describe('Sop', function () {
     it("Stops raining", async function () {
       await this.field.incrementTotalPodsE(to18('100'))
       await this.season.rainSunrise()
-      await this.silo.mow(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool.address);
       await this.season.droughtSunrise()
-      await this.silo.mow(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool.address);
       const season = await this.season.time()
       expect(season.rainStart).to.be.equal(season.current - 1)
       const userRain = await this.silo.balanceOfSop(userAddress);
@@ -109,7 +109,7 @@ describe('Sop', function () {
     beforeEach(async function () {
       await this.beanMetapool.connect(user).add_liquidity([to6('0'), to18('200')], to18('50'))
       await this.season.rainSunrise();
-      await this.silo.mow(user2Address);
+      await this.silo.mow(user2Address, this.bean.address);
       await this.season.rainSunrises(24);
     })
 
@@ -128,7 +128,7 @@ describe('Sop', function () {
     })
 
     it('tracks user plenty after update', async function () {
-      await this.silo.mow(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool.address);
       const userSop = await this.silo.balanceOfSop(userAddress);
       expect(userSop.lastRain).to.be.equal(3)
       expect(userSop.lastSop).to.be.equal(3)
@@ -141,8 +141,9 @@ describe('Sop', function () {
       expect(await this.silo.connect(user).balanceOfPlenty(user2Address)).to.be.equal('50208107346352812150')
     })
 
-    it('tracks user2 plenty after update', async function () {
-      await this.silo.mow(user2Address);
+    it.only('tracks user2 plenty after update', async function () {
+      await this.silo.mow(user2Address, this.beanMetapool.address);
+      // await this.silo.mow(user2Address, this.bean.address); //with this one uncommented it's 10002000000000000000000000
       const userSop = await this.silo.balanceOfSop(user2Address);
       expect(userSop.lastRain).to.be.equal(3)
       expect(userSop.lastSop).to.be.equal(3)
@@ -152,7 +153,7 @@ describe('Sop', function () {
     })
 
     it('claims user plenty', async function () {
-      await this.silo.mow(user2Address);
+      await this.silo.mow(user2Address, this.beanMetapool.address);
       await this.silo.connect(user2).claimPlenty();
       expect(await this.silo.balanceOfPlenty(user2Address)).to.be.equal('0')
       expect(await this.threeCurve.balanceOf(user2Address)).to.be.equal('50208107346352812150')
@@ -161,13 +162,22 @@ describe('Sop', function () {
 
   describe('multiple sop', async function () {
     beforeEach(async function () {
+      console.log('stalk 1: ', await this.silo.balanceOfStalk(user2Address));
+      console.log('roots 1: ', await this.silo.balanceOfRoots(user2Address));
       await this.beanMetapool.connect(user).add_liquidity([to6('0'), to18('200')], to18('50'))
       await this.season.rainSunrise();
-      await this.silo.mow(user2Address);
+      console.log('stalk 2a: ', await this.silo.balanceOfStalk(user2Address));
+      console.log('roots 2a: ', await this.silo.balanceOfRoots(user2Address));
+      await this.silo.mow(user2Address, this.beanMetapool.address);
+      await this.silo.mow(user2Address, this.bean.address);
+      console.log('stalk 2b: ', await this.silo.balanceOfStalk(user2Address));
+      console.log('roots 2b: ', await this.silo.balanceOfRoots(user2Address));
       await this.season.rainSunrises(24);
       await this.season.droughtSunrise();
       await this.beanMetapool.connect(user).add_liquidity([to6('0'), to18('200')], to18('50'))
       await this.season.rainSunrises(25);
+      console.log('stalk 3: ', await this.silo.balanceOfStalk(user2Address));
+      console.log('roots 3: ', await this.silo.balanceOfRoots(user2Address));
     })
 
     it('sops p > 1', async function () {
@@ -185,7 +195,7 @@ describe('Sop', function () {
     })
 
     it('tracks user plenty after update', async function () {
-      await this.silo.mow(userAddress, this.beanMetapool);
+      await this.silo.mow(userAddress, this.beanMetapool.address);
       const userSop = await this.silo.balanceOfSop(userAddress);
       expect(userSop.lastRain).to.be.equal(29)
       expect(userSop.lastSop).to.be.equal(29)
@@ -199,7 +209,8 @@ describe('Sop', function () {
     })
 
     it('tracks user2 plenty after update', async function () {
-      await this.silo.mow(user2Address);
+      await this.silo.mow(user2Address, this.beanMetapool.address);
+      await this.silo.mow(user2Address, this.bean.address);
       const userSop = await this.silo.balanceOfSop(user2Address);
       expect(userSop.lastRain).to.be.equal(29)
       expect(userSop.lastSop).to.be.equal(29)

--- a/protocol/test/Sop.test.js
+++ b/protocol/test/Sop.test.js
@@ -141,7 +141,7 @@ describe('Sop', function () {
       expect(await this.silo.connect(user).balanceOfPlenty(user2Address)).to.be.equal('50208107346352812150')
     })
 
-    it.only('tracks user2 plenty after update', async function () {
+    it('tracks user2 plenty after update', async function () {
       await this.silo.mow(user2Address, this.beanMetapool.address);
       // await this.silo.mow(user2Address, this.bean.address); //with this one uncommented it's 10002000000000000000000000
       const userSop = await this.silo.balanceOfSop(user2Address);
@@ -168,7 +168,6 @@ describe('Sop', function () {
       await this.season.rainSunrise();
       console.log('stalk 2a: ', await this.silo.balanceOfStalk(user2Address));
       console.log('roots 2a: ', await this.silo.balanceOfRoots(user2Address));
-      await this.silo.mow(user2Address, this.beanMetapool.address);
       await this.silo.mow(user2Address, this.bean.address);
       console.log('stalk 2b: ', await this.silo.balanceOfStalk(user2Address));
       console.log('roots 2b: ', await this.silo.balanceOfRoots(user2Address));

--- a/protocol/test/bdv.test.js
+++ b/protocol/test/bdv.test.js
@@ -51,6 +51,7 @@ describe('BDV', function () {
       this.siloToken.address, 
       this.silo.interface.getSighash("mockBDV(uint256 amount)"), 
       '10000', 
+      1e6, //aka "1 seed"
       '1');
 
     await this.season.siloSunrise(0);

--- a/protocol/test/utils/Convert.test.js
+++ b/protocol/test/utils/Convert.test.js
@@ -113,7 +113,7 @@
   
 //       it('properly updates total values', async function () {
 //         expect(await this.silo.totalDepositedBeans()).to.eq('47');
-//         expect(await this.silo.totalSeeds()).to.eq('3906');
+//         //expect(await this.silo.totalSeeds()).to.eq('3906');
 //         expect(await this.silo.totalStalk()).to.eq('10000000');
 //       });
 
@@ -141,7 +141,7 @@
   
 //       it('properly updates total values', async function () {
 //         expect(await this.silo.totalDepositedBeans()).to.eq('18098');
-//         expect(await this.silo.totalSeeds()).to.eq('43804');
+//         //expect(await this.silo.totalSeeds()).to.eq('43804');
 //         expect(await this.silo.totalStalk()).to.eq('200000000');
 //       });
 
@@ -170,7 +170,7 @@
   
 //       it('properly updates total values', async function () {
 //         expect(await this.silo.totalDepositedBeans()).to.eq('47');
-//         expect(await this.silo.totalSeeds()).to.eq('3906');
+//         //expect(await this.silo.totalSeeds()).to.eq('3906');
 //         expect(await this.silo.totalStalk()).to.eq('10000094');
 //       });
 
@@ -200,7 +200,7 @@
   
 //       it('properly updates total values', async function () {
 //         expect(await this.silo.totalDepositedBeans()).to.eq('47');
-//         expect(await this.silo.totalSeeds()).to.eq('3906');
+//         //expect(await this.silo.totalSeeds()).to.eq('3906');
 //         expect(await this.silo.totalStalk()).to.eq('10004000');
 //       });
 
@@ -230,7 +230,7 @@
   
 //       it('properly updates total values', async function () {
 //         expect(await this.silo.totalDepositedBeans()).to.eq('1047');
-//         expect(await this.silo.totalSeeds()).to.eq('5906');
+//         //expect(await this.silo.totalSeeds()).to.eq('5906');
 //         expect(await this.silo.totalStalk()).to.eq('20001000');
 //       });
 
@@ -284,7 +284,7 @@
 //       it('properly updates total values', async function () {
 //         expect(await this.silo.totalDepositedLP()).to.eq('0');
 //         expect(await this.silo.totalDepositedBeans()).to.eq('796');
-//         expect(await this.silo.totalSeeds()).to.eq('1592');
+//         //expect(await this.silo.totalSeeds()).to.eq('1592');
 //         expect(await this.silo.totalStalk()).to.eq('7960000');
 //       });
 
@@ -314,7 +314,7 @@
 //       it('properly updates total values', async function () {
 //         expect(await this.silo.totalDepositedLP()).to.eq('0');
 //         expect(await this.silo.totalDepositedBeans()).to.eq('799');
-//         expect(await this.silo.totalSeeds()).to.eq('1598');
+//         //expect(await this.silo.totalSeeds()).to.eq('1598');
 //         expect(await this.silo.totalStalk()).to.eq('7991598');
 //       });
 
@@ -345,7 +345,7 @@
 //       it('properly updates total values', async function () {
 //         expect(await this.silo.totalDepositedLP()).to.eq('1');
 //         expect(await this.silo.totalDepositedBeans()).to.eq('1596');
-//         expect(await this.silo.totalSeeds()).to.eq('4792');
+//         //expect(await this.silo.totalSeeds()).to.eq('4792');
 //         expect(await this.silo.totalStalk()).to.eq('19961600');
 //       });
 
@@ -398,17 +398,17 @@
 //       it('properly updates the total balances', async function () {
 //         expect(await this.silo.totalDepositedLP()).to.eq('1');
 //         expect(await this.silo.totalDepositedBeans()).to.eq('0');
-//         expect(await this.silo.totalSeeds()).to.eq('8000');
+//         //expect(await this.silo.totalSeeds()).to.eq('8000');
 //         expect(await this.silo.totalStalk()).to.eq('20000000');
 //       });
 
 //       it('properly updates the user balance', async function () {
-//         expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('8000');
+//         //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('8000');
 //         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('20000000')
 //       });
 
 //       it('properly updates the user total', async function () {
-//         expect(await this.silo.totalSeeds()).to.eq('8000');
+//         //expect(await this.silo.totalSeeds()).to.eq('8000');
 //         expect(await this.silo.totalStalk()).to.eq('20000000')
 //       });
 
@@ -430,12 +430,12 @@
 //       });
 
 //       it('properly updates the user balance', async function () {
-//         expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('8000');
+//         //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('8000');
 //         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('20016000')
 //       });
 
 //       it('properly updates the user total', async function () {
-//         expect(await this.silo.totalSeeds()).to.eq('8000');
+//         //expect(await this.silo.totalSeeds()).to.eq('8000');
 //         expect(await this.silo.totalStalk()).to.eq('20016000')
 //       });
 
@@ -461,12 +461,12 @@
 //       });
 
 //       it('properly updates the user balance', async function () {
-//         expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('9000');
+//         //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('9000');
 //         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('25018000')
 //       });
 
 //       it('properly updates the user total', async function () {
-//         expect(await this.silo.totalSeeds()).to.eq('9000');
+//         //expect(await this.silo.totalSeeds()).to.eq('9000');
 //         expect(await this.silo.totalStalk()).to.eq('25018000')
 //       });
 
@@ -497,17 +497,17 @@
 //       it('properly updates the total balances', async function () {
 //         expect(await this.silo.totalDepositedLP()).to.eq('1');
 //         expect(await this.silo.totalDepositedBeans()).to.eq('0');
-//         expect(await this.silo.totalSeeds()).to.eq('8000');
+//         //expect(await this.silo.totalSeeds()).to.eq('8000');
 //         expect(await this.silo.totalStalk()).to.eq('20000000');
 //       });
 
 //       it('properly updates the user balance', async function () {
-//         expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('8000');
+//         //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('8000');
 //         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('20000000')
 //       });
 
 //       it('properly updates the user total', async function () {
-//         expect(await this.silo.totalSeeds()).to.eq('8000');
+//         //expect(await this.silo.totalSeeds()).to.eq('8000');
 //         expect(await this.silo.totalStalk()).to.eq('20000000')
 //       });
 
@@ -541,12 +541,12 @@
 //       });
 
 //       it('properly updates the user balance', async function () {
-//         expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('8000');
+//         //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('8000');
 //         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('20016000')
 //       });
 
 //       it('properly updates the user total', async function () {
-//         expect(await this.silo.totalSeeds()).to.eq('8000');
+//         //expect(await this.silo.totalSeeds()).to.eq('8000');
 //         expect(await this.silo.totalStalk()).to.eq('20016000')
 //       });
 
@@ -581,12 +581,12 @@
 //       });
 
 //       it('properly updates the user balance', async function () {
-//         expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('9000');
+//         //expect(await this.silo.balanceOfSeeds(userAddress)).to.eq('9000');
 //         expect(await this.silo.balanceOfStalk(userAddress)).to.eq('25018000')
 //       });
 
 //       it('properly updates the user total', async function () {
-//         expect(await this.silo.totalSeeds()).to.eq('9000');
+//         //expect(await this.silo.totalSeeds()).to.eq('9000');
 //         expect(await this.silo.totalStalk()).to.eq('25018000')
 //       });
 

--- a/protocol/test/utils/print.js
+++ b/protocol/test/utils/print.js
@@ -64,7 +64,7 @@ async function printAccount(account, silo) {
   console.log('---------------------------------------------')
   console.log(`Account: ${account}`)
   console.log(`Stalk: ${await silo.balanceOfStalk(account)}`)
-  console.log(`Seeds: ${await silo.balanceOfSeeds(account)}`)
+  // console.log(`Seeds: ${await silo.balanceOfSeeds(account)}`)
   console.log(`Plenty: ${await silo.balanceOfPlentyBase(account)}`)
   console.log(`Roots: ${await silo.balanceOfRoots(account)}`)
   console.log(`Last Update: ${await silo.lastUpdate(account)}`)


### PR DESCRIPTION
# Problem

Currently there are 2 problems in Beanstalk related to Deposits

1. Farmers with older Deposits may forfeit Stalk when converting from a Whitelisted Silo token with a higher `seedsPerBdv` to a Whitelisted Silo token with a lower `seedsPerBdv`
2.  `seedsPerBdv` must be static over time for each Whitelisted Silo token
3. `seedsPerBdv` cannot have Decimals

https://beanstalk-farms.notion.site/RFC-Cumulative-Stalk-per-BDV-2ed64ebd9aa6448f92e015c7a254b5c6

