### PR TITLE
Mobile - Chart + Copy tweaks

### DIFF
--- a/projects/ui/src/components/Common/Charts/LineChart.tsx
+++ b/projects/ui/src/components/Common/Charts/LineChart.tsx
@@ -174,12 +174,24 @@ const Graph: React.FC<GraphProps> = (props) => {
 
   // const yTickNum = height > 180 ? undefined : 5;
   const xTickNum = width > 700 ? undefined : Math.floor(width / 70);
+  const [tickSeasons, tickDates] = useMemo(() => {
+    const interval = Math.ceil(series[0].length / (width > 700 ? 12 : width < 450 ? 6 : 9));
+    const shift = Math.ceil(interval / 3); // slight shift on tick labels
+    return series[0].reduce<[number[], string[]]>(
+      (prev, curr, i) => {
+        if (i % interval === shift) {
+          prev[0].push(curr.season);
+          prev[1].push(`${curr.date.getMonth() + 1}/${curr.date.getDate()}`);
+        }
+        return prev;
+      },
+      [[], []]
+    );
+  }, [series, scales]);
+
   const xTickFormat = useCallback(
-    (v: NumberValue) => {
-      const d = scales[0].dScale.invert(v);
-      return `${d.getMonth() + 1}/${d.getDate()}`;
-    },
-    [scales]
+    (_: any, i: number) => tickDates[i],
+    [tickDates]
   );
 
   // Empty state
@@ -253,7 +265,7 @@ const Graph: React.FC<GraphProps> = (props) => {
             tickFormat={xTickFormat}
             tickStroke={axisColor}
             tickLabelProps={xTickLabelProps}
-            numTicks={xTickNum}
+            tickValues={tickSeasons}
           />
         </g>
         <g transform={`translate(${width - chartPadding.right}, 1)`}>

--- a/projects/ui/src/components/Common/Charts/MultiLineChart.tsx
+++ b/projects/ui/src/components/Common/Charts/MultiLineChart.tsx
@@ -104,7 +104,7 @@ const MultiLineChartInner: React.FC<Props> = (props) => {
   const xTickNum = width > 700 ? undefined : Math.floor(width / 70);
 
   const [tickSeasons, tickDates] = useMemo(() => {
-    const interval = Math.ceil(series[0].length / 12);
+    const interval = Math.ceil(series[0].length / (width > 700 ? 12 : width < 450 ? 6 : 9));
     const shift = Math.ceil(interval / 3); // slight shift on tick labels
     return series[0].reduce<[number[], string[]]>(
       (prev, curr, i) => {
@@ -116,7 +116,7 @@ const MultiLineChartInner: React.FC<Props> = (props) => {
       },
       [[], []]
     );
-  }, [series]);
+  }, [series, scales]);
 
   const xTickFormat = useCallback(
     (_: any, i: number) => tickDates[i],
@@ -205,7 +205,6 @@ const MultiLineChartInner: React.FC<Props> = (props) => {
             tickFormat={xTickFormat}
             tickStroke={common.axisColor}
             tickLabelProps={common.xTickLabelProps}
-            numTicks={xTickNum}
             tickValues={tickSeasons}
           />
         </g>

--- a/projects/ui/src/components/Common/Charts/StackedAreaChart.tsx
+++ b/projects/ui/src/components/Common/Charts/StackedAreaChart.tsx
@@ -74,7 +74,7 @@ const Graph = (props: Props) => {
 
   // generate ticks
   const [tickSeasons, tickDates] = useMemo(() => {
-    const interval = Math.ceil(data.length / 12);
+    const interval = Math.ceil(series[0].length / (width > 700 ? 12 : width < 450 ? 6 : 9));
     const shift = Math.ceil(interval / 3); // slight shift on tick labels
     return data.reduce<[number[], string[]]>(
       (prev, curr, i) => {
@@ -90,7 +90,7 @@ const Graph = (props: Props) => {
       },
       [[], []]
     );
-  }, [data]);
+  }, [data, scales]);
 
   // tooltip
   const { containerRef, containerBounds } = useTooltipInPortal({

--- a/projects/ui/src/components/Field/FieldConditionsHeader.tsx
+++ b/projects/ui/src/components/Field/FieldConditionsHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography, useMediaQuery, useTheme } from '@mui/material';
 
 import { useSelector } from 'react-redux';
 import { FontWeight } from '~/components/App/muiTheme';
@@ -19,6 +19,8 @@ const FieldConditionsHeader: React.FC<{
   );
   const season = useSeason();
   const interval = morning.index.plus(1).toString();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   if (morning.isMorning) {
     return (
@@ -44,7 +46,9 @@ const FieldConditionsHeader: React.FC<{
   return (
     <Row gap={0.2} width="100%" justifyContent="space-between">
       <Typography variant="h4" fontWeight={FontWeight.bold}>
-        🌤️ Field Conditions, Season {season.gt(0) && season.toString()}
+        {isMobile 
+          ? '🌤️ Field Conditions'
+          : `🌤️ Field Conditions, Season ${season.gt(0) && season.toString()}`}
       </Typography>
       <Box onClick={toggleMorning}>
         <Typography
@@ -56,9 +60,13 @@ const FieldConditionsHeader: React.FC<{
             },
           }}
         >
-          {toggled
-            ? 'View Normal Field Conditions'
-            : 'View Morning Field Conditions'}
+          {isMobile
+            ? toggled
+              ? 'View Normal'
+              : 'View Morning'
+            : toggled
+              ? 'View Normal Field Conditions'
+              : 'View Morning Field Conditions'}
         </Typography>
       </Box>
     </Row>


### PR DESCRIPTION
Charts will now display a suitable amount of x-axis ticks according to the chart's width
Added shorter copy for the Field Conditions header on mobile