### PR TITLE
Trigger subgraph snapshots using Sunrise event

### DIFF
--- a/projects/subgraph-wells/schema.graphql
+++ b/projects/subgraph-wells/schema.graphql
@@ -28,7 +28,7 @@ type Aquifer @entity(immutable: true) {
   id: Bytes!
 
   " Wells deployed by this aquifer "
-  wells: [Well!]! @derivedFrom(field: "aquifer")
+  wells: [Well!]!
 }
 
 type WellFunction @entity {

--- a/projects/subgraph-wells/src/BeanstalkHandler.ts
+++ b/projects/subgraph-wells/src/BeanstalkHandler.ts
@@ -1,0 +1,16 @@
+import { Address } from "@graphprotocol/graph-ts";
+import { AQUIFER } from "../../subgraph-core/utils/Constants";
+import { Sunrise } from "../generated/Beanstalk/Beanstalk";
+import { loadOrCreateAquifer } from "./utils/Aquifer";
+import { checkForSnapshot } from "./utils/Well";
+
+export function handleSunrise(event: Sunrise): void {
+  // Right now this is a manual list of aquifers that are checked for deployments and wells updated
+  // Keeping this manual is reasonable as each aquifer has to be defined as a datasource in subgraph.yaml
+
+  let aquifer = loadOrCreateAquifer(AQUIFER);
+
+  for (let i = 0; i < aquifer.wells.length; i++) {
+    checkForSnapshot(Address.fromBytes(aquifer.wells[i]), event.block.timestamp, event.block.number);
+  }
+}

--- a/projects/subgraph-wells/src/templates/AquiferHandler.ts
+++ b/projects/subgraph-wells/src/templates/AquiferHandler.ts
@@ -7,7 +7,7 @@ import { loadOrCreateToken } from "../utils/Token";
 import { createWell, loadOrCreateWellFunction } from "../utils/Well";
 
 export function handleBoreWell(event: BoreWell): void {
-  loadOrCreateAquifer(event.address);
+  let aquifer = loadOrCreateAquifer(event.address);
 
   Well.create(event.params.well);
 
@@ -39,4 +39,9 @@ export function handleBoreWell(event: BoreWell): void {
   well.createdTimestamp = event.block.timestamp;
   well.createdBlockNumber = event.block.number;
   well.save();
+
+  let wells = aquifer.wells;
+  wells.push(event.params.well);
+  aquifer.wells = wells;
+  aquifer.save();
 }

--- a/projects/subgraph-wells/src/utils/Aquifer.ts
+++ b/projects/subgraph-wells/src/utils/Aquifer.ts
@@ -2,10 +2,11 @@ import { Address } from "@graphprotocol/graph-ts";
 import { Aquifer } from "../../generated/schema";
 
 export function loadOrCreateAquifer(aquiferAddress: Address): Aquifer {
-    let aquifer = Aquifer.load(aquiferAddress)
-    if (aquifer == null) {
-        aquifer = new Aquifer(aquiferAddress)
-        aquifer.save()
-    }
-    return aquifer as Aquifer
+  let aquifer = Aquifer.load(aquiferAddress);
+  if (aquifer == null) {
+    aquifer = new Aquifer(aquiferAddress);
+    aquifer.wells = [];
+    aquifer.save();
+  }
+  return aquifer as Aquifer;
 }

--- a/projects/subgraph-wells/subgraph.yaml
+++ b/projects/subgraph-wells/subgraph.yaml
@@ -24,6 +24,26 @@ dataSources:
         - event: BoreWell(address,address,address[],(address,bytes),(address,bytes)[],bytes)
           handler: handleBoreWell
       file: ./src/templates/AquiferHandler.ts
+  - kind: ethereum/contract
+    name: Beanstalk
+    network: mainnet
+    source:
+      address: "0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5"
+      abi: Beanstalk
+      startBlock: 16650000
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Beanstalk
+      abis:
+        - name: Beanstalk
+          file: ../subgraph-core/abis/Beanstalk/Beanstalk-Replanted.json
+      eventHandlers:
+        - event: Sunrise(indexed uint256)
+          handler: handleSunrise
+      file: ./src/BeanstalkHandler.ts
 templates:
   - kind: ethereum/contract
     name: Well


### PR DESCRIPTION
This adds a Beanstalk datasource to the Wells subgraph purely to use the `Sunrise` event as a trigger to check if any Well entity needs to have an hourly or daily snapshot taken.