### PR TITLE
Silo Transaction Details - Copy fixes

### DIFF
--- a/projects/ui/src/components/Silo/Actions/Withdraw.tsx
+++ b/projects/ui/src/components/Silo/Actions/Withdraw.tsx
@@ -191,8 +191,8 @@ const WithdrawForm: FC<
                     },
                     {
                       type: ActionType.UPDATE_SILO_REWARDS,
-                      stalk: toBN(withdrawResult.stalk),
-                      seeds: toBN(withdrawResult.seeds),
+                      stalk: toBN(withdrawResult.stalk.mul(-1)),
+                      seeds: toBN(withdrawResult.seeds.mul(-1)),
                     },
                     {
                       type: ActionType.IN_TRANSIT,

--- a/projects/ui/src/util/Actions.ts
+++ b/projects/ui/src/util/Actions.ts
@@ -317,7 +317,7 @@ export const parseActionMessage = (a: Action) => {
         a.stalk.abs(),
         2
       )} Stalk and ${
-        a.seeds.lt(0) ? (a.stalk.gt(0) ? 'burn ' : '') : ''
+        a.seeds.lt(0) ? (a.stalk.gte(0) ? 'burn ' : '') : ''
       }${displayFullBN(a.seeds.abs(), 2)} Seeds.`;
     case ActionType.CLAIM_WITHDRAWAL:
       return `Claim ${displayFullBN(a.amount, 2)} ${a.token.name}.`;


### PR DESCRIPTION
Fixed text displayed in the Transaction Details component when user is receiving Stalk but losing Seeds

Fixed the Withdraw Transaction Details to correctly indicate that the user is losing seeds/stalk.