### PR TITLE
Improved approval checks

### DIFF
--- a/projects/ui/src/components/Barn/Actions/Buy.tsx
+++ b/projects/ui/src/components/Barn/Actions/Buy.tsx
@@ -159,6 +159,11 @@ const BuyForm: FC<
     return _params;
   }, [values.balanceFrom]);
 
+  /// Approval Checks
+  const shouldApprove = 
+    values.balanceFrom === BalanceFrom.EXTERNAL || 
+    values.balanceFrom === BalanceFrom.TOTAL && values.tokens[0].amount?.gt(balances[tokenIn.address].internal);
+
   return (
     <FormWithDrawer autoComplete="off" noValidate siblingRef={formRef}>
       <Stack gap={1} ref={formRef}>
@@ -257,7 +262,7 @@ const BuyForm: FC<
           disabled={!isValid}
           // Smart props
           contract={sdk.contracts.beanstalk}
-          tokens={values.tokens}
+          tokens={shouldApprove ? values.tokens : []}
         >
           Buy
         </SmartSubmitButton>

--- a/projects/ui/src/components/Field/Actions/Sow.tsx
+++ b/projects/ui/src/components/Field/Actions/Sow.tsx
@@ -149,6 +149,11 @@ const SowForm: FC<
     claimBeansState: values.claimableBeans,
   });
 
+  /// Checks
+  const shouldApprove = 
+    values.balanceFrom === BalanceFrom.EXTERNAL || 
+    values.balanceFrom === BalanceFrom.TOTAL && values.tokens[0].amount?.gt(balances[tokenIn.address].internal);
+
   const handleSetBalanceFrom = useCallback(
     (_balanceFrom: BalanceFrom) => {
       setFieldValue('balanceFrom', _balanceFrom);
@@ -354,7 +359,7 @@ const SowForm: FC<
           size="large"
           disabled={!isSubmittable || isSubmitting}
           contract={sdk.contracts.beanstalk}
-          tokens={values.tokens}
+          tokens={shouldApprove ? values.tokens : []}
           mode="auto"
         >
           Sow

--- a/projects/ui/src/components/Field/Actions/Sow.tsx
+++ b/projects/ui/src/components/Field/Actions/Sow.tsx
@@ -149,7 +149,7 @@ const SowForm: FC<
     claimBeansState: values.claimableBeans,
   });
 
-  /// Checks
+  /// Approval Checks
   const shouldApprove = 
     values.balanceFrom === BalanceFrom.EXTERNAL || 
     values.balanceFrom === BalanceFrom.TOTAL && values.tokens[0].amount?.gt(balances[tokenIn.address].internal);

--- a/projects/ui/src/components/Silo/Actions/Deposit.tsx
+++ b/projects/ui/src/components/Silo/Actions/Deposit.tsx
@@ -179,6 +179,11 @@ const DepositForm: FC<
     values.tokens[0].amount === undefined &&
     values.claimableBeans.amount?.eq(0);
 
+  /// Approval Checks
+  const shouldApprove = 
+    values.balanceFrom === BalanceFrom.EXTERNAL || 
+    values.balanceFrom === BalanceFrom.TOTAL && values.tokens[0].amount?.gt(balances[tokenIn.address].internal);
+    
   return (
     <FormWithDrawer noValidate autoComplete="off" siblingRef={siblingRef}>
       <TokenSelectDialogNew
@@ -280,7 +285,7 @@ const DepositForm: FC<
           color="primary"
           size="large"
           contract={contract}
-          tokens={values.tokens}
+          tokens={shouldApprove ? values.tokens : []}
           mode="auto"
         >
           Deposit

--- a/projects/ui/src/components/Swap/Actions/Transfer.tsx
+++ b/projects/ui/src/components/Swap/Actions/Transfer.tsx
@@ -236,7 +236,7 @@ const TransferForm: FC<
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [handleSetBalanceFrom, account, toMode]);
 
-  /// Checks
+  /// Approval Checks
   const shouldApprove =
     fromMode === FarmFromMode.EXTERNAL ||
     fromMode === FarmFromMode.INTERNAL_EXTERNAL && amount?.gt(balances[tokenIn.address]?.internal);

--- a/projects/ui/src/components/Swap/Actions/Transfer.tsx
+++ b/projects/ui/src/components/Swap/Actions/Transfer.tsx
@@ -239,7 +239,7 @@ const TransferForm: FC<
   /// Checks
   const shouldApprove =
     fromMode === FarmFromMode.EXTERNAL ||
-    fromMode === FarmFromMode.INTERNAL_EXTERNAL;
+    fromMode === FarmFromMode.INTERNAL_EXTERNAL && amount?.gt(balances[tokenIn.address]?.internal);
 
   const amountsCheck = amount?.gt(0);
   const enoughBalanceCheck = amount


### PR DESCRIPTION
Now we only prompt the user for an approval if:

- Circulating Balance is selected
- Combined Balance is selected and the amount is higher than the Farm Balance

Addresses issue #478