### PR TITLE
Change Analytic's Volume chart to a bar chart and general improvements

### DIFF
--- a/projects/ui/src/components/Analytics/Bean/VolumeChart.tsx
+++ b/projects/ui/src/components/Analytics/Bean/VolumeChart.tsx
@@ -1,0 +1,164 @@
+import { CircularProgress, Stack, Typography } from '@mui/material';
+import React, { useMemo, useState } from 'react';
+import {
+  SeasonalVolumeDocument,
+  SeasonalVolumeQuery,
+} from '~/generated/graphql';
+import { timeFormat, timeParse } from 'd3-time-format';
+
+import BarChart from '~/components/Common/Charts/BarChart';
+import { BaseDataPoint } from '../../Common/Charts/ChartPropProvider';
+import ChartInfoOverlay from '../../Common/Charts/ChartInfoOverlay';
+import { FC } from '~/types';
+import ParentSize from '@visx/responsive/lib/components/ParentSize';
+import { QueryData } from '~/components/Common/Charts/BaseSeasonPlot';
+import QueryState from '../../Common/Charts/QueryState';
+import Row from '../../Common/Row';
+import TimeTabs from '../../Common/Charts/TimeTabs';
+import { tickFormatUSD } from '~/components/Analytics/formatters';
+import useGenerateChartSeries from '~/hooks/beanstalk/useGenerateChartSeries';
+import useSeasonsQuery from '~/hooks/beanstalk/useSeasonsQuery';
+import useTimeTabState from '~/hooks/app/useTimeTabState';
+
+type BarChartDatum = {
+  count: number;
+  maxSeason: number;
+  minSeason: number;
+  date: string;
+};
+
+type DataByDate = {
+  [key: string]: BaseDataPoint[];
+};
+
+const VolumeChart: FC<{ width: number; height: number }> = ({
+  width = undefined,
+  height,
+}) => {
+  const [currentHoverBar, setHoverBar] = useState<BarChartDatum | undefined>(
+    undefined
+  );
+
+  const queryConfig = useMemo(() => ({ context: { subgraph: 'bean' } }), []);
+
+  const timeTabParams = useTimeTabState();
+
+  const seasonsQuery = useSeasonsQuery(
+    SeasonalVolumeDocument,
+    timeTabParams[0][1],
+    queryConfig
+  );
+
+  const getValue = (season: SeasonalVolumeQuery['seasons'][number]) =>
+    parseFloat(season.hourlyVolumeUSD);
+
+  const queryData: QueryData = useGenerateChartSeries(
+    [{ query: seasonsQuery, getValue, key: 'value' }],
+    timeTabParams[0],
+    'timestamp'
+  );
+
+  const transformData: (data: BaseDataPoint[]) => BarChartDatum[] = (data) => {
+    if (data?.length === 0) return [];
+
+    const dateFormat = timeFormat('%Y/%m/%d');
+    const parseDate = timeParse('%Y/%m/%d');
+    const shortDateFormat = timeFormat('%m/%d');
+    const dataByDate = data.reduce((accum: DataByDate, datum: any) => {
+      const key = dateFormat(datum.date);
+      if (!accum[key]) {
+        accum[key] = [];
+      }
+      accum[key].push(datum);
+      return accum;
+    }, {});
+
+    return Object.entries(dataByDate).map(([date, dayData]) => {
+      const seasons = dayData.map((datum) => datum.season);
+      return {
+        date: shortDateFormat(parseDate(date) as Date),
+        maxSeason: Math.max(...seasons),
+        minSeason: Math.min(...seasons),
+        count: dayData.reduce((accum: number, datum) => accum + datum.value, 0),
+      };
+    });
+  };
+
+  const formatValue = (value: number) =>
+    `$${value.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+
+  const currentSeason =
+    currentHoverBar?.minSeason && currentHoverBar?.maxSeason
+      ? `${currentHoverBar?.minSeason ?? ''} - ${
+          currentHoverBar?.maxSeason ?? ''
+        }`
+      : 0;
+
+  const chartControlsHeight = 75;
+  const chartHeight = height - chartControlsHeight;
+  const containerStyle = {
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: chartHeight,
+  };
+
+  return (
+    <>
+      <Row
+        justifyContent="space-between"
+        sx={{ px: 2, maxHeight: chartControlsHeight }}
+      >
+        <ChartInfoOverlay
+          title="Volume"
+          titleTooltip="The total volume in the BEAN:3CRV pool in every Season."
+          gap={0.25}
+          isLoading={queryData?.loading}
+          amount={formatValue(currentHoverBar?.count ?? 0)}
+          subtitle={`Season ${currentSeason}`}
+        />
+        <Stack alignItems="flex-end" alignSelf="flex-start">
+          <TimeTabs
+            state={timeTabParams[0]}
+            setState={timeTabParams[1]}
+            aggregation={false}
+          />
+        </Stack>
+      </Row>
+      <QueryState
+        queryData={queryData}
+        loading={
+          <Stack sx={containerStyle}>
+            <CircularProgress variant="indeterminate" />
+          </Stack>
+        }
+        error={
+          <Stack sx={containerStyle}>
+            <Typography>An error occurred while loading this data.</Typography>
+          </Stack>
+        }
+        success={
+          <ParentSize parentSizeStyles={{ height: chartHeight }}>
+            {(parent) => (
+              <BarChart
+                seriesData={transformData(queryData?.data[0])}
+                getX={(datum) => datum.date}
+                getY={(datum) => Number(datum.count)}
+                xTickFormat={(date: string) => date}
+                yTickFormat={tickFormatUSD}
+                width={width || parent.width}
+                height={chartHeight || parent.height}
+                onBarHoverEnter={(datum) => {
+                  setHoverBar(datum as BarChartDatum);
+                }}
+                onBarHoverLeave={() => setHoverBar(undefined)}
+              />
+            )}
+          </ParentSize>
+        }
+      />
+    </>
+  );
+};
+
+export default VolumeChart;

--- a/projects/ui/src/components/Analytics/Bean/VolumeChart.tsx
+++ b/projects/ui/src/components/Analytics/Bean/VolumeChart.tsx
@@ -151,7 +151,6 @@ const VolumeChart: FC<{ width: number; height: number }> = ({
                 onBarHoverEnter={(datum) => {
                   setHoverBar(datum as BarChartDatum);
                 }}
-                onBarHoverLeave={() => setHoverBar(undefined)}
               />
             )}
           </ParentSize>

--- a/projects/ui/src/components/Analytics/Bean/index.tsx
+++ b/projects/ui/src/components/Analytics/Bean/index.tsx
@@ -8,7 +8,7 @@ import MarketCap from '~/components/Analytics/Bean/MarketCap';
 import Price from './Price';
 import React from 'react';
 import Supply from '~/components/Analytics/Bean/Supply';
-import Volume from '~/components/Analytics/Bean/Volume';
+import VolumeChart from '~/components/Analytics/Bean/VolumeChart';
 import useTabs from '~/hooks/display/useTabs';
 
 const SLUGS = [
@@ -46,7 +46,7 @@ const BeanAnalytics: FC<{}> = () => {
           exact height. Alternatively, the existing height prop should be renamed to chartHeight.
       */}
       {tab === 0 && <Price height={CHART_HEIGHT} />}
-      {tab === 1 && <Volume height={CHART_HEIGHT} />}
+      {tab === 1 && <VolumeChart height={375} />}
       {tab === 2 && <Liquidity height={CHART_HEIGHT} />}
       {tab === 3 && <MarketCap height={CHART_HEIGHT} />}
       {tab === 4 && <Supply height={CHART_HEIGHT} />}

--- a/projects/ui/src/components/Analytics/Bean/index.tsx
+++ b/projects/ui/src/components/Analytics/Bean/index.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
 import { Card, Tab, Tabs } from '@mui/material';
 
-import useTabs from '~/hooks/display/useTabs';
-import Price from './Price';
-import Supply from '~/components/Analytics/Bean/Supply';
-import MarketCap from '~/components/Analytics/Bean/MarketCap';
-import Volume from '~/components/Analytics/Bean/Volume';
-import Liquidity from '~/components/Analytics/Bean/Liquidity';
 import Crosses from '~/components/Analytics/Bean/Crosses';
 import DeltaB from '~/components/Analytics/Bean/DeltaB';
 import { FC } from '~/types';
+import Liquidity from '~/components/Analytics/Bean/Liquidity';
+import MarketCap from '~/components/Analytics/Bean/MarketCap';
+import Price from './Price';
+import React from 'react';
+import Supply from '~/components/Analytics/Bean/Supply';
+import Volume from '~/components/Analytics/Bean/Volume';
+import useTabs from '~/hooks/display/useTabs';
 
 const SLUGS = [
   'price',
@@ -23,6 +23,7 @@ const SLUGS = [
 
 const BeanAnalytics: FC<{}> = () => {
   const [tab, handleChangeTab] = useTabs(SLUGS, 'bean');
+  const CHART_HEIGHT = 300;
   return (
     <Card>
       <Tabs
@@ -38,13 +39,19 @@ const BeanAnalytics: FC<{}> = () => {
         <Tab label="Crosses" />
         <Tab label="Delta B" />
       </Tabs>
-      {tab === 0 && <Price height={300} />}
-      {tab === 1 && <Volume height={300} />}
-      {tab === 2 && <Liquidity height={300} />}
-      {tab === 3 && <MarketCap height={300} />}
-      {tab === 4 && <Supply height={300} />}
-      {tab === 5 && <Crosses height={300} />}
-      {tab === 6 && <DeltaB height={300} />}
+      {/* 
+        TODO: The height prop currently *only* reflects in the chart height. However, the full component
+          has other components that yield a larger height. All the components below should be refactored
+          to account for their additional parts, so when a height is put in then you would get that 
+          exact height. Alternatively, the existing height prop should be renamed to chartHeight.
+      */}
+      {tab === 0 && <Price height={CHART_HEIGHT} />}
+      {tab === 1 && <Volume height={CHART_HEIGHT} />}
+      {tab === 2 && <Liquidity height={CHART_HEIGHT} />}
+      {tab === 3 && <MarketCap height={CHART_HEIGHT} />}
+      {tab === 4 && <Supply height={CHART_HEIGHT} />}
+      {tab === 5 && <Crosses height={CHART_HEIGHT} />}
+      {tab === 6 && <DeltaB height={CHART_HEIGHT} />}
     </Card>
   );
 };

--- a/projects/ui/src/components/Common/Charts/BarChart.tsx
+++ b/projects/ui/src/components/Common/Charts/BarChart.tsx
@@ -177,8 +177,8 @@ const BarChart: React.FC<{
   getY: (datum: any) => number;
   xTickFormat: (datum: any) => string;
   yTickFormat: (datum: any) => string;
-  onBarHoverEnter: (datum: object) => void;
-  onBarHoverLeave: (datum: object) => void;
+  onBarHoverEnter?: (datum: object) => void;
+  onBarHoverLeave?: (datum: object) => void;
 }> = ({
   seriesData,
   width,
@@ -187,8 +187,8 @@ const BarChart: React.FC<{
   getY,
   xTickFormat,
   yTickFormat,
-  onBarHoverEnter,
-  onBarHoverLeave,
+  onBarHoverEnter = () => {},
+  onBarHoverLeave = () => {},
 }) => {
   const [activeBarIndex, setActiveBarIndex] = useState<number | undefined>(
     undefined

--- a/projects/ui/src/components/Common/Charts/BarChart.tsx
+++ b/projects/ui/src/components/Common/Charts/BarChart.tsx
@@ -205,7 +205,6 @@ const BarChart: React.FC<{
 
   return (
     <svg width={width} height={height}>
-      <rect width={width} height={height} fill="url(#teal)" rx={14} />
       <YAxis />
       <XAxis />
       <Group width={width - yAxisWidth}>

--- a/projects/ui/src/components/Common/Charts/BarChart.tsx
+++ b/projects/ui/src/components/Common/Charts/BarChart.tsx
@@ -1,0 +1,232 @@
+import { Axis, Orientation } from '@visx/axis';
+import React, { useMemo, useState } from 'react';
+import { scaleBand, scaleLinear } from '@visx/scale';
+
+import { BarRounded } from '@visx/shape';
+import { BeanstalkPalette } from '~/components/App/muiTheme';
+import { Group } from '@visx/group';
+import { chartHelpers } from './ChartPropProvider';
+import { withTooltip } from '@visx/tooltip';
+
+const {
+  common: {
+    axisColor,
+    axisHeight,
+    yAxisWidth,
+    xTickLabelProps,
+    yTickLabelProps,
+    margin,
+    chartPadding,
+  },
+} = chartHelpers;
+
+type BarChartHookParams = {
+  seriesData: any[];
+  chartWidth: number;
+  chartHeight: number;
+  getX: (datum: object) => string;
+  getY: (datum: object) => number;
+  xTickFormat: (datum: any) => string;
+  yTickFormat: (datum: any) => string;
+};
+
+const useBarChart = ({
+  seriesData,
+  chartWidth,
+  chartHeight,
+  getX,
+  getY,
+  xTickFormat,
+  yTickFormat,
+}: BarChartHookParams) => {
+  const xMax = chartWidth - yAxisWidth;
+  const yMax = chartHeight - axisHeight - margin.bottom;
+  const yMaxDomain = Math.max(...seriesData.map(getY));
+
+  const xScale = useMemo(
+    () =>
+      scaleBand<string>({
+        range: [0, xMax],
+        round: true,
+        domain: seriesData.map(getX),
+        padding: 0.4,
+      }),
+    // We are disabling this lint error because we only want this effect to re-run
+    // for the following values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [xMax, seriesData]
+  );
+
+  const yScale = useMemo(
+    () =>
+      scaleLinear<number>({
+        range: [yMax, 0],
+        round: true,
+        domain: [0, yMaxDomain * 1.2],
+      }),
+    // We are disabling this lint error because we only want this effect to re-run
+    // for the following values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [yMax, yMaxDomain, seriesData]
+  );
+
+  const Bar = useMemo(
+    () => {
+      const BarComponent: React.FC<{
+        datum: object;
+        isActive: boolean;
+        onBarHoverEnter: (datum: object) => void;
+        onBarHoverLeave: (datum: object) => void;
+      }> = ({ datum, isActive = false, onBarHoverEnter, onBarHoverLeave }) => {
+        const x = getX(datum);
+        const barWidth = xScale.bandwidth();
+        const barHeight = yMax - (yScale(getY(datum)) ?? 0);
+        const xPosition = xScale(x);
+        const yPosition = yMax - barHeight;
+
+        const fillColor = isActive ? 'rgba(0, 0, 0, 0.08)' : 'transparent';
+        const additionalHoverBarWidth = Math.round(barWidth * 0.3);
+        return (
+          <>
+            <BarRounded
+              key={`bar-${x}`}
+              radius={4}
+              top
+              style={{ cursor: 'pointer' }}
+              x={xPosition}
+              y={yPosition}
+              width={barWidth}
+              height={barHeight}
+              fill={BeanstalkPalette.theme.winter.primary}
+            />
+            <BarRounded
+              key={`hover-bar-${x}`}
+              radius={4}
+              top
+              style={{ cursor: 'pointer' }}
+              x={xPosition - additionalHoverBarWidth / 2}
+              y={0}
+              width={barWidth + additionalHoverBarWidth}
+              height={yMax}
+              fill={fillColor}
+              onPointerEnter={() => onBarHoverEnter(datum)}
+              onPointerLeave={() => onBarHoverLeave(datum)}
+            />
+          </>
+        );
+      };
+
+      return BarComponent;
+    },
+    // We are disabling this lint error because we only want this effect to re-run
+    // for the following values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [yMax, xScale, yScale]
+  );
+
+  const XAxis = useMemo(() => {
+    const XAxisComponent: React.FC = () => (
+      <Axis
+        key="x-axis"
+        top={yMax}
+        orientation={Orientation.bottom}
+        scale={xScale}
+        stroke={axisColor}
+        tickStroke={axisColor}
+        tickFormat={xTickFormat}
+        tickLabelProps={xTickLabelProps}
+      />
+    );
+
+    return XAxisComponent;
+    // We are disabling this lint error because we only want this effect to re-run
+    // for the following values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chartHeight, xScale]);
+
+  const YAxis = useMemo(() => {
+    const YAxisComponent: React.FC = () => (
+      <Axis
+        key="y-axis"
+        left={chartWidth - chartPadding.right}
+        orientation={Orientation.right}
+        scale={yScale}
+        stroke={axisColor}
+        tickFormat={yTickFormat}
+        tickStroke={axisColor}
+        tickLabelProps={yTickLabelProps}
+        numTicks={6}
+        strokeWidth={0}
+      />
+    );
+
+    return YAxisComponent;
+    // We are disabling this lint error because we only want this effect to re-run
+    // for the following values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chartWidth, yScale]);
+
+  return { XAxis, YAxis, Bar };
+};
+
+const BarChart: React.FC<{
+  seriesData: Array<object>;
+  width: number;
+  height: number;
+  getX: (datum: any) => string;
+  getY: (datum: any) => number;
+  xTickFormat: (datum: any) => string;
+  yTickFormat: (datum: any) => string;
+  onBarHoverEnter: (datum: object) => void;
+  onBarHoverLeave: (datum: object) => void;
+}> = ({
+  seriesData,
+  width,
+  height,
+  getX,
+  getY,
+  xTickFormat,
+  yTickFormat,
+  onBarHoverEnter,
+  onBarHoverLeave,
+}) => {
+  const [activeBarIndex, setActiveBarIndex] = useState<number | undefined>(
+    undefined
+  );
+  const { XAxis, YAxis, Bar } = useBarChart({
+    seriesData,
+    chartWidth: width,
+    chartHeight: height,
+    getX,
+    getY,
+    xTickFormat,
+    yTickFormat,
+  });
+
+  return (
+    <svg width={width} height={height}>
+      <rect width={width} height={height} fill="url(#teal)" rx={14} />
+      <YAxis />
+      <XAxis />
+      <Group width={width - yAxisWidth}>
+        {seriesData.map((d, index) => (
+          <Bar
+            key={index}
+            datum={d}
+            isActive={activeBarIndex === index}
+            onBarHoverEnter={(datum) => {
+              setActiveBarIndex(index);
+              onBarHoverEnter(datum);
+            }}
+            onBarHoverLeave={(datum) => {
+              setActiveBarIndex(undefined);
+              onBarHoverLeave(datum);
+            }}
+          />
+        ))}
+      </Group>
+    </svg>
+  );
+};
+
+export default withTooltip(BarChart);

--- a/projects/ui/src/components/Common/Charts/BaseSeasonPlot.tsx
+++ b/projects/ui/src/components/Common/Charts/BaseSeasonPlot.tsx
@@ -10,6 +10,7 @@ import { ApolloError } from '@apollo/client';
 import ChartInfoOverlay from './ChartInfoOverlay';
 import { MinimumViableSnapshotQuery } from '~/hooks/beanstalk/useSeasonsQuery';
 import MultiLineChart from './MultiLineChart';
+import QueryState from './QueryState';
 import Row from '../Row';
 import StackedAreaChart from './StackedAreaChart';
 import { StatProps } from '../Stat';
@@ -136,6 +137,12 @@ function BaseSeasonPlot<T extends MinimumViableSnapshotQuery>(props: Props<T>) {
     displaySeason !== undefined ? displaySeason : defaults.season
   ).toFixed();
 
+  const containerStyle = {
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
   return (
     <>
       <Row justifyContent="space-between" sx={{ px: 2 }}>
@@ -164,37 +171,47 @@ function BaseSeasonPlot<T extends MinimumViableSnapshotQuery>(props: Props<T>) {
         </Stack>
       </Row>
       <Box width="100%" sx={{ height, position: 'relative' }}>
-        {queryData.loading || seriesInput.length === 0 || queryData.error ? (
-          <Stack height="100%" alignItems="center" justifyContent="center">
-            {queryData.error ? (
+        <QueryState
+          queryData={queryData}
+          loading={
+            <Stack sx={containerStyle}>
+              <CircularProgress variant="indeterminate" />
+            </Stack>
+          }
+          error={
+            <Stack sx={containerStyle}>
               <Typography>
                 An error occurred while loading this data.
               </Typography>
-            ) : (
-              <CircularProgress variant="indeterminate" />
-            )}
-          </Stack>
-        ) : stackedArea ? (
-          <StackedAreaChart
-            series={seriesInput}
-            keys={queryData.keys}
-            onCursor={handleCursor}
-            formatValue={formatValue}
-            {...chartProps}
-          >
-            {(childProps) => <ExploitLine {...childProps} />}
-          </StackedAreaChart>
-        ) : (
-          <MultiLineChart
-            series={seriesInput}
-            keys={queryData.keys}
-            onCursor={handleCursor}
-            formatValue={formatValue}
-            {...chartProps}
-          >
-            {(childProps) => <ExploitLine {...childProps} />}
-          </MultiLineChart>
-        )}
+            </Stack>
+          }
+          success={
+            <>
+              {stackedArea && (
+                <StackedAreaChart
+                  series={seriesInput}
+                  keys={queryData.keys}
+                  onCursor={handleCursor}
+                  formatValue={formatValue}
+                  {...chartProps}
+                >
+                  {(childProps) => <ExploitLine {...childProps} />}
+                </StackedAreaChart>
+              )}
+              {!stackedArea && (
+                <MultiLineChart
+                  series={seriesInput}
+                  keys={queryData.keys}
+                  onCursor={handleCursor}
+                  formatValue={formatValue}
+                  {...chartProps}
+                >
+                  {(childProps) => <ExploitLine {...childProps} />}
+                </MultiLineChart>
+              )}
+            </>
+          }
+        />
       </Box>
     </>
   );

--- a/projects/ui/src/components/Common/Charts/BaseSeasonPlot.tsx
+++ b/projects/ui/src/components/Common/Charts/BaseSeasonPlot.tsx
@@ -5,13 +5,14 @@ import {
 } from './ChartPropProvider';
 import { Box, CircularProgress, Stack, Typography } from '@mui/material';
 import React, { useCallback, useMemo, useState } from 'react';
-import Stat, { StatProps } from '../Stat';
 
 import { ApolloError } from '@apollo/client';
+import ChartInfoOverlay from './ChartInfoOverlay';
 import { MinimumViableSnapshotQuery } from '~/hooks/beanstalk/useSeasonsQuery';
 import MultiLineChart from './MultiLineChart';
 import Row from '../Row';
 import StackedAreaChart from './StackedAreaChart';
+import { StatProps } from '../Stat';
 import { TimeTabStateParams } from '~/hooks/app/useTimeTabState';
 import TimeTabs from './TimeTabs';
 import { defaultValueFormatter } from './SeasonPlot';
@@ -131,30 +132,25 @@ function BaseSeasonPlot<T extends MinimumViableSnapshotQuery>(props: Props<T>) {
   if (!seriesInput || !queryData) {
     return null;
   }
+  const currentSeason = (
+    displaySeason !== undefined ? displaySeason : defaults.season
+  ).toFixed();
 
   return (
     <>
       <Row justifyContent="space-between" sx={{ px: 2 }}>
-        {statProps ? (
-          <Stat
-            {...statProps}
-            amount={
-              queryData?.loading ? (
-                <CircularProgress
-                  variant="indeterminate"
-                  size="1.18em"
-                  thickness={5}
-                />
-              ) : (
-                formatValue(displayValue ?? defaults.value)
-              )
-            }
-            subtitle={`Season ${(displaySeason !== undefined
-              ? displaySeason
-              : defaults.season
-            ).toFixed()}`}
+        {statProps && (
+          <ChartInfoOverlay
+            title={statProps.title}
+            titleTooltip={statProps.titleTooltip}
+            gap={statProps.gap}
+            sx={statProps.sx ?? {}}
+            isLoading={queryData?.loading}
+            amount={formatValue(displayValue ?? defaults.value)}
+            subtitle={`Season ${currentSeason}`}
           />
-        ) : null}
+        )}
+
         <Stack
           alignItems="flex-end"
           alignSelf="flex-start"

--- a/projects/ui/src/components/Common/Charts/BaseSeasonPlot.tsx
+++ b/projects/ui/src/components/Common/Charts/BaseSeasonPlot.tsx
@@ -1,16 +1,20 @@
+import {
+  BaseChartProps,
+  BaseDataPoint,
+  ExploitLine,
+} from './ChartPropProvider';
 import { Box, CircularProgress, Stack, Typography } from '@mui/material';
 import React, { useCallback, useMemo, useState } from 'react';
-import { ApolloError } from '@apollo/client';
-import { TimeTabStateParams } from '~/hooks/app/useTimeTabState';
-import { MinimumViableSnapshotQuery } from '~/hooks/beanstalk/useSeasonsQuery';
-
-import Row from '../Row';
 import Stat, { StatProps } from '../Stat';
-import { defaultValueFormatter } from './SeasonPlot';
-import TimeTabs from './TimeTabs';
-import { BaseChartProps, BaseDataPoint, ExploitLine } from './ChartPropProvider';
+
+import { ApolloError } from '@apollo/client';
+import { MinimumViableSnapshotQuery } from '~/hooks/beanstalk/useSeasonsQuery';
 import MultiLineChart from './MultiLineChart';
+import Row from '../Row';
 import StackedAreaChart from './StackedAreaChart';
+import { TimeTabStateParams } from '~/hooks/app/useTimeTabState';
+import TimeTabs from './TimeTabs';
+import { defaultValueFormatter } from './SeasonPlot';
 
 type BaseSeasonPlotProps = {
   /**
@@ -41,11 +45,11 @@ type BaseSeasonPlotProps = {
 };
 
 export type QueryData = {
-    data: BaseDataPoint[][];
-    loading: boolean;
-    error: ApolloError[] | undefined;
-    keys: string[];
-  }
+  data: BaseDataPoint[][];
+  loading: boolean;
+  error: ApolloError[] | undefined;
+  keys: string[];
+};
 
 type Props<T extends MinimumViableSnapshotQuery> = BaseSeasonPlotProps & {
   queryData?: QueryData;
@@ -69,7 +73,7 @@ function BaseSeasonPlot<T extends MinimumViableSnapshotQuery>(props: Props<T>) {
     ChartProps: chartProps,
     timeTabParams,
   } = props;
-  
+
   /// Display values
   const [displayValue, setDisplayValue] = useState<number | undefined>(
     undefined

--- a/projects/ui/src/components/Common/Charts/ChartInfoOverlay.tsx
+++ b/projects/ui/src/components/Common/Charts/ChartInfoOverlay.tsx
@@ -1,0 +1,31 @@
+import { CircularProgress } from '@mui/material';
+import React from 'react';
+import Stat from '../Stat';
+
+type ChartInfoProps = {
+  title: JSX.Element | string;
+  titleTooltip?: JSX.Element | string;
+  amount: JSX.Element | string;
+  subtitle: JSX.Element | string;
+  gap: any;
+  sx?: object;
+  isLoading: boolean;
+};
+
+const ChartInfoOverlay: React.FC<ChartInfoProps> = ({
+  isLoading,
+  amount,
+  ...statProps
+}) => (
+  <Stat
+    {...statProps}
+    amount={
+      isLoading ? (
+        <CircularProgress variant="indeterminate" size="1.18em" thickness={5} />
+      ) : (
+        amount
+      )
+    }
+  />
+);
+export default ChartInfoOverlay;

--- a/projects/ui/src/components/Common/Charts/ChartPropProvider.tsx
+++ b/projects/ui/src/components/Common/Charts/ChartPropProvider.tsx
@@ -51,6 +51,7 @@ type ChartStyleConfig = {
 type ChartSharedValuesProps = {
   strokeBuffer: number;
   margin: { top: number; bottom: number; left: number; right: number };
+  chartPadding: { right: number };
   axisColor: string;
   axisHeight: number;
   backgroundColor: string;
@@ -165,6 +166,10 @@ const margin = {
   bottom: 9,
   left: 0,
   right: 0,
+};
+
+const chartPadding = {
+  right: 17,
 };
 
 const chartColors = BeanstalkPalette.theme.winter.chart;
@@ -516,6 +521,7 @@ export const chartHelpers: ProviderChartProps = {
   common: {
     strokeBuffer,
     margin,
+    chartPadding,
     axisHeight,
     backgroundColor,
     labelColor,

--- a/projects/ui/src/components/Common/Charts/ChartPropProvider.tsx
+++ b/projects/ui/src/components/Common/Charts/ChartPropProvider.tsx
@@ -1,22 +1,23 @@
+import { CurveFactory, Series } from 'd3-shape';
+import { NumberLike, scaleLinear, scaleLog, scaleTime } from '@visx/scale';
 import React, { useMemo } from 'react';
-import { Series, CurveFactory } from 'd3-shape';
-import { bisector, extent, min, max } from 'd3-array';
-import { SeriesPoint } from '@visx/shape/lib/types';
-import { scaleLinear, scaleTime, scaleLog, NumberLike } from '@visx/scale';
 import { ScaleLinear, ScaleTime } from 'd3-scale';
-import { localPoint } from '@visx/event';
-import { TickFormatter } from '@visx/axis';
-import { Line } from '@visx/shape';
+import { bisector, extent, max, min } from 'd3-array';
 import {
+  curveBasis,
   curveLinear,
+  curveMonotoneX,
+  curveNatural,
   curveStep,
   curveStepAfter,
   curveStepBefore,
-  curveNatural,
-  curveBasis,
-  curveMonotoneX,
 } from '@visx/curve';
+
 import { BeanstalkPalette } from '~/components/App/muiTheme';
+import { Line } from '@visx/shape';
+import { SeriesPoint } from '@visx/shape/lib/types';
+import { TickFormatter } from '@visx/axis';
+import { localPoint } from '@visx/event';
 
 // -------------------------------------------------------------------------
 // --------------------------------- TYPES ---------------------------------
@@ -168,22 +169,22 @@ const margin = {
 
 const chartColors = BeanstalkPalette.theme.winter.chart;
 const defaultChartStyles: ChartMultiStyles = {
-  0 : {
+  0: {
     stroke: BeanstalkPalette.theme.winter.primary,
     fillPrimary: chartColors.primaryLight,
     strokeWidth: 2,
   },
-  1 : {
+  1: {
     stroke: chartColors.purple,
     fillPrimary: chartColors.purpleLight,
     strokeWidth: 2,
   },
-  2 : {
+  2: {
     stroke: chartColors.green,
     fillPrimary: chartColors.greenLight,
     strokeWidth: 2,
   },
-  3 : {
+  3: {
     stroke: chartColors.yellow,
     fillPrimary: chartColors.yellowLight,
     strokeWidth: 2,
@@ -280,7 +281,8 @@ const getY = (d: BaseDataPoint) => d.value;
 /**
  * Gets the Y value for a specific stack in a stacked area chart.
  */
-const getYByAsset = (d: BaseDataPoint, asset: string) => (d[asset] ? d[asset] : 0);
+const getYByAsset = (d: BaseDataPoint, asset: string) =>
+  d[asset] ? d[asset] : 0;
 
 /**
  * access 'date' property from BaseDataPoint
@@ -406,22 +408,19 @@ const generateScale = (
       // TWAP: floor at 0, max at 1.2 * highest price
       yScale = scaleLinear<number>({
         domain: [
-          Math.max(1 - (biggestDifference * M), 0),
-          Math.min(1 + (biggestDifference * M), 1.2 * yMax)
+          Math.max(1 - biggestDifference * M, 0),
+          Math.min(1 + biggestDifference * M, 1.2 * yMax),
         ],
       });
     } else if (isStackedArea) {
       yScale = scaleLinear<number>({
         clamp: true,
-        domain: [
-          0,
-          1.05 * (max(data, getY) as number),
-        ],
+        domain: [0, 1.05 * (max(data, getY) as number)],
       });
     } else {
       const yMin = min(data, getY) as number;
       const yMax = max(data, getY) as number;
-      const M = [0.9980, 1.002]; 
+      const M = [0.998, 1.002];
 
       yScale = scaleLinear<number>({
         clamp: false,
@@ -433,10 +432,7 @@ const generateScale = (
     }
 
     // Set range for xScale
-    xScale.range([
-      0,
-      width - yAxisWidth
-    ]);
+    xScale.range([0, width - yAxisWidth]);
 
     // Set range for yScale
     yScale.range([

--- a/projects/ui/src/components/Common/Charts/ChartPropProvider.tsx
+++ b/projects/ui/src/components/Common/Charts/ChartPropProvider.tsx
@@ -512,46 +512,45 @@ type ChartWrapperProps = {
   children: (props: ProviderChartProps) => React.ReactNode;
 };
 
+export const chartHelpers: ProviderChartProps = {
+  common: {
+    strokeBuffer,
+    margin,
+    axisHeight,
+    backgroundColor,
+    labelColor,
+    axisColor,
+    tickLabelColor,
+    yAxisWidth,
+    defaultChartStyles,
+    xTickLabelProps,
+    yTickLabelProps,
+    getChartStyles,
+  },
+  accessors: {
+    getX,
+    getY,
+    getYByAsset,
+    getD,
+    getY0,
+    getY1,
+    bisectSeason,
+    getYMin,
+    getYMax,
+  },
+  utils: {
+    generatePathFromStack,
+    generateScale,
+    getPointerValue,
+    getCurve,
+  },
+};
+
 /**
  * hook used to access commonly used chart functions and values
  */
 const ChartPropProvider: React.FC<ChartWrapperProps> = ({ children }) => {
-  const props = useMemo(
-    () => ({
-      common: {
-        strokeBuffer,
-        margin,
-        axisHeight,
-        backgroundColor,
-        labelColor,
-        axisColor,
-        tickLabelColor,
-        yAxisWidth,
-        defaultChartStyles,
-        xTickLabelProps,
-        yTickLabelProps,
-        getChartStyles,
-      },
-      accessors: {
-        getX,
-        getY,
-        getYByAsset,
-        getD,
-        getY0,
-        getY1,
-        bisectSeason,
-        getYMin,
-        getYMax,
-      },
-      utils: {
-        generatePathFromStack,
-        generateScale,
-        getPointerValue,
-        getCurve,
-      },
-    }),
-    []
-  );
+  const props = useMemo(() => chartHelpers, []);
   return (
     <>
       {children({

--- a/projects/ui/src/components/Common/Charts/LineChart.tsx
+++ b/projects/ui/src/components/Common/Charts/LineChart.tsx
@@ -113,6 +113,7 @@ const Graph: React.FC<GraphProps> = (props) => {
   } = props;
   const {
     margin,
+    chartPadding,
     axisHeight,
     axisColor,
     yAxisWidth,
@@ -255,7 +256,7 @@ const Graph: React.FC<GraphProps> = (props) => {
             numTicks={xTickNum}
           />
         </g>
-        <g transform={`translate(${width - 17}, 1)`}>
+        <g transform={`translate(${width - chartPadding.right}, 1)`}>
           <Axis
             key="axis"
             orientation={Orientation.right}

--- a/projects/ui/src/components/Common/Charts/LineChart.tsx
+++ b/projects/ui/src/components/Common/Charts/LineChart.tsx
@@ -1,23 +1,27 @@
+import { Axis, Orientation, TickFormatter } from '@visx/axis';
+import ChartPropProvider, {
+  BaseDataPoint,
+  ProviderChartProps,
+} from './ChartPropProvider';
+import { Line, LinePath } from '@visx/shape';
+import { NumberLike, scaleLinear } from '@visx/scale';
 import React, { useCallback, useMemo } from 'react';
-import ParentSize from '@visx/responsive/lib/components/ParentSize';
-import { LinePath, Line } from '@visx/shape';
-import { Group } from '@visx/group';
-import { scaleLinear, NumberLike } from '@visx/scale';
-import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import {
+  curveBasis,
   curveLinear,
+  curveMonotoneX,
+  curveNatural,
   curveStep,
   curveStepAfter,
   curveStepBefore,
-  curveNatural,
-  curveBasis,
-  curveMonotoneX,
 } from '@visx/curve';
-import { Axis, Orientation, TickFormatter } from '@visx/axis';
-import { CurveFactory } from 'd3-shape';
-import { NumberValue } from 'd3-scale';
+import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
+
 import { BeanstalkPalette } from '~/components/App/muiTheme';
-import ChartPropProvider, { BaseDataPoint, ProviderChartProps } from './ChartPropProvider';
+import { CurveFactory } from 'd3-shape';
+import { Group } from '@visx/group';
+import { NumberValue } from 'd3-scale';
+import ParentSize from '@visx/responsive/lib/components/ParentSize';
 
 // ------------------------
 //       Line Chart
@@ -61,7 +65,8 @@ export type LineChartProps = {
 type GraphProps = {
   width: number;
   height: number;
-} & LineChartProps & ProviderChartProps
+} & LineChartProps &
+  ProviderChartProps;
 
 // ------------------------
 //           Data
@@ -102,21 +107,32 @@ const Graph: React.FC<GraphProps> = (props) => {
     curve: _curve = 'linear',
     children,
     yTickFormat,
-    common, 
+    common,
     accessors,
-    utils
+    utils,
   } = props;
-  const { margin, axisHeight, axisColor, yAxisWidth, xTickLabelProps, yTickLabelProps } = common;
+  const {
+    margin,
+    axisHeight,
+    axisColor,
+    yAxisWidth,
+    xTickLabelProps,
+    yTickLabelProps,
+  } = common;
   const { getX, getY } = accessors;
   const { generateScale, getCurve, getPointerValue } = utils;
 
-  const series = useMemo(() => _series as unknown as BaseDataPoint[][], [_series]);
+  const series = useMemo(
+    () => _series as unknown as BaseDataPoint[][],
+    [_series]
+  );
   const curve = getCurve(_curve);
 
   // tooltip
-  const { containerBounds, containerRef } = useTooltipInPortal(
-    { scroll: true, detectBounds: true }
-  );
+  const { containerBounds, containerRef } = useTooltipInPortal({
+    scroll: true,
+    detectBounds: true,
+  });
 
   const {
     showTooltip,
@@ -126,8 +142,9 @@ const Graph: React.FC<GraphProps> = (props) => {
   } = useTooltip<BaseDataPoint[] | undefined>();
 
   const scales = useMemo(
-    () => generateScale(series, height, width, ['value'], false, isTWAP), 
-  [height, isTWAP, series, generateScale, width]);
+    () => generateScale(series, height, width, ['value'], false, isTWAP),
+    [height, isTWAP, series, generateScale, width]
+  );
 
   // Handlers
   const handleMouseLeave = useCallback(() => {
@@ -156,10 +173,13 @@ const Graph: React.FC<GraphProps> = (props) => {
 
   // const yTickNum = height > 180 ? undefined : 5;
   const xTickNum = width > 700 ? undefined : Math.floor(width / 70);
-  const xTickFormat = useCallback((v: NumberValue) => {
-    const d = scales[0].dScale.invert(v);
-    return `${d.getMonth() + 1}/${d.getDate()}`;
-  }, [scales]);
+  const xTickFormat = useCallback(
+    (v: NumberValue) => {
+      const d = scales[0].dScale.invert(v);
+      return `${d.getMonth() + 1}/${d.getDate()}`;
+    },
+    [scales]
+  );
 
   // Empty state
   if (!series || series.length === 0) return null;
@@ -178,7 +198,7 @@ const Graph: React.FC<GraphProps> = (props) => {
 
   return (
     <div style={{ position: 'relative' }}>
-      <div 
+      <div
         style={{
           position: 'absolute',
           bottom: dataRegion.yTop,
@@ -288,13 +308,17 @@ const LineChart: React.FC<LineChartProps> = (props) => (
     {({ ...providerProps }) => (
       <ParentSize debounceTime={50}>
         {({ width: visWidth, height: visHeight }) => (
-          <Graph width={visWidth} height={visHeight} {...providerProps} {...props}>
+          <Graph
+            width={visWidth}
+            height={visHeight}
+            {...providerProps}
+            {...props}
+          >
             {props.children}
           </Graph>
         )}
       </ParentSize>
     )}
-
   </ChartPropProvider>
 );
 

--- a/projects/ui/src/components/Common/Charts/QueryState.tsx
+++ b/projects/ui/src/components/Common/Charts/QueryState.tsx
@@ -1,0 +1,26 @@
+import { QueryData } from '~/components/Common/Charts/BaseSeasonPlot';
+import React from 'react';
+
+type QueryStateProps = {
+  queryData: QueryData;
+  loading: JSX.Element;
+  error: JSX.Element;
+  success: JSX.Element;
+};
+
+const QueryState: React.FC<QueryStateProps> = ({
+  queryData,
+  loading,
+  error,
+  success,
+}) => {
+  if (queryData.loading) {
+    return loading;
+  }
+  if (queryData.data.length === 0 || queryData.error) {
+    return error;
+  }
+  return success;
+};
+
+export default QueryState;


### PR DESCRIPTION




There are quite a few prettier formatting change commits, and there are quite a few refactor commits in this PR. When reviewing, please go through each commit individually. I segmented my changes with the reviewer in mind, so that it can be reviewed more easily.

I attached a video demonstrating the bar chart. Notice the season is now a range (ex, `Season  X - Y`). Previously, it was a singular value. This was necessary since I am grouping the data by day (previously it was hourly).
https://user-images.githubusercontent.com/92072158/222723401-a039080b-f921-44bf-bd29-5e9bd175ae25.mp4

Here is a screenshot of the current line chart:
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/92072158/222722979-2076dae0-fa14-484b-be2f-28785998f18c.png">




