### PR TITLE
Fixing issues seen in the BIP-34 proposal page

### DIFF
--- a/projects/ui/src/components/Common/MarkdownWrapper.tsx
+++ b/projects/ui/src/components/Common/MarkdownWrapper.tsx
@@ -134,7 +134,7 @@ const MarkdownWrapper: FC<{}> = ({ children }) => (
       img: {
         props: {
           style: {
-            width: '100%'
+            maxWidth: '100%'
           }
         }
       }

--- a/projects/ui/src/pages/governance/proposal.tsx
+++ b/projects/ui/src/pages/governance/proposal.tsx
@@ -46,7 +46,7 @@ const ProposalPageInner : FC<{ proposal: Proposal }> = ({ proposal }) => {
         ]} 
         />
         {/* <PageHeader returnPath="/governance" /> */}
-        <Grid container direction={{ xs: 'column-reverse', md: 'row' }} spacing={{ xs: 0, md: 2 }} gap={{ xs: 2, md: 0 }} maxWidth="100%">
+        <Grid container wrap="nowrap" direction={{ xs: 'column-reverse', md: 'row' }} spacing={{ xs: 0, md: 2 }} gap={{ xs: 2, md: 0 }} maxWidth="100%">
           <Grid item xs={12} md={8} maxWidth="100% !important">
             <ProposalContent
               proposal={proposal}


### PR DESCRIPTION
Fixed small images being stretched to maximum width 
Fixed proposal column sometimes being too wide and pushing the votes component to the bottom of the page