### PR TITLE
Show date/time on charts

### DIFF
--- a/projects/ui/src/components/Analytics/Bean/Price.tsx
+++ b/projects/ui/src/components/Analytics/Bean/Price.tsx
@@ -26,6 +26,7 @@ const lineChartProps: Partial<LineChartProps> = {
 const Price: FC<{ height?: SeasonPlotBaseProps['height'] }> = ({ height }) => {
   const price = usePrice();
   const season = useSeason();
+  const date = new Date();
   return (
     <SeasonPlot
       document={SeasonalPriceDocument}

--- a/projects/ui/src/components/Common/Charts/BaseSeasonPlot.tsx
+++ b/projects/ui/src/components/Common/Charts/BaseSeasonPlot.tsx
@@ -31,6 +31,12 @@ type BaseSeasonPlotProps = {
    * otherwise returns 0.
    */
   defaultSeason?: number;
+    /**
+   * The date displayed when the chart isn't being hovered.
+   * If not provided, uses the `date` of the last data point if available,
+   * otherwise returns the current timestamp.
+   */
+  defaultDate?: Date;
   /**
    * Height applied to the chart range. Can be a fixed
    * pixel number or a percent if the parent element has a constrained height.
@@ -68,6 +74,7 @@ function BaseSeasonPlot<T extends MinimumViableSnapshotQuery>(props: Props<T>) {
     // season plot base props
     defaultValue: _defaultValue,
     defaultSeason: _defaultSeason,
+    defaultDate: _defaultDate,
     height = '175px',
     stackedArea = false,
     formatValue = defaultValueFormatter,
@@ -85,16 +92,21 @@ function BaseSeasonPlot<T extends MinimumViableSnapshotQuery>(props: Props<T>) {
   const [displaySeason, setDisplaySeason] = useState<number | undefined>(
     undefined
   );
+  const [displayDate, setDisplayDate] = useState<any | undefined>(
+    undefined
+  );
 
   const handleCursor = useCallback(
-    (season: number | undefined, v?: number | undefined) => {
-      if (!season || !v) {
+    (season: number | undefined, value?: number | undefined, date?: Date | undefined ) => {
+      if (!season || !value) {
         setDisplaySeason(undefined);
         setDisplayValue(undefined);
+        setDisplayDate(undefined);
         return;
       }
       setDisplaySeason(season);
-      setDisplayValue(v);
+      setDisplayValue(value);
+      setDisplayDate(date);
     },
     []
   );
@@ -103,9 +115,12 @@ function BaseSeasonPlot<T extends MinimumViableSnapshotQuery>(props: Props<T>) {
 
   /// If one of the defaults is missing, use the last data point.
   const defaults = useMemo(() => {
+    const dataArray = seriesInput && seriesInput[0] ? seriesInput[0] : [{date: new Date()}];
+    const lastUpdateDate = dataArray[dataArray.length -1];
     const d = {
       value: _defaultValue ?? 0,
       season: _defaultSeason ?? 0,
+      date: _defaultDate ?? lastUpdateDate ? lastUpdateDate.date : new Date(),
     };
     const getVal = chartProps.getDisplayValue;
     const seriesLen = seriesInput?.length;
@@ -139,6 +154,10 @@ function BaseSeasonPlot<T extends MinimumViableSnapshotQuery>(props: Props<T>) {
     displaySeason !== undefined ? displaySeason : defaults.season
   ).toFixed();
 
+  const currentDate = (
+    displayDate !== undefined ? displayDate.toLocaleString() : defaults.date.toLocaleString()
+  );
+
   const containerStyle = {
     height: '100%',
     alignItems: 'center',
@@ -160,6 +179,7 @@ function BaseSeasonPlot<T extends MinimumViableSnapshotQuery>(props: Props<T>) {
             isLoading={queryData?.loading}
             amount={formatValue(displayValue ?? defaults.value)}
             subtitle={`Season ${currentSeason}`}
+            secondSubtitle={currentDate ?? `${currentDate}`}
           />
         )}
 

--- a/projects/ui/src/components/Common/Charts/BaseSeasonPlot.tsx
+++ b/projects/ui/src/components/Common/Charts/BaseSeasonPlot.tsx
@@ -153,9 +153,9 @@ function BaseSeasonPlot<T extends MinimumViableSnapshotQuery>(props: Props<T>) {
   const currentSeason = (
     displaySeason !== undefined ? displaySeason : defaults.season
   ).toFixed();
-
+    
   const currentDate = (
-    displayDate !== undefined ? displayDate.toLocaleString() : defaults.date.toLocaleString()
+    displayDate !== undefined ? displayDate.toLocaleString(undefined, {dateStyle: 'short', timeStyle: 'short'}) : defaults.date.toLocaleString(undefined, {dateStyle: 'short', timeStyle: 'short'})
   );
 
   const containerStyle = {

--- a/projects/ui/src/components/Common/Charts/ChartInfoOverlay.tsx
+++ b/projects/ui/src/components/Common/Charts/ChartInfoOverlay.tsx
@@ -7,6 +7,7 @@ type ChartInfoProps = {
   titleTooltip?: JSX.Element | string;
   amount: JSX.Element | string;
   subtitle: JSX.Element | string;
+  secondSubtitle: JSX.Element | string;
   gap: any;
   sx?: object;
   isLoading: boolean;

--- a/projects/ui/src/components/Common/Charts/ChartInfoOverlay.tsx
+++ b/projects/ui/src/components/Common/Charts/ChartInfoOverlay.tsx
@@ -7,7 +7,7 @@ type ChartInfoProps = {
   titleTooltip?: JSX.Element | string;
   amount: JSX.Element | string;
   subtitle: JSX.Element | string;
-  secondSubtitle: JSX.Element | string;
+  secondSubtitle?: JSX.Element | string;
   gap: any;
   sx?: object;
   isLoading: boolean;

--- a/projects/ui/src/components/Common/Charts/ChartPropProvider.tsx
+++ b/projects/ui/src/components/Common/Charts/ChartPropProvider.tsx
@@ -142,7 +142,7 @@ export type BaseChartProps = {
   stackedArea?: boolean;
   tooltip?: boolean | (({ d }: { d?: BaseDataPoint[] }) => JSX.Element | null);
   getDisplayValue: (v: BaseDataPoint[]) => number;
-  onCursor?: (season: number | undefined, v?: number | undefined) => void;
+  onCursor?: (season: number | undefined, v?: number | undefined, date?: Date | undefined) => void;
   children?: (props: ChartChildParams) => React.ReactElement | null;
   yTickFormat?: TickFormatter<NumberLike>;
   formatValue?: (value: number) => string | JSX.Element;

--- a/projects/ui/src/components/Common/Charts/MultiLineChart.tsx
+++ b/projects/ui/src/components/Common/Charts/MultiLineChart.tsx
@@ -87,7 +87,7 @@ const MultiLineChartInner: React.FC<Props> = (props) => {
         tooltipTop: containerY, // in pixels
       });
       const season = pointerData.length ? pointerData[0].season : undefined;
-      onCursor?.(season, getDisplayValue(pointerData));
+      onCursor?.(season, getDisplayValue(pointerData), pointerData[0].date);
     },
     [
       containerBounds,

--- a/projects/ui/src/components/Common/Charts/SeasonPlot.tsx
+++ b/projects/ui/src/components/Common/Charts/SeasonPlot.tsx
@@ -35,6 +35,12 @@ export type SeasonPlotBaseProps = {
    */
   defaultSeason?: number;
   /**
+   * The date displayed when the chart isn't being hovered.
+   * If not provided, uses the `date` of the last data point if available,
+   * otherwise returns the current timestamp.
+   */
+  defaultDate?: Date;
+  /**
    * Height applied to the chart range. Can be a fixed
    * pixel number or a percent if the parent element has a constrained height.
    */
@@ -67,6 +73,7 @@ function SeasonPlot<T extends MinimumViableSnapshotQuery>({
   document,
   defaultValue: _defaultValue,
   defaultSeason: _defaultSeason,
+  defaultDate: _defaultDate,
   getValue,
   formatValue = defaultValueFormatter,
   height = '175px',

--- a/projects/ui/src/components/Common/Charts/StackedAreaChart.tsx
+++ b/projects/ui/src/components/Common/Charts/StackedAreaChart.tsx
@@ -121,13 +121,12 @@ const Graph = (props: Props) => {
       const containerY =
         ('clientY' in event ? event.clientY : 0) - containerBounds.top - 10;
       const pointerData = getPointerValue(event, scales, series)[0];
-
       showTooltip({
         tooltipLeft: containerX,
         tooltipTop: containerY,
         tooltipData: pointerData,
       });
-      onCursor?.(pointerData.season, getDisplayValue([pointerData]));
+      onCursor?.(pointerData.season, getDisplayValue([pointerData]), pointerData.date);
     },
     [
       containerBounds,

--- a/projects/ui/src/components/Common/Stat.tsx
+++ b/projects/ui/src/components/Common/Stat.tsx
@@ -28,6 +28,8 @@ export type StatProps = {
   amountTooltip?: JSX.Element | string;
   /** Subtext shown below the statistic (ex. "Season X") */
   subtitle?: JSX.Element | string;
+  /** Subtext shown below the subtitle */
+  secondSubtitle?: JSX.Element | string;
   /** Typography variant to use (default: h1) */
   variant?: TypographyProps['variant'];
   /** Typography styles */
@@ -46,6 +48,7 @@ const Stat: FC<StatProps> = ({
   amountIcon,
   amountTooltip = '',
   subtitle,
+  secondSubtitle,
   // Typography
   sx,
   variant = 'h2',
@@ -97,6 +100,12 @@ const Stat: FC<StatProps> = ({
       {subtitle !== undefined && (
         <Typography variant="bodySmall" color="text.primary">
           {subtitle}
+        </Typography>
+      )}
+      {/* Second Subtitle */}
+      {secondSubtitle !== undefined && (
+        <Typography variant="bodySmall" color="text.primary">
+          {secondSubtitle}
         </Typography>
       )}
     </Stack>

--- a/projects/ui/src/components/Silo/Overview.tsx
+++ b/projects/ui/src/components/Silo/Overview.tsx
@@ -156,7 +156,7 @@ const Overview: FC<{
             () => [breakdown.states.deposited.value],
             [breakdown.states.deposited.value]
           )}
-          date={data.deposits[data.deposits.length - 1].date}
+          date={data.deposits[data.deposits.length - 1] ? data.deposits[data.deposits.length - 1].date : ""}
           series={
             useMemo(() => [data.deposits], [data.deposits]) as BaseDataPoint[][]
           }
@@ -178,7 +178,7 @@ const Overview: FC<{
             ],
             [farmerSilo.stalk.active, ownership]
           )}
-          date={data.stalk[data.stalk.length - 1].date}
+          date={data.stalk[data.stalk.length - 1] ? data.stalk[data.stalk.length - 1].date : ""}
           series={useMemo(
             () => [
               data.stalk,
@@ -201,7 +201,7 @@ const Overview: FC<{
             [farmerSilo.seeds.active]
           )}
           series={useMemo(() => [data.seeds], [data.seeds])}
-          date={data.seeds[data.seeds.length - 1].date}
+          date={data.seeds[data.seeds.length - 1] ? data.seeds[data.seeds.length - 1].date : ""}
           season={season}
           stats={seedsStats}
           loading={loading}

--- a/projects/ui/src/components/Silo/Overview.tsx
+++ b/projects/ui/src/components/Silo/Overview.tsx
@@ -27,7 +27,7 @@ import { BaseDataPoint } from '~/components/Common/Charts/ChartPropProvider';
 import stalkIconWinter from '~/img/beanstalk/stalk-icon-green.svg';
 import seedIconWinter from '~/img/beanstalk/seed-icon-green.svg';
 
-const depositStats = (s: BigNumber, v: BigNumber[]) => (
+const depositStats = (s: BigNumber, v: BigNumber[], d: string) => (
   <Stat
     title="Value Deposited"
     titleTooltip={
@@ -41,6 +41,7 @@ const depositStats = (s: BigNumber, v: BigNumber[]) => (
     }
     color="primary"
     subtitle={`Season ${s.toString()}`}
+    secondSubtitle={d}
     amount={displayUSD(v[0])}
     amountIcon={undefined}
     gap={0.25}
@@ -48,11 +49,12 @@ const depositStats = (s: BigNumber, v: BigNumber[]) => (
   />
 );
 
-const seedsStats = (s: BigNumber, v: BigNumber[]) => (
+const seedsStats = (s: BigNumber, v: BigNumber[], d: string) => (
   <Stat
     title="Seed Balance"
     titleTooltip="Seeds are illiquid tokens that yield 1/10,000 Stalk each Season."
     subtitle={`Season ${s.toString()}`}
+    secondSubtitle={d}
     amount={displayStalk(v[0])}
     sx={{ minWidth: 180, ml: 0 }}
     amountIcon={undefined}
@@ -74,18 +76,21 @@ const Overview: FC<{
   const account = useAccount();
   const { data, loading } = useFarmerSiloHistory(account, false, true);
 
+  console.log("SILO DATA", data)
+
   //
   const ownership =
     farmerSilo.stalk.active?.gt(0) && beanstalkSilo.stalk.total?.gt(0)
       ? farmerSilo.stalk.active.div(beanstalkSilo.stalk.total)
       : ZERO_BN;
   const stalkStats = useCallback(
-    (s: BigNumber, v: BigNumber[]) => (
+    (s: BigNumber, v: BigNumber[], d: string) => (
       <>
         <Stat
           title="Stalk Balance"
           titleTooltip="Stalk is the governance token of the Beanstalk DAO. Stalk entitles holders to passive interest in the form of a share of future Bean mints, and the right to propose and vote on BIPs. Your Stalk is forfeited when you Withdraw your Deposited assets from the Silo."
           subtitle={`Season ${s.toString()}`}
+          secondSubtitle={d}
           amount={displayStalk(v[0])}
           color="text.primary"
           sx={{ minWidth: 220, ml: 0 }}
@@ -153,6 +158,7 @@ const Overview: FC<{
             () => [breakdown.states.deposited.value],
             [breakdown.states.deposited.value]
           )}
+          date={data.deposits[data.deposits.length - 1].date}
           series={
             useMemo(() => [data.deposits], [data.deposits]) as BaseDataPoint[][]
           }
@@ -174,6 +180,7 @@ const Overview: FC<{
             ],
             [farmerSilo.stalk.active, ownership]
           )}
+          date={data.stalk[data.stalk.length - 1].date}
           series={useMemo(
             () => [
               data.stalk,
@@ -196,6 +203,7 @@ const Overview: FC<{
             [farmerSilo.seeds.active]
           )}
           series={useMemo(() => [data.seeds], [data.seeds])}
+          date={data.seeds[data.seeds.length - 1].date}
           season={season}
           stats={seedsStats}
           loading={loading}

--- a/projects/ui/src/components/Silo/Overview.tsx
+++ b/projects/ui/src/components/Silo/Overview.tsx
@@ -76,8 +76,6 @@ const Overview: FC<{
   const account = useAccount();
   const { data, loading } = useFarmerSiloHistory(account, false, true);
 
-  console.log("SILO DATA", data)
-
   //
   const ownership =
     farmerSilo.stalk.active?.gt(0) && beanstalkSilo.stalk.total?.gt(0)

--- a/projects/ui/src/components/Silo/OverviewPlot.tsx
+++ b/projects/ui/src/components/Silo/OverviewPlot.tsx
@@ -60,8 +60,6 @@ const OverviewPlot: FC<OverviewPlotProps> = ({
     [current, season, date]
   );
 
-  console.log("DATE: ", date)
-
   const [tabState, setTimeTab] = useState<TimeTabState>([
     SeasonAggregation.HOUR,
     SeasonRange.WEEK,

--- a/projects/ui/src/components/Silo/OverviewPlot.tsx
+++ b/projects/ui/src/components/Silo/OverviewPlot.tsx
@@ -44,17 +44,17 @@ const OverviewPlot: FC<OverviewPlotProps> = ({
 }) => {
   const [displaySeason, setDisplaySeason] = useState<BigNumber>(season);
   const [displayValue, setDisplayValue] = useState<BigNumber[]>(current);
-  const [displayDate, setDisplayDate] = useState<string>(date.toLocaleString());
+  const [displayDate, setDisplayDate] = useState<string>(date.toLocaleString(undefined, {dateStyle: 'short', timeStyle: 'short'}));
 
   useEffect(() => setDisplayValue(current), [current]);
   useEffect(() => setDisplaySeason(season), [season]);
-  useEffect(() => setDisplayDate(date.toLocaleString()), [date]);
+  useEffect(() => setDisplayDate(date.toLocaleString(undefined, {dateStyle: 'short', timeStyle: 'short'})), [date]);
 
   const handleCursor = useCallback(
     (dps?: BaseDataPoint[]) => {
       setDisplaySeason(dps ? new BigNumber(dps[0].season) : season);
       setDisplayValue(dps ? dps.map((dp) => new BigNumber(dp.value)) : current);
-      setDisplayDate(dps ? new Date(dps[0].date).toLocaleString() : date.toLocaleString());
+      setDisplayDate(dps ? new Date(dps[0].date).toLocaleString(undefined, {dateStyle: 'short', timeStyle: 'short'}) : date.toLocaleString(undefined, {dateStyle: 'short', timeStyle: 'short'}));
     },
     
     [current, season, date]

--- a/projects/ui/src/components/Silo/OverviewPlot.tsx
+++ b/projects/ui/src/components/Silo/OverviewPlot.tsx
@@ -23,8 +23,9 @@ export type OverviewPlotProps = {
   account: string | undefined;
   season: BigNumber;
   current: BigNumber[];
+  date: Date;
   series: BaseDataPoint[][];
-  stats: (season: BigNumber, value: BigNumber[]) => React.ReactElement;
+  stats: (season: BigNumber, value: BigNumber[], date: string) => React.ReactElement;
   empty: boolean;
   loading: boolean;
   label: string;
@@ -34,6 +35,7 @@ const OverviewPlot: FC<OverviewPlotProps> = ({
   account,
   season,
   current,
+  date,
   series,
   stats,
   loading,
@@ -42,17 +44,23 @@ const OverviewPlot: FC<OverviewPlotProps> = ({
 }) => {
   const [displaySeason, setDisplaySeason] = useState<BigNumber>(season);
   const [displayValue, setDisplayValue] = useState<BigNumber[]>(current);
+  const [displayDate, setDisplayDate] = useState<string>(date.toLocaleString());
 
   useEffect(() => setDisplayValue(current), [current]);
   useEffect(() => setDisplaySeason(season), [season]);
+  useEffect(() => setDisplayDate(date.toLocaleString()), [date]);
 
   const handleCursor = useCallback(
     (dps?: BaseDataPoint[]) => {
       setDisplaySeason(dps ? new BigNumber(dps[0].season) : season);
       setDisplayValue(dps ? dps.map((dp) => new BigNumber(dp.value)) : current);
+      setDisplayDate(dps ? new Date(dps[0].date).toLocaleString() : date.toLocaleString());
     },
-    [current, season]
+    
+    [current, season, date]
   );
+
+  console.log("DATE: ", date)
 
   const [tabState, setTimeTab] = useState<TimeTabState>([
     SeasonAggregation.HOUR,
@@ -82,7 +90,7 @@ const OverviewPlot: FC<OverviewPlotProps> = ({
           sx={{ px: 2, pb: { xs: 2, md: 0 } }}
           alignItems="flex-start"
         >
-          {stats(displaySeason, displayValue)}
+          {stats(displaySeason, displayValue, displayDate)}
         </Stack>
         <Stack alignItems="right">
           <TimeTabs

--- a/projects/ui/src/components/Silo/OverviewPlot.tsx
+++ b/projects/ui/src/components/Silo/OverviewPlot.tsx
@@ -23,7 +23,7 @@ export type OverviewPlotProps = {
   account: string | undefined;
   season: BigNumber;
   current: BigNumber[];
-  date: Date;
+  date: Date | string;
   series: BaseDataPoint[][];
   stats: (season: BigNumber, value: BigNumber[], date: string) => React.ReactElement;
   empty: boolean;


### PR DESCRIPTION
Added Date/Time display to a number of charts, by default it shows the date and time of the last season, updates on hover

Addresses Issue #427 