### PR TITLE
Remove immutable from Aquifer entity

### DIFF
--- a/projects/subgraph-wells/schema.graphql
+++ b/projects/subgraph-wells/schema.graphql
@@ -23,7 +23,7 @@ type Token @entity {
   lastPriceBlockNumber: BigInt!
 }
 
-type Aquifer @entity(immutable: true) {
+type Aquifer @entity() {
   " Smart contract address of the aquifer "
   id: Bytes!
 


### PR DESCRIPTION
Now that we are manually populating the list of wells deployed by an aquifer rather than using a derived field, this entity can no longer be flagged as immutable.