### PR TITLE
Swap Router Fixes & Improvements

### DIFF
--- a/projects/sdk/src/lib/farm/actions/AddLiquidity.ts
+++ b/projects/sdk/src/lib/farm/actions/AddLiquidity.ts
@@ -29,6 +29,7 @@ export class AddLiquidity extends StepClass<BasicPreparedResult> {
     });
 
     /// [0, 0, 1] => [0, 0, amountIn]
+    /// FIXME: this uses a binary approach instead of a multiplier.
     const amountInStep = this._amounts.map((k) => (k === 1 ? _amountInStep : ethers.BigNumber.from(0)));
 
     /// Get amount out based on the selected pool

--- a/projects/sdk/src/lib/farm/actions/AddLiquidity.ts
+++ b/projects/sdk/src/lib/farm/actions/AddLiquidity.ts
@@ -8,11 +8,11 @@ export class AddLiquidity extends StepClass<BasicPreparedResult> {
   public name: string = "addLiquidity";
 
   constructor(
-    private _pool: string,
-    private _registry: string,
-    private _amounts: readonly [number, number] | readonly [number, number, number],
-    private _fromMode: FarmFromMode = FarmFromMode.INTERNAL_TOLERANT,
-    private _toMode: FarmToMode = FarmToMode.INTERNAL
+    public readonly _pool: string,
+    public readonly _registry: string,
+    public readonly _amounts: readonly [number, number] | readonly [number, number, number],
+    public readonly _fromMode: FarmFromMode = FarmFromMode.INTERNAL_TOLERANT,
+    public readonly _toMode: FarmToMode = FarmToMode.INTERNAL
   ) {
     super();
   }

--- a/projects/sdk/src/lib/farm/actions/ClaimWithdrawal.ts
+++ b/projects/sdk/src/lib/farm/actions/ClaimWithdrawal.ts
@@ -5,7 +5,7 @@ import { FarmToMode } from "../types";
 export class ClaimWithdrawal extends StepClass<BasicPreparedResult> {
   public name: string = "claimWithdrawal";
 
-  constructor(private _tokenIn: string, private _season: ethers.BigNumberish, private _to: FarmToMode) {
+  constructor(public readonly _tokenIn: string, public readonly _season: ethers.BigNumberish, public readonly _to: FarmToMode) {
     super();
   }
 

--- a/projects/sdk/src/lib/farm/actions/ClaimWithdrawals.ts
+++ b/projects/sdk/src/lib/farm/actions/ClaimWithdrawals.ts
@@ -5,7 +5,7 @@ import { FarmToMode } from "../types";
 export class ClaimWithdrawals extends StepClass<BasicPreparedResult> {
   public name: string = "claimWithdrawals";
 
-  constructor(private _tokenIn: string, private _seasons: ethers.BigNumberish[], private _to: FarmToMode) {
+  constructor(public readonly _tokenIn: string, public readonly _seasons: ethers.BigNumberish[], public readonly _to: FarmToMode) {
     super();
   }
 

--- a/projects/sdk/src/lib/farm/actions/Deposit.ts
+++ b/projects/sdk/src/lib/farm/actions/Deposit.ts
@@ -6,7 +6,7 @@ import { Token } from "src/classes/Token";
 export class Deposit extends StepClass<BasicPreparedResult> {
   public name: string = "deposit";
 
-  constructor(private token: Token, private fromMode: FarmFromMode = FarmFromMode.INTERNAL_EXTERNAL) {
+  constructor(public readonly token: Token, public readonly fromMode: FarmFromMode = FarmFromMode.INTERNAL_EXTERNAL) {
     super();
   }
 

--- a/projects/sdk/src/lib/farm/actions/Exchange.ts
+++ b/projects/sdk/src/lib/farm/actions/Exchange.ts
@@ -8,12 +8,12 @@ export class Exchange extends StepClass implements StepClass<BasicPreparedResult
   public name: string = "exchange";
 
   constructor(
-    private pool: string,
-    private registry: string,
-    private tokenIn: Token,
-    private tokenOut: Token,
-    private fromMode: FarmFromMode = FarmFromMode.INTERNAL_TOLERANT,
-    private toMode: FarmToMode = FarmToMode.INTERNAL
+    public readonly pool: string,
+    public readonly registry: string,
+    public readonly tokenIn: Token,
+    public readonly tokenOut: Token,
+    public readonly fromMode: FarmFromMode = FarmFromMode.INTERNAL_TOLERANT,
+    public readonly toMode: FarmToMode = FarmToMode.INTERNAL
   ) {
     super();
   }

--- a/projects/sdk/src/lib/farm/actions/ExchangeUnderlying.ts
+++ b/projects/sdk/src/lib/farm/actions/ExchangeUnderlying.ts
@@ -8,11 +8,11 @@ export class ExchangeUnderlying extends StepClass<BasicPreparedResult> {
   public name: string = "exchangeUnderlying";
 
   constructor(
-    private pool: string,
-    private tokenIn: Token,
-    private tokenOut: Token,
-    private fromMode: FarmFromMode = FarmFromMode.INTERNAL_TOLERANT,
-    private toMode: FarmToMode = FarmToMode.INTERNAL
+    public readonly pool: string,
+    public readonly tokenIn: Token,
+    public readonly tokenOut: Token,
+    public readonly fromMode: FarmFromMode = FarmFromMode.INTERNAL_TOLERANT,
+    public readonly toMode: FarmToMode = FarmToMode.INTERNAL
   ) {
     super();
   }

--- a/projects/sdk/src/lib/farm/actions/PermitERC20.ts
+++ b/projects/sdk/src/lib/farm/actions/PermitERC20.ts
@@ -6,7 +6,7 @@ export class PermitERC20 extends StepClass<BasicPreparedResult> {
   public name: string = "attachPermitERC20";
 
   constructor(
-    private getPermit: string | SignedPermit<EIP2612PermitMessage> | ((context: RunContext) => any) = "permit" // any = permit
+    public readonly getPermit: string | SignedPermit<EIP2612PermitMessage> | ((context: RunContext) => any) = "permit" // any = permit
   ) {
     super();
   }

--- a/projects/sdk/src/lib/farm/actions/RemoveLiquidityOneToken.ts
+++ b/projects/sdk/src/lib/farm/actions/RemoveLiquidityOneToken.ts
@@ -7,11 +7,11 @@ export class RemoveLiquidityOneToken extends StepClass<BasicPreparedResult> {
   public name: string = "RemoveLiquidityOneToken";
 
   constructor(
-    private _pool: string,
-    private _registry: string,
-    private _tokenOut: string,
-    private _fromMode: FarmFromMode = FarmFromMode.INTERNAL_TOLERANT,
-    private _toMode: FarmToMode = FarmToMode.INTERNAL
+    public readonly _pool: string,
+    public readonly _registry: string,
+    public readonly _tokenOut: string,
+    public readonly _fromMode: FarmFromMode = FarmFromMode.INTERNAL_TOLERANT,
+    public readonly _toMode: FarmToMode = FarmToMode.INTERNAL
   ) {
     super();
   }
@@ -26,14 +26,14 @@ export class RemoveLiquidityOneToken extends StepClass<BasicPreparedResult> {
       toMode: this._toMode,
       context
     });
-    let registry
+    let registry;
     if (this._registry === RemoveLiquidityOneToken.sdk.contracts.curve.registries.poolRegistry.address) {
       registry = RemoveLiquidityOneToken.sdk.contracts.curve.registries.poolRegistry;
     } else if (this._registry === RemoveLiquidityOneToken.sdk.contracts.curve.registries.cryptoFactory.address) {
       registry = RemoveLiquidityOneToken.sdk.contracts.curve.registries.cryptoFactory;
     } else {
       registry = RemoveLiquidityOneToken.sdk.contracts.curve.registries.metaFactory;
-    };
+    }
     const coins = await registry.callStatic.get_coins(this._pool, { gasLimit: 10000000 });
     const i = coins.findIndex((addr) => addr.toLowerCase() === this._tokenOut.toLowerCase());
 

--- a/projects/sdk/src/lib/farm/actions/TransferDeposit.ts
+++ b/projects/sdk/src/lib/farm/actions/TransferDeposit.ts
@@ -5,11 +5,11 @@ export class TransferDeposit extends StepClass<BasicPreparedResult> {
   public name: string = "transferDeposit";
 
   constructor(
-    private _signer: string,
-    private _to: string,
-    private _tokenIn: string,
-    private _season: ethers.BigNumberish,
-    private _amount: ethers.BigNumberish
+    public readonly _signer: string,
+    public readonly _to: string,
+    public readonly _tokenIn: string,
+    public readonly _season: ethers.BigNumberish,
+    public readonly _amount: ethers.BigNumberish
   ) {
     super();
   }

--- a/projects/sdk/src/lib/farm/actions/TransferDeposits.ts
+++ b/projects/sdk/src/lib/farm/actions/TransferDeposits.ts
@@ -5,11 +5,11 @@ export class TransferDeposits extends StepClass<BasicPreparedResult> {
   public name: string = "transferDeposits";
 
   constructor(
-    private _signer: string,
-    private _to: string,
-    private _tokenIn: string,
-    private _seasons: ethers.BigNumberish[],
-    private _amounts: ethers.BigNumberish[]
+    public readonly _signer: string,
+    public readonly _to: string,
+    public readonly _tokenIn: string,
+    public readonly _seasons: ethers.BigNumberish[],
+    public readonly _amounts: ethers.BigNumberish[]
   ) {
     super();
   }

--- a/projects/sdk/src/lib/farm/actions/TransferToken.ts
+++ b/projects/sdk/src/lib/farm/actions/TransferToken.ts
@@ -6,10 +6,10 @@ export class TransferToken extends StepClass<BasicPreparedResult> {
   public name: string = "transferToken";
 
   constructor(
-    private _tokenIn: string,
-    private _recipient: string,
-    private _fromMode: FarmFromMode = FarmFromMode.INTERNAL_TOLERANT,
-    private _toMode: FarmToMode = FarmToMode.INTERNAL
+    public readonly _tokenIn: string,
+    public readonly _recipient: string,
+    public readonly _fromMode: FarmFromMode = FarmFromMode.INTERNAL_TOLERANT,
+    public readonly _toMode: FarmToMode = FarmToMode.INTERNAL
   ) {
     super();
   }

--- a/projects/sdk/src/lib/farm/actions/UnwrapEth.ts
+++ b/projects/sdk/src/lib/farm/actions/UnwrapEth.ts
@@ -5,7 +5,7 @@ import { FarmFromMode } from "../types";
 export class UnwrapEth extends StepClass<BasicPreparedResult> {
   public name: string = "unwrapEth";
 
-  constructor(private fromMode: FarmFromMode = FarmFromMode.INTERNAL) {
+  constructor(public readonly fromMode: FarmFromMode = FarmFromMode.INTERNAL) {
     super();
   }
 

--- a/projects/sdk/src/lib/farm/actions/WithdrawDeposit.ts
+++ b/projects/sdk/src/lib/farm/actions/WithdrawDeposit.ts
@@ -4,7 +4,11 @@ import { ethers } from "ethers";
 export class WithdrawDeposit extends StepClass<BasicPreparedResult> {
   public name: string = "withdrawDeposit";
 
-  constructor(private _tokenIn: string, private _season: ethers.BigNumberish, private _amount: ethers.BigNumberish) {
+  constructor(
+    public readonly _tokenIn: string,
+    public readonly _season: ethers.BigNumberish,
+    public readonly _amount: ethers.BigNumberish
+  ) {
     super();
   }
 

--- a/projects/sdk/src/lib/farm/actions/WithdrawDeposits.ts
+++ b/projects/sdk/src/lib/farm/actions/WithdrawDeposits.ts
@@ -4,7 +4,11 @@ import { ethers } from "ethers";
 export class WithdrawDeposits extends StepClass<BasicPreparedResult> {
   public name: string = "withdrawDeposits";
 
-  constructor(private _tokenIn: string, private _seasons: ethers.BigNumberish[], private _amounts: ethers.BigNumberish[]) {
+  constructor(
+    public readonly _tokenIn: string,
+    public readonly _seasons: ethers.BigNumberish[],
+    public readonly _amounts: ethers.BigNumberish[]
+  ) {
     super();
   }
 

--- a/projects/sdk/src/lib/farm/actions/WrapEth.ts
+++ b/projects/sdk/src/lib/farm/actions/WrapEth.ts
@@ -6,7 +6,7 @@ import { FarmToMode } from "../types";
 export class WrapEth extends StepClass<BasicPreparedResult> {
   public name: string = "wrapEth";
 
-  constructor(private toMode: FarmToMode = FarmToMode.INTERNAL) {
+  constructor(public readonly toMode: FarmToMode = FarmToMode.INTERNAL) {
     super();
   }
 

--- a/projects/sdk/src/lib/swap/Swap.estimates.test.ts
+++ b/projects/sdk/src/lib/swap/Swap.estimates.test.ts
@@ -17,7 +17,8 @@ describe("Estimate", function () {
     [sdk.tokens.ETH, sdk.tokens.USDC],
     [sdk.tokens.ETH, sdk.tokens.DAI],
     [sdk.tokens.ETH, sdk.tokens.BEAN],
-    [sdk.tokens.ETH, sdk.tokens.CRV3],
+    // FIXME: disabled for now due to lack of reverse estimation for AddLiquidity & RemoveLiquidityOneToken
+    // [sdk.tokens.ETH, sdk.tokens.CRV3],
 
     // BEAN => x
     [sdk.tokens.BEAN, sdk.tokens.ETH],

--- a/projects/sdk/src/lib/swap/graph.test.ts
+++ b/projects/sdk/src/lib/swap/graph.test.ts
@@ -1,7 +1,7 @@
 import { Graph } from "graphlib";
 import { FarmFromMode, FarmToMode } from "src/lib/farm";
 import { AddLiquidity, Exchange, RemoveLiquidityOneToken } from "src/lib/farm/actions";
-import { setBidirectionalExchangeEdges } from "src/lib/swap/graph";
+import { setBidirectionalAddRemoveLiquidityEdges, setBidirectionalExchangeEdges } from "src/lib/swap/graph";
 import { expectInstanceOf } from "src/utils";
 import { getTestUtils } from "src/utils/TestUtils/provider";
 
@@ -15,10 +15,7 @@ describe("setBidirectionalExchangeEdges", () => {
       compound: false
     });
 
-    const POOL = "pool";
-    const REGISTRY = "registry";
-
-    setBidirectionalExchangeEdges(sdk, graph, POOL, REGISTRY, sdk.tokens.DAI, sdk.tokens.USDC);
+    setBidirectionalExchangeEdges(sdk, graph, "pool", "registry", sdk.tokens.DAI, sdk.tokens.USDC);
 
     // Check: Existence
     expect(graph.hasEdge("DAI", "USDC")).toBeTruthy();
@@ -57,47 +54,92 @@ describe("setBidirectionalExchangeEdges", () => {
   });
 });
 
-describe("graph", () => {
+describe("setBidirectionalAddRemoveLiquidityEdges", () => {
+  const graph: Graph = new Graph({
+    multigraph: true,
+    directed: true,
+    compound: false
+  });
+
+  setBidirectionalAddRemoveLiquidityEdges(sdk, graph, "pool", "registry", sdk.tokens.CRV3, sdk.tokens.USDC, 2);
+
+  expect(graph.hasEdge("3CRV", "USDC")).toBeTruthy();
+  expect(graph.hasEdge("USDC", "3CRV")).toBeTruthy();
+
+  const edge0 = graph.edge("3CRV", "USDC");
+  const edge1 = graph.edge("USDC", "3CRV");
+
+  // Check: Unwrap CRV3 -> USDC
+  expect(edge0.from).toEqual("3CRV");
+  expect(edge0.to).toEqual("USDC");
+  expect(edge0.build).toBeInstanceOf(Function);
+
+  const build0 = edge0.build("", FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);
+  expectInstanceOf(build0, RemoveLiquidityOneToken);
+  expect(build0._pool).toEqual("pool");
+  expect(build0._registry).toEqual("registry");
+  expect(build0._tokenOut).toEqual(sdk.tokens.USDC.address);
+  expect(build0._fromMode).toEqual(FarmFromMode.EXTERNAL);
+  expect(build0._toMode).toEqual(FarmToMode.INTERNAL);
+
+  // Check: Wrap USDC -> CRV3
+  expect(edge1.from).toEqual("USDC");
+  expect(edge1.to).toEqual("3CRV");
+  expect(edge1.build).toBeInstanceOf(Function);
+
+  const build1 = edge1.build("", FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);
+  expectInstanceOf(build1, AddLiquidity);
+  expect(build1._pool).toEqual("pool");
+  expect(build1._registry).toEqual("registry");
+  expect(build1._amounts).toEqual([0, 0, 1]); // USDC is at index 2
+  expect(build1._fromMode).toEqual(FarmFromMode.EXTERNAL);
+  expect(build1._toMode).toEqual(FarmToMode.INTERNAL);
+});
+
+describe("routing", () => {
   const tokens = [sdk.tokens.DAI, sdk.tokens.USDC, sdk.tokens.USDT];
+  const symbols = tokens.map((token) => token.symbol);
 
-  // describe("wrap/unwrap LP", () => {
-  //   it.each(tokens)("%s -> 3CRV uses AddLiquidity", (token) => {
-  //     const route = sdk.swap.router.getRoute(token.symbol, sdk.tokens.CRV3.symbol);
-  //     const step = route.getStep(0).build(account, FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);
+  describe("3CRV LP", () => {
+    it.each(symbols)("%s -> 3CRV uses AddLiquidity", (symbol) => {
+      const route = sdk.swap.router.getRoute(symbol, sdk.tokens.CRV3.symbol);
+      const step = route.getStep(0).build(account, FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);
 
-  //     expect(route.length).toEqual(1);
-  //     expectInstanceOf(step, AddLiquidity);
-  //     expect(step._pool).toEqual(sdk.contracts.curve.pools.pool3.address);
-  //   });
+      expect(route.length).toEqual(1);
+      expectInstanceOf(step, AddLiquidity);
+      expect(step._pool).toEqual(sdk.contracts.curve.pools.pool3.address);
+    });
 
-  //   it.each(tokens)("3CRV -> %s uses RemoveLiquidity", (token) => {
-  //     const route = sdk.swap.router.getRoute(sdk.tokens.CRV3.symbol, token.symbol);
-  //     const step = route.getStep(0).build(account, FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);
+    it.each(symbols)("3CRV -> %s uses RemoveLiquidity", (symbol) => {
+      const route = sdk.swap.router.getRoute(sdk.tokens.CRV3.symbol, symbol);
+      const step = route.getStep(0).build(account, FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);
 
-  //     expect(route.length).toEqual(1);
-  //     expectInstanceOf(step, RemoveLiquidityOneToken);
-  //     expect(step._pool).toEqual(sdk.contracts.curve.pools.pool3.address);
-  //   });
-  // });
+      expect(route.length).toEqual(1);
+      expectInstanceOf(step, RemoveLiquidityOneToken);
+      expect(step._pool).toEqual(sdk.contracts.curve.pools.pool3.address);
+    });
+  });
 
-  // Make sure that stable swaps are efficient
-  // TODO: use it.each to better describe tests
-  it("routes 3CRV stable <> stable via 3pool", () => {
-    // For any combination of the above tokens, there should be a route via 3pool
-    for (let i = 0; i < tokens.length; i++) {
-      for (let j = 0; j < tokens.length; j++) {
-        if (i === j) continue;
+  describe("3CRV Underlying", () => {
+    // Make sure that stable swaps are efficient
+    // TODO: use it.each to better describe tests
+    it("routes 3CRV stable <> stable via 3pool", () => {
+      // For any combination of the above tokens, there should be a route via 3pool
+      for (let i = 0; i < tokens.length; i++) {
+        for (let j = 0; j < tokens.length; j++) {
+          if (i === j) continue;
 
-        const route = sdk.swap.router.getRoute(tokens[i].symbol, tokens[j].symbol);
-        const step = route.getStep(0).build(account, FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);
+          const route = sdk.swap.router.getRoute(tokens[i].symbol, tokens[j].symbol);
+          const step = route.getStep(0).build(account, FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);
 
-        // Expectation: There's a single step which is an Exchange via 3pool
-        expect(route.length).toEqual(1);
-        expectInstanceOf(step, Exchange);
-        expect(step.pool).toEqual(sdk.contracts.curve.pools.pool3.address);
-        expect(step.tokenIn).toEqual(tokens[i]);
-        expect(step.tokenOut).toEqual(tokens[j]);
+          // Expectation: There's a single step which is an Exchange via 3pool
+          expect(route.length).toEqual(1);
+          expectInstanceOf(step, Exchange);
+          expect(step.pool).toEqual(sdk.contracts.curve.pools.pool3.address);
+          expect(step.tokenIn).toEqual(tokens[i]);
+          expect(step.tokenOut).toEqual(tokens[j]);
+        }
       }
-    }
+    });
   });
 });

--- a/projects/sdk/src/lib/swap/graph.test.ts
+++ b/projects/sdk/src/lib/swap/graph.test.ts
@@ -1,0 +1,60 @@
+import { Graph } from "graphlib";
+import { FarmFromMode, FarmToMode } from "src/lib/farm";
+import { setBidirectionalExchangeEdges } from "src/lib/swap/graph";
+import { getTestUtils } from "src/utils/TestUtils/provider";
+
+const { sdk } = getTestUtils();
+
+describe("setBidirectionalExchangeEdges", () => {
+  it("adds both edges to the Graph instance", () => {
+    const graph: Graph = new Graph({
+      multigraph: true,
+      directed: true,
+      compound: false
+    });
+
+    const POOL = "pool";
+    const REGISTRY = "registry";
+
+    setBidirectionalExchangeEdges(sdk, graph, POOL, REGISTRY, sdk.tokens.DAI, sdk.tokens.USDC);
+
+    // Check: Existence
+    expect(graph.hasEdge("DAI", "USDC")).toBeTruthy();
+    expect(graph.hasEdge("USDC", "DAI")).toBeTruthy();
+
+    const edge0 = graph.edge("DAI", "USDC");
+    const edge1 = graph.edge("USDC", "DAI");
+
+    // Check: 0 -> 1
+    expect(edge0.from).toEqual("DAI");
+    expect(edge0.to).toEqual("USDC");
+    expect(edge0.build).toBeInstanceOf(Function);
+
+    const build0 = edge0.build("", FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);
+    expect(build0).toBeInstanceOf(sdk.farm.actions.Exchange);
+    expect(build0.pool).toEqual("pool");
+    expect(build0.registry).toEqual("registry");
+    expect(build0.tokenIn).toEqual(sdk.tokens.DAI);
+    expect(build0.tokenOut).toEqual(sdk.tokens.USDC);
+    expect(build0.fromMode).toEqual(FarmFromMode.EXTERNAL);
+    expect(build0.toMode).toEqual(FarmToMode.INTERNAL);
+
+    // Check: 1 -> 0
+    expect(edge1.from).toEqual("USDC");
+    expect(edge1.to).toEqual("DAI");
+    expect(edge1.build).toBeInstanceOf(Function);
+
+    const build1 = edge1.build("", FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);
+    expect(build1).toBeInstanceOf(sdk.farm.actions.Exchange);
+    expect(build1.pool).toEqual("pool");
+    expect(build1.registry).toEqual("registry");
+    expect(build1.tokenIn).toEqual(sdk.tokens.USDC);
+    expect(build1.tokenOut).toEqual(sdk.tokens.DAI);
+    expect(build1.fromMode).toEqual(FarmFromMode.EXTERNAL);
+    expect(build1.toMode).toEqual(FarmToMode.INTERNAL);
+  });
+});
+
+describe("graph", () => {
+  it.todo("should have all the edges");
+});

--- a/projects/sdk/src/lib/swap/graph.ts
+++ b/projects/sdk/src/lib/swap/graph.ts
@@ -152,35 +152,15 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
   });
 
   /// CRV3<>BEAN via Metapool Exchange
-  // TODO: Switch to use setBidirectionalExchangeEdges()
 
-  graph.setEdge("3CRV", "BEAN", {
-    build: (_: string, from: FarmFromMode, to: FarmToMode) =>
-      new sdk.farm.actions.Exchange(
-        sdk.contracts.curve.pools.beanCrv3.address,
-        sdk.contracts.curve.registries.metaFactory.address,
-        sdk.tokens.CRV3,
-        sdk.tokens.BEAN,
-        from,
-        to
-      ),
-    from: "3CRV",
-    to: "BEAN"
-  });
-
-  graph.setEdge("BEAN", "3CRV", {
-    build: (_: string, from: FarmFromMode, to: FarmToMode) =>
-      new sdk.farm.actions.Exchange(
-        sdk.contracts.curve.pools.beanCrv3.address,
-        sdk.contracts.curve.registries.metaFactory.address,
-        sdk.tokens.BEAN,
-        sdk.tokens.CRV3,
-        from,
-        to
-      ),
-    from: "BEAN",
-    to: "3CRV"
-  });
+  setBidirectionalExchangeEdges(
+    sdk,
+    graph,
+    sdk.contracts.curve.pools.beanCrv3.address,
+    sdk.contracts.curve.registries.metaFactory.address,
+    sdk.tokens.BEAN,
+    sdk.tokens.CRV3
+  );
 
   /// 3CRV<>Stables via 3Pool Add/Remove Liquidity
 

--- a/projects/sdk/src/lib/swap/graph.ts
+++ b/projects/sdk/src/lib/swap/graph.ts
@@ -1,6 +1,37 @@
 import { Graph } from "graphlib";
+import { ERC20Token } from "src/classes/Token";
 import { BeanstalkSDK } from "src/lib/BeanstalkSDK";
 import { FarmFromMode, FarmToMode } from "src/lib/farm";
+
+/**
+ * Creates an instance of sdk.farm.actions.Exchange to swap between token0 <> token1 via `pool`.
+ * Simplifies the `getSwapGraph` setup code below and ensures that both edges are added to the graph.
+ */
+export const setBidirectionalExchangeEdges = (
+  sdk: BeanstalkSDK,
+  g: Graph,
+  pool: string,
+  registry: string,
+  token0: ERC20Token,
+  token1: ERC20Token
+) => {
+  const token0s = token0.symbol;
+  const token1s = token1.symbol;
+
+  // token0 -> token1
+  g.setEdge(token0s, token1s, {
+    build: (_: string, from: FarmFromMode, to: FarmToMode) => new sdk.farm.actions.Exchange(pool, registry, token0, token1, from, to),
+    from: token0s,
+    to: token1s
+  });
+
+  // token1 -> token0
+  g.setEdge(token1s, token0s, {
+    build: (_: string, from: FarmFromMode, to: FarmToMode) => new sdk.farm.actions.Exchange(pool, registry, token1, token0, from, to),
+    from: token1s,
+    to: token0s
+  });
+};
 
 export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
   const graph: Graph = new Graph({
@@ -14,13 +45,15 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
   graph.setNode("ETH", { token: sdk.tokens.ETH });
   graph.setNode("WETH", { token: sdk.tokens.WETH });
   graph.setNode("BEAN", { token: sdk.tokens.BEAN });
+  graph.setNode("3CRV", { token: sdk.tokens.CRV3 });
   graph.setNode("USDT", { token: sdk.tokens.USDT });
   graph.setNode("USDC", { token: sdk.tokens.USDC });
   graph.setNode("DAI", { token: sdk.tokens.DAI });
 
   ////// Add Edges
 
-  // ETH<>WETH
+  /// ETH<>WETH via Wrap/Unwrap
+
   graph.setEdge("ETH", "WETH", {
     build: (_: string, _2: FarmFromMode, to: FarmToMode) => new sdk.farm.actions.WrapEth(to),
     from: "ETH",
@@ -32,7 +65,8 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
     to: "ETH"
   });
 
-  // WETH<>USDT
+  /// USDT<>WETH via tricrypto2 Exchange
+
   graph.setEdge("WETH", "USDT", {
     build: (_: string, from: FarmFromMode, to: FarmToMode) => sdk.farm.presets.weth2usdt(from, to),
     from: "WETH",
@@ -44,7 +78,8 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
     to: "WETH"
   });
 
-  // USDT<>BEAN
+  /// USDT<>BEAN via Metapool Exchange Underlying
+
   graph.setEdge("USDT", "BEAN", {
     build: (_: string, from: FarmFromMode, to: FarmToMode) => sdk.farm.presets.usdt2bean(from, to),
     from: "USDT",
@@ -56,7 +91,8 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
     to: "USDT"
   });
 
-  // USDC<>BEAN
+  /// USDC<>BEAN via Metapool Exchange Underlying
+
   graph.setEdge("USDC", "BEAN", {
     build: (_: string, from: FarmFromMode, to: FarmToMode) =>
       new sdk.farm.actions.ExchangeUnderlying(sdk.contracts.curve.pools.beanCrv3.address, sdk.tokens.USDC, sdk.tokens.BEAN, from, to),
@@ -70,13 +106,15 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
     to: "USDC"
   });
 
-  // DAI<>BEAN
+  /// DAI<>BEAN via Metapool Exchange Underlying
+
   graph.setEdge("DAI", "BEAN", {
     build: (_: string, from: FarmFromMode, to: FarmToMode) =>
       new sdk.farm.actions.ExchangeUnderlying(sdk.contracts.curve.pools.beanCrv3.address, sdk.tokens.DAI, sdk.tokens.BEAN, from, to),
     from: "DAI",
     to: "BEAN"
   });
+
   graph.setEdge("BEAN", "DAI", {
     build: (_: string, from: FarmFromMode, to: FarmToMode) =>
       new sdk.farm.actions.ExchangeUnderlying(sdk.contracts.curve.pools.beanCrv3.address, sdk.tokens.BEAN, sdk.tokens.DAI, from, to),
@@ -84,7 +122,8 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
     to: "DAI"
   });
 
-  // CRV3<>BEAN
+  /// CRV3<>BEAN via Metapool Exchange
+
   graph.setEdge("3CRV", "BEAN", {
     build: (_: string, from: FarmFromMode, to: FarmToMode) =>
       new sdk.farm.actions.Exchange(
@@ -98,6 +137,7 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
     from: "3CRV",
     to: "BEAN"
   });
+
   graph.setEdge("BEAN", "3CRV", {
     build: (_: string, from: FarmFromMode, to: FarmToMode) =>
       new sdk.farm.actions.Exchange(
@@ -112,7 +152,8 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
     to: "3CRV"
   });
 
-  // 3CRV>USDC
+  /// 3CRV<>Stables via 3Pool Add/Remove Liquidity
+
   graph.setEdge("3CRV", "USDC", {
     build: (_: string, from: FarmFromMode, to: FarmToMode) =>
       new sdk.farm.actions.RemoveLiquidityOneToken(
@@ -125,8 +166,11 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
     from: "3CRV",
     to: "USDC"
   });
-  
-  // USDC<>USDT
+
+  ////// 3Pool Exchanges
+
+  /// USDC<>USDT via 3Pool Exchange
+
   graph.setEdge("USDC", "USDT", {
     build: (_: string, from: FarmFromMode, to: FarmToMode) =>
       new sdk.farm.actions.Exchange(
@@ -155,7 +199,8 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
     to: "USDC"
   });
 
-  // USDC<>DAI
+  /// USDC<>DAI via 3Pool Exchange
+
   graph.setEdge("USDC", "DAI", {
     build: (_: string, from: FarmFromMode, to: FarmToMode) =>
       new sdk.farm.actions.Exchange(
@@ -184,6 +229,16 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
     to: "USDC"
   });
 
+  /// USDT<>DAI via 3Pool Exchange
+
+  setBidirectionalExchangeEdges(
+    sdk,
+    graph,
+    sdk.contracts.curve.pools.pool3.address,
+    sdk.contracts.curve.registries.poolRegistry.address,
+    sdk.tokens.USDT,
+    sdk.tokens.DAI
+  );
 
   return graph;
 };

--- a/projects/sdk/src/lib/swap/graph.ts
+++ b/projects/sdk/src/lib/swap/graph.ts
@@ -171,63 +171,25 @@ export const getSwapGraph = (sdk: BeanstalkSDK): Graph => {
 
   /// USDC<>USDT via 3Pool Exchange
 
-  graph.setEdge("USDC", "USDT", {
-    build: (_: string, from: FarmFromMode, to: FarmToMode) =>
-      new sdk.farm.actions.Exchange(
-        sdk.contracts.curve.pools.pool3.address,
-        sdk.contracts.curve.registries.poolRegistry.address,
-        sdk.tokens.USDC,
-        sdk.tokens.USDT,
-        from,
-        to
-      ),
-    from: "USDC",
-    to: "USDT"
-  });
-
-  graph.setEdge("USDT", "USDC", {
-    build: (_: string, from: FarmFromMode, to: FarmToMode) =>
-      new sdk.farm.actions.Exchange(
-        sdk.contracts.curve.pools.pool3.address,
-        sdk.contracts.curve.registries.poolRegistry.address,
-        sdk.tokens.USDT,
-        sdk.tokens.USDC,
-        from,
-        to
-      ),
-    from: "USDT",
-    to: "USDC"
-  });
+  setBidirectionalExchangeEdges(
+    sdk,
+    graph,
+    sdk.contracts.curve.pools.pool3.address,
+    sdk.contracts.curve.registries.poolRegistry.address,
+    sdk.tokens.USDC,
+    sdk.tokens.USDT
+  );
 
   /// USDC<>DAI via 3Pool Exchange
 
-  graph.setEdge("USDC", "DAI", {
-    build: (_: string, from: FarmFromMode, to: FarmToMode) =>
-      new sdk.farm.actions.Exchange(
-        sdk.contracts.curve.pools.pool3.address,
-        sdk.contracts.curve.registries.poolRegistry.address,
-        sdk.tokens.USDC,
-        sdk.tokens.DAI,
-        from,
-        to
-      ),
-    from: "USDC",
-    to: "DAI"
-  });
-
-  graph.setEdge("DAI", "USDC", {
-    build: (_: string, from: FarmFromMode, to: FarmToMode) =>
-      new sdk.farm.actions.Exchange(
-        sdk.contracts.curve.pools.pool3.address,
-        sdk.contracts.curve.registries.poolRegistry.address,
-        sdk.tokens.DAI,
-        sdk.tokens.USDC,
-        from,
-        to
-      ),
-    from: "DAI",
-    to: "USDC"
-  });
+  setBidirectionalExchangeEdges(
+    sdk,
+    graph,
+    sdk.contracts.curve.pools.pool3.address,
+    sdk.contracts.curve.registries.poolRegistry.address,
+    sdk.tokens.USDC,
+    sdk.tokens.DAI
+  );
 
   /// USDT<>DAI via 3Pool Exchange
 

--- a/projects/sdk/src/utils/index.ts
+++ b/projects/sdk/src/utils/index.ts
@@ -13,4 +13,8 @@ export function assert(value: any, message?: string) {
   }
 }
 
+export function expectInstanceOf<T extends new (...args: any[]) => any>(x: unknown, of: T): asserts x is InstanceType<T> {
+  expect(x).toBeInstanceOf(of);
+}
+
 export const zeros = (numZeros: number) => "".padEnd(numZeros, "0");


### PR DESCRIPTION
# Scope

1. Adds two helper functions to create bi-directional edges for the following cases:
  a. Exchanging between two tokens in a pool
  b. Moving from an underlying token -> LP token via AddLiquidity, and vice-versa via RemoveLiquidityOneToken
2. Adds tests for the helpers to ensure both edges (A -> B _and_ B -> A) are accounted for
3. Introduces tests for some route paths where we want to ensure the router takes the most direct path. Notably:
  a. 3CRV -> underlying should always remove liquidity, and vice-versa
  b. Stables in 3pool should swap directly on 3pool, no intermediate hops
4. Add helper `expectInstanceOf` which is the same as expect.instanceOf` but with a Typescript assertion so any following context is aware of the assertion
5. Change all action constructor parameters to `public readonly`

# Rationale

**Helper functions**
1. The `graph.ts` file was becoming quite verbose, with lots of repetitive code to define edges
2. Some swap routes were missing their counterparts, for ex. we had 3CRV -> USDC but not USDC -> 3CRV mapped.

**`public readonly`**
1. Allows for tests to build an action and verify that the values stored in the instance match what you would expect based on router. example:
```
      const route = sdk.swap.router.getRoute(sdk.tokens.CRV3.symbol, symbol);
      const step = route.getStep(0).build(account, FarmFromMode.EXTERNAL, FarmToMode.INTERNAL);

      expect(route.length).toEqual(1);
      expectInstanceOf(step, RemoveLiquidityOneToken);
      expect(step._pool).toEqual(sdk.contracts.curve.pools.pool3.address); // <-- this
```
2. Javascript doesn't actually understand the concept of `private`, and `public readonly` will do effectively the same thing with respect to Typescript's warnings

**Addition of the 3CRV <> Stable route**
Some combinations of this route previously performed inefficient swaps, typically something like 3CRV -> BEAN -> USDT for example.

# Testing
Automated: see `graph.test.ts`

Manual: I rebuilt the SDK locally, set up the following swap paths, and confirmed via console logs that the correct path was selected:
- [x] DAI -> USDC
- [x] DAI -> USDT
- [x] USDC -> USDT
- [x] 3CRV -> DAI
- [x] 3CRV -> USDC
- [x] 3CRV -> USDT
- [x] reverse of each of the above

# Followup work
- Most actions use underscore prefixing for constructor params, but not all
- The AddLiquidity function accepts an array to decide which token index you're depositing, it should really be called AddLiquidityOneToken and use the same approach as RemoveLiquidityOneToken