### PR TITLE
Tweaked popup positioning and behavior on mobile

### DIFF
--- a/projects/ui/src/components/App/muiTheme.ts
+++ b/projects/ui/src/components/App/muiTheme.ts
@@ -538,7 +538,6 @@ const muiThemeBase: ThemeOptions = {
     MuiTooltip: {
       defaultProps: {
         enterTouchDelay: 0,
-        leaveTouchDelay: 2000,
         onClick: (e: React.MouseEvent) => e.stopPropagation(),
       },
       variants: [

--- a/projects/ui/src/components/App/muiTheme.ts
+++ b/projects/ui/src/components/App/muiTheme.ts
@@ -537,8 +537,6 @@ const muiThemeBase: ThemeOptions = {
     },
     MuiTooltip: {
       defaultProps: {
-        enterTouchDelay: 0,
-        leaveTouchDelay: 1000000,
         onClick: (e: React.MouseEvent) => e.stopPropagation(),
       },
       variants: [

--- a/projects/ui/src/components/App/muiTheme.ts
+++ b/projects/ui/src/components/App/muiTheme.ts
@@ -539,6 +539,11 @@ const muiThemeBase: ThemeOptions = {
       defaultProps: {
         enterTouchDelay: 0,
         onClick: (e: React.MouseEvent) => e.stopPropagation(),
+        PopperProps: {           
+          sx: {
+            zIndex: 5,
+          },
+        },
       },
       variants: [
         {

--- a/projects/ui/src/components/App/muiTheme.ts
+++ b/projects/ui/src/components/App/muiTheme.ts
@@ -537,6 +537,7 @@ const muiThemeBase: ThemeOptions = {
     },
     MuiTooltip: {
       defaultProps: {
+        enterTouchDelay: 0,
         onClick: (e: React.MouseEvent) => e.stopPropagation(),
       },
       variants: [

--- a/projects/ui/src/components/App/muiTheme.ts
+++ b/projects/ui/src/components/App/muiTheme.ts
@@ -538,6 +538,7 @@ const muiThemeBase: ThemeOptions = {
     MuiTooltip: {
       defaultProps: {
         enterTouchDelay: 0,
+        leaveTouchDelay: 2000,
         onClick: (e: React.MouseEvent) => e.stopPropagation(),
       },
       variants: [

--- a/projects/ui/src/components/Barn/MyFertilizer.tsx
+++ b/projects/ui/src/components/Barn/MyFertilizer.tsx
@@ -9,7 +9,9 @@ import {
   Tabs,
   Tooltip,
   Typography,
+  useMediaQuery,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { useSelector } from 'react-redux';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import FertilizerItem from '~/components/Barn/FertilizerItem';
@@ -54,6 +56,9 @@ const MyFertilizer: FC<{}> = () => {
     return true;
   }) || [], [farmerBarn.balances, pctRepaid, tab]);
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
   return (
     <Card>
       {/* Card Header */}
@@ -64,17 +69,17 @@ const MyFertilizer: FC<{}> = () => {
             alignItems="center"
             justifyContent="space-between"
           >
-            <Tooltip
-              title="The number of Beans left to be earned from your Fertilizer. Sprouts become Rinsable on a pari passu basis."
-              placement="bottom"
-            >
-              <Typography variant="body1">
-                Sprouts&nbsp;
+            <Typography variant="body1">
+              Sprouts&nbsp;
+              <Tooltip
+                title="The number of Beans left to be earned from your Fertilizer. Sprouts become Rinsable on a pari passu basis."
+                placement={isMobile ? "top" : "bottom"}
+              >
                 <HelpOutlineIcon
                   sx={{ color: 'text.secondary', fontSize: FontSize.sm }}
                 />
-              </Typography>
-            </Tooltip>
+              </Tooltip>
+            </Typography>
             <Row alignItems="center" gap={0.2}>
               <TokenIcon token={SPROUTS} />
               <Typography>
@@ -88,17 +93,17 @@ const MyFertilizer: FC<{}> = () => {
             alignItems="center"
             justifyContent="space-between"
           >
-            <Tooltip
-              title="Sprouts that are redeemable for 1 Bean each. Rinsable Sprouts must be Rinsed in order to use them."
-              placement="bottom"
-            >
-              <Typography variant="body1">
-                Rinsable Sprouts&nbsp;
+            <Typography variant="body1">
+              Rinsable Sprouts&nbsp;
+              <Tooltip
+                title="Sprouts that are redeemable for 1 Bean each. Rinsable Sprouts must be Rinsed in order to use them."
+                placement={isMobile ? "top" : "bottom"}
+              >
                 <HelpOutlineIcon
                   sx={{ color: 'text.secondary', fontSize: FontSize.sm }}
                 />
-              </Typography>
-            </Tooltip>
+              </Tooltip>
+            </Typography>
             <Row alignItems="center" gap={0.2}>
               <TokenIcon token={RINSABLE_SPROUTS} />
               <Typography>

--- a/projects/ui/src/components/Barn/RemainingFertilizer.tsx
+++ b/projects/ui/src/components/Barn/RemainingFertilizer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Box, Card, Stack, Typography, Tooltip } from '@mui/material';
+import { Box, Card, Stack, Typography, Tooltip, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import useHumidity from '~/hooks/beanstalk/useHumidity';
 import SunriseCountdown from '~/components/Sun/SunriseCountdown';
@@ -24,6 +25,9 @@ const RemainingFertilizer: FC<{}> = () => {
   const nextDecreaseTimeString = season.eq(6074) 
     ? 'per Season upon Unpause'
     : <SunriseCountdown />;
+  
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   return (
     <Card sx={{ p: 2 }}>
@@ -44,7 +48,7 @@ const RemainingFertilizer: FC<{}> = () => {
             <Stack gap={0.5}>
               <Tooltip
                 title="The number of Fertilizer that can be bought from Beanstalk in exchange for 1 USDC each."
-                placement="bottom"
+                placement={isMobile ? "top" : "bottom"}
               >
                 <Typography variant="body1">
                   Available Fertilizer&nbsp;
@@ -76,7 +80,7 @@ const RemainingFertilizer: FC<{}> = () => {
             <Stack gap={0.5}>
               <Tooltip
                 title="The interest rate on Fertilizer. The Humidity determines how many Sprouts come with Fertilizer."
-                placement="bottom"
+                placement={isMobile ? "top" : "bottom"}
               >
                 <Typography>
                   Humidity&nbsp;

--- a/projects/ui/src/components/Barn/RemainingFertilizer.tsx
+++ b/projects/ui/src/components/Barn/RemainingFertilizer.tsx
@@ -46,18 +46,17 @@ const RemainingFertilizer: FC<{}> = () => {
           {/* right column */}
           <Stack justifyContent="space-between" gap={2}>
             <Stack gap={0.5}>
-              <Tooltip
-                title="The number of Fertilizer that can be bought from Beanstalk in exchange for 1 USDC each."
-                placement={isMobile ? "top" : "bottom"}
-              >
-                <Typography variant="body1">
-                  Available Fertilizer&nbsp;
+              <Typography variant="body1">
+                Available Fertilizer&nbsp;
+                <Tooltip
+                  title="The number of Fertilizer that can be bought from Beanstalk in exchange for 1 USDC each."
+                  placement={isMobile ? "top" : "bottom"}
+                >
                   <HelpOutlineIcon
                     sx={{ color: 'text.secondary', fontSize: FontSize.sm }}
                   />
-                </Typography>
-              </Tooltip>
-
+                </Tooltip>
+              </Typography>
               <Row gap={1} alignItems="center">
                 <Typography
                   display="inline-block"
@@ -78,17 +77,17 @@ const RemainingFertilizer: FC<{}> = () => {
               </Row>
             </Stack>
             <Stack gap={0.5}>
-              <Tooltip
-                title="The interest rate on Fertilizer. The Humidity determines how many Sprouts come with Fertilizer."
-                placement={isMobile ? "top" : "bottom"}
-              >
-                <Typography>
-                  Humidity&nbsp;
+              <Typography>
+                Humidity&nbsp;
+                <Tooltip
+                  title="The interest rate on Fertilizer. The Humidity determines how many Sprouts come with Fertilizer."
+                  placement={isMobile ? "top" : "bottom"}
+                >
                   <HelpOutlineIcon
                     sx={{ color: 'text.secondary', fontSize: FontSize.sm }}
                   />
-                </Typography>
-              </Tooltip>
+                </Tooltip>
+              </Typography>
               <Row alignItems="center" gap={1}>
                 <Typography variant="bodyLarge">
                   {displayFullBN(humidity.multipliedBy(100))}%

--- a/projects/ui/src/components/Common/Form/FieldWrapper.tsx
+++ b/projects/ui/src/components/Common/Form/FieldWrapper.tsx
@@ -1,9 +1,10 @@
 import React, { ReactNode } from 'react';
-import { Box, Tooltip, Typography } from '@mui/material';
+import { Box, Tooltip, Typography, useMediaQuery } from '@mui/material';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { FontSize } from '../../App/muiTheme';
 
 import { FC } from '~/types';
+import { useTheme } from '@mui/material/styles';
 
 const FieldWrapper : FC<{
   label?: ReactNode | string;
@@ -12,32 +13,39 @@ const FieldWrapper : FC<{
   label,
   tooltip,
   children
-}) => (
-  <Box>
-    {label && (
-      <Tooltip
-        title={tooltip !== undefined ? tooltip : ''}
-        placement="right-start"
-      >
-        <Typography
-          sx={{
-            fontSize: 'bodySmall',
-            px: 0.5,
-            mb: 0.25
-          }}
-          display="inline-block"
-        >
-          {label}&nbsp;
-          {tooltip && (
-            <HelpOutlineIcon
-              sx={{ color: 'text.tertiary', fontSize: FontSize.sm }}
-            />
-          )}
-        </Typography>
-      </Tooltip>
-    )}
-    {children}
-  </Box>
-);
+}) => {
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  return (
+    <Box>
+      {label && (
+          <Typography
+            sx={{
+              fontSize: 'bodySmall',
+              px: 0.5,
+              mb: 0.25
+            }}
+            display="inline-block"
+          >
+            {label}&nbsp;
+            {tooltip && (
+              <Tooltip
+                title={tooltip !== undefined ? tooltip : ''}
+                placement={isMobile ? "top" : "right-start"}
+              >
+                <HelpOutlineIcon
+                  sx={{ color: 'text.tertiary', fontSize: FontSize.sm }}
+                />
+              </Tooltip>
+            )}
+          </Typography>
+
+      )}
+      {children}
+    </Box>
+  );
+};
 
 export default FieldWrapper;

--- a/projects/ui/src/components/Common/Stat.tsx
+++ b/projects/ui/src/components/Common/Stat.tsx
@@ -4,7 +4,9 @@ import {
   TypographyProps,
   StackProps,
   Tooltip,
+  useMediaQuery
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import React from 'react';
 import Row from '~/components/Common/Row';
@@ -50,43 +52,49 @@ const Stat: FC<StatProps> = ({
   color,
   // Stack
   gap = 1,
-}) => (
-  <Stack gap={gap}>
-    {/* Title */}
-    <Row gap={0.5}>
-      {titleIcon && (<Typography><> {titleIcon}</></Typography>)}
-      <Typography variant="body1">
-        {title}
-        {titleTooltip && (
-          <Tooltip title={titleTooltip} placement="right">
-            <HelpOutlineIcon
-              sx={{
-                color: 'text.secondary',
-                display: 'inline',
-                mb: 0.5,
-                fontSize: '11px',
-              }}
-            />
-          </Tooltip>
-        )}
-      </Typography>
-    </Row>
-    {/* Amount */}
-    <Tooltip title={amountTooltip}>
-      <Typography variant={variant} color={color} sx={sx}>
-        <Row gap={0.5} width="100%">
-          {amountIcon && <>{amountIcon}</>}
-          {amount}
-        </Row>
-      </Typography>
-    </Tooltip>
-    {/* Subtitle */}
-    {subtitle !== undefined && (
-      <Typography variant="bodySmall" color="text.primary">
-        {subtitle}
-      </Typography>
-    )}
-  </Stack>
-);
+}) => {
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  return (
+    <Stack gap={gap}>
+      {/* Title */}
+      <Row gap={0.5}>
+        {titleIcon && (<Typography><> {titleIcon}</></Typography>)}
+        <Typography variant="body1">
+          {title}
+          {titleTooltip && (
+            <Tooltip title={titleTooltip} placement={isMobile ? "top" : "right" }>
+              <HelpOutlineIcon
+                sx={{
+                  color: 'text.secondary',
+                  display: 'inline',
+                  mb: 0.5,
+                  fontSize: '11px',
+                }}
+              />
+            </Tooltip>
+          )}
+        </Typography>
+      </Row>
+      {/* Amount */}
+      <Tooltip title={amountTooltip}>
+        <Typography variant={variant} color={color} sx={sx}>
+          <Row gap={0.5} width="100%">
+            {amountIcon && <>{amountIcon}</>}
+            {amount}
+          </Row>
+        </Typography>
+      </Tooltip>
+      {/* Subtitle */}
+      {subtitle !== undefined && (
+        <Typography variant="bodySmall" color="text.primary">
+          {subtitle}
+        </Typography>
+      )}
+    </Stack>
+  );
+};
 
 export default Stat;

--- a/projects/ui/src/components/Field/FieldConditions.tsx
+++ b/projects/ui/src/components/Field/FieldConditions.tsx
@@ -24,17 +24,17 @@ const FieldConditions: FC<FieldConditionsProps> = ({
       <Grid container spacing={1}>
         <Grid item xs={6} md={3}>
           <Stack gap={0.5}>
-            <Tooltip
-              title="The number of Beans that can currently be Sown (lent to Beanstalk)."
-              placement="top"
-            >
-              <Typography variant="body1">
-                Available Soil&nbsp;
+            <Typography variant="body1">
+              Available Soil&nbsp;
+              <Tooltip
+                title="The number of Beans that can currently be Sown (lent to Beanstalk)."
+                placement="top"
+              >
                 <HelpOutlineIcon
                   sx={{ color: 'text.secondary', fontSize: FontSize.sm }}
                 />
-              </Typography>
-            </Tooltip>
+              </Tooltip>
+            </Typography>
             <Typography variant="bodyLarge" fontWeight="400">
               {displayBN(beanstalkField.soil)}
             </Typography>
@@ -42,14 +42,14 @@ const FieldConditions: FC<FieldConditionsProps> = ({
         </Grid>
         <Grid item xs={6} md={3}>
           <Stack gap={0.5}>
-            <Tooltip title="The interest rate for Sowing Beans." placement="top">
-              <Typography variant="body1">
-                Temperature&nbsp;
+            <Typography variant="body1">
+              Temperature&nbsp;
+              <Tooltip title="The interest rate for Sowing Beans." placement="top">
                 <HelpOutlineIcon
                   sx={{ color: 'text.secondary', fontSize: FontSize.sm }}
                 />
-              </Typography>
-            </Tooltip>
+              </Tooltip>
+            </Typography>
             <Typography variant="bodyLarge" fontWeight="400">
               {displayBN(beanstalkField.weather.yield)}%
             </Typography>
@@ -57,29 +57,29 @@ const FieldConditions: FC<FieldConditionsProps> = ({
         </Grid>
         <Grid item xs={6} md={3}>
           <Stack gap={0.5}>
-            <Tooltip title="The number of Pods that will become Harvestable before Pods earned for newly Sown Beans, based on the FIFO Harvest schedule." placement="top">
-              <Typography variant="body1">
-                Pod Line&nbsp;
+            <Typography variant="body1">
+              Pod Line&nbsp;
+              <Tooltip title="The number of Pods that will become Harvestable before Pods earned for newly Sown Beans, based on the FIFO Harvest schedule." placement="top">
                 <HelpOutlineIcon
                   sx={{ color: 'text.secondary', fontSize: FontSize.sm }}
                 />
-              </Typography>
-            </Tooltip>
+              </Tooltip>
+            </Typography>
             <Typography variant="bodyLarge" fontWeight="400">
               {displayBN(beanstalkField.podLine)}
             </Typography>
           </Stack>
         </Grid>
         <Grid item xs={6} md={3}>
-          <Stack gap={0.5}>
-            <Tooltip title="The number of Pods that have become redeemable for a Bean (i.e., the debt paid back by Beanstalk to date)." placement="top">
-              <Typography variant="body1">
-                Pods Harvested&nbsp;
+          <Stack gap={0.5}>            
+            <Typography variant="body1">
+              Pods Harvested&nbsp;
+              <Tooltip title="The number of Pods that have become redeemable for a Bean (i.e., the debt paid back by Beanstalk to date)." placement="top">
                 <HelpOutlineIcon
                   sx={{ color: 'text.secondary', fontSize: FontSize.sm }}
                 />
-              </Typography>
-            </Tooltip>
+              </Tooltip>
+            </Typography>
             <Typography variant="bodyLarge">
               {displayBN(beanstalkField.harvestableIndex)}
             </Typography>

--- a/projects/ui/src/components/Silo/RewardItem.tsx
+++ b/projects/ui/src/components/Silo/RewardItem.tsx
@@ -40,16 +40,16 @@ const RewardItem: FC<RewardItemProps> = ({
   );
 
   const Title = () => (
-    <Tooltip title={tooltip ?? ''} placement="top">
-      <Typography sx={{ color: titleColor }}>
-        {title}
-        {tooltip && (
+    <Typography sx={{ color: titleColor }}>
+      {title}
+      {tooltip && (
+        <Tooltip title={tooltip ?? ''} placement="top">
           <HelpOutlineIcon
             sx={{ display: 'inline', mb: 0.5, fontSize: '11px', color: 'text.secondary' }}
           />
-        )}
-      </Typography>
-    </Tooltip>
+        </Tooltip>
+      )}
+    </Typography>
   );
 
   return (


### PR DESCRIPTION
Addressing some UX issues that have been brought up recently

Popups no longer instantly react to touch, needing a longer touch to open
Popups close themselves shortly after the touch event
Moved some popups so they appear above the button (and thus above the user's finger) on mobile