### PR TITLE
Event processor: Field

### DIFF
--- a/projects/sdk/src/lib/events/processor.test.ts
+++ b/projects/sdk/src/lib/events/processor.test.ts
@@ -1,5 +1,11 @@
 import { BigNumber as EBN } from "ethers";
-import { AddDepositEvent, RemoveDepositEvent } from "src/constants/generated/protocol/abi/Beanstalk";
+import {
+  AddDepositEvent,
+  HarvestEvent,
+  PlotTransferEvent,
+  RemoveDepositEvent,
+  SowEvent
+} from "src/constants/generated/protocol/abi/Beanstalk";
 import { EventProcessor } from "./processor";
 import { BeanstalkSDK } from "../BeanstalkSDK";
 import { getProvider } from "../../utils/TestUtils/provider";
@@ -48,120 +54,125 @@ describe("utilities", () => {
 
 // ------------------------------------------
 
-// describe('the Field', () => {
-//   // 1.
-//   it('adds a single Plot', () => {
-//     const p = mockProcessor();
-//     p.ingest({
-//       event: 'Sow',
-//       args: propArray({
-//         index: EBN.from(10 * 10 ** Bean.decimals),
-//         pods:  EBN.from(42 * 10 ** Bean.decimals)
-//       })
-//     } as SowEvent);
+describe("the Field", () => {
+  // 1.
+  it("adds a single Plot", () => {
+    const p = mockProcessor();
 
-//     expect(Object.keys(p.plots).length === 1);
-//     expect(p.plots['10']).toStrictEqual(EBN.from(42));
-//   });
+    p.ingest({
+      event: "Sow",
+      args: propArray({
+        index: EBN.from(10),
+        pods: EBN.from(42)
+      })
+    } as SowEvent);
 
-//   // 2.
-//   it('adds a single Plot and Harvests', () => {
-//     const p = mockProcessor();
-//     p.ingest({
-//       event: 'Sow',
-//       args: propArray({
-//         index: EBN.from(10 * 10 ** Bean.decimals),
-//         pods:  EBN.from(42 * 10 ** Bean.decimals)
-//       })
-//     } as SowEvent);
-//     p.ingest({
-//       event: 'Harvest',
-//       args: propArray({
-//         beans: EBN.from(5 * 10 ** Bean.decimals),
-//         plots: [EBN.from(10 * 10 ** Bean.decimals)]
-//       })
-//     } as HarvestEvent);
+    expect(Object.keys(p.plots).length === 1);
+    expect(p.plots.get("10")).toStrictEqual(EBN.from(42));
+  });
 
-//     expect(Object.keys(p.plots).length === 1);
-//     expect(p.plots['10']).toBeUndefined();
-//     expect(p.plots['15']).toStrictEqual(EBN.from(42 - 5));
+  // 2.
+  it("adds a single Plot and Harvests", () => {
+    const p = mockProcessor();
+    p.ingest({
+      event: "Sow",
+      args: propArray({
+        index: EBN.from(10),
+        pods: EBN.from(42)
+      })
+    } as SowEvent);
+    p.ingest({
+      event: "Harvest",
+      args: propArray({
+        beans: EBN.from(5),
+        plots: [EBN.from(10)]
+      })
+    } as HarvestEvent);
 
-//     p.ingest({
-//       event: 'Harvest',
-//       args: propArray({
-//         beans: EBN.from(37 * 10 ** Bean.decimals),
-//         plots: [EBN.from(15 * 10 ** Bean.decimals)]
-//       })
-//     } as HarvestEvent);
+    expect(Object.keys(p.plots).length === 1);
+    expect(p.plots.get("10")).toBeUndefined();
+    expect(p.plots.get("15")).toStrictEqual(EBN.from(42 - 5));
 
-//     expect(Object.keys(p.plots).length === 0);
-//     expect(p.plots['10']).toBeUndefined();
-//     expect(p.plots['15']).toBeUndefined();
-//   });
+    p.ingest({
+      event: "Harvest",
+      args: propArray({
+        beans: EBN.from(37),
+        plots: [EBN.from(15)]
+      })
+    } as HarvestEvent);
 
-//   // 3.
-//   it('sends a single Plot, full', () => {
-//     const p = mockProcessor();
-//     p.ingest({
-//       event: 'Sow',
-//       args: propArray({
-//         index: EBN.from(10 * 10 ** Bean.decimals),
-//         pods:  EBN.from(42 * 10 ** Bean.decimals)
-//       })
-//     } as SowEvent);
-//     p.ingest({
-//       event: 'PlotTransfer',
-//       args: propArray({
-//         from: '0xFARMER',
-//         to: '0xPUBLIUS',
-//         id: EBN.from(10 * 10 ** Bean.decimals),
-//         pods: EBN.from(42 * 10 ** Bean.decimals)
-//       })
-//     } as PlotTransferEvent);
+    expect(Object.keys(p.plots).length === 0);
+    expect(p.plots.get("10")).toBeUndefined();
+    expect(p.plots.get("15")).toBeUndefined();
+  });
 
-//     expect(Object.keys(p.plots).length).toBe(0);
-//   });
+  // 3.
+  it("sends a single Plot, full", () => {
+    const p = mockProcessor();
+    p.ingest({
+      event: "Sow",
+      args: propArray({
+        index: EBN.from(10),
+        pods: EBN.from(42)
+      })
+    } as SowEvent);
+    p.ingest({
+      event: "PlotTransfer",
+      args: propArray({
+        from: "0xFARMER",
+        to: "0xPUBLIUS",
+        id: EBN.from(10),
+        pods: EBN.from(42)
+      })
+    } as PlotTransferEvent);
 
-//   // 4.
-//   it('sends a single Plot, partial (indexed from the front)', () => {
-//     const p = mockProcessor();
-//     p.ingest({
-//       event: 'Sow',
-//       args: propArray({
-//         index: EBN.from(10 * 10 ** Bean.decimals),
-//         pods:  EBN.from(42 * 10 ** Bean.decimals)
-//       })
-//     } as SowEvent);
-//     p.ingest({
-//       event: 'PlotTransfer',
-//       args: propArray({
-//         from: '0xFARMER',
-//         to:   '0xPUBLIUS',
-//         id:   EBN.from(10 * 10 ** Bean.decimals), // front of the Plot
-//         pods: EBN.from(22 * 10 ** Bean.decimals)  // don't send the whole Plot
-//       })
-//     } as PlotTransferEvent);
+    expect(Object.keys(p.plots).length).toBe(0);
+  });
 
-//     // Since the Plot is sent from the front, index starts at 10 + 22 = 32.
-//     expect(Object.keys(p.plots).length).toBe(1);
-//     expect(p.plots[(10 + 22).toString()]).toStrictEqual(EBN.from(42 - 22));
-//   });
+  // 4.
+  it("sends a single Plot, partial (indexed from the front)", () => {
+    const p = mockProcessor();
 
-//   // 5.
-//   it('works with large-index plots', () => {
-//     const p = mockProcessor();
-//     p.ingest({
-//       event: 'Sow',
-//       args: propArray({
-//         index: EBN.from('737663715081254'),
-//         pods:  EBN.from('57980000'),
-//       })
-//     } as SowEvent);
+    p.ingest({
+      event: "Sow",
+      args: propArray({
+        index: EBN.from(10),
+        pods: EBN.from(42)
+      })
+    } as SowEvent);
 
-//     expect(p.plots['737663715.081254']).toBeDefined();
-//     expect(p.plots['737663715.081254'].eq(57.980000)).toBe(true);
-//   });
-// });
+    p.ingest({
+      event: "PlotTransfer",
+      args: propArray({
+        from: "0xFARMER",
+        to: "0xPUBLIUS",
+        id: EBN.from(10), // front of the Plot
+        pods: EBN.from(22) // don't send the whole Plot
+      })
+    } as PlotTransferEvent);
+
+    console.log(p.plots);
+
+    // Since the Plot is sent from the front, index starts at 10 + 22 = 32.
+    expect(p.plots.size).toBe(1);
+    expect(p.plots.get((10 + 22).toString())).toStrictEqual(EBN.from(42 - 22));
+  });
+
+  // 5.
+  it("works with large-index plots", () => {
+    const p = mockProcessor();
+    p.ingest({
+      event: "Sow",
+      args: propArray({
+        index: EBN.from("737663715081254"),
+        pods: EBN.from("57980000")
+      })
+    } as SowEvent);
+
+    expect(p.plots.get("737663715081254")).toBeDefined();
+    expect(p.plots.get("737663715081254")?.eq(57980000)).toBe(true);
+  });
+});
 
 // --------------------------------
 

--- a/projects/sdk/src/lib/events/processor.ts
+++ b/projects/sdk/src/lib/events/processor.ts
@@ -123,167 +123,160 @@ export class EventProcessor {
 
   // /// /////////////////////// FIELD //////////////////////////
 
-  // Sow(event: Simplify<SowEvent>) {
-  //   const index       = tokenBN(event.args.index, PODS).toString();
-  //   this.plots[index] = tokenBN(event.args.pods,  PODS);
-  // }
+  Sow(event: Simplify<SowEvent>) {
+    const index = tokenBN(event.args.index, PODS).toString();
+    this.plots[index] = tokenBN(event.args.pods, PODS);
+  }
 
-  // Harvest(event: Simplify<HarvestEvent>) {
-  //   let beansClaimed = tokenBN(event.args.beans, Bean);
-  //   const plots = (
-  //     event.args.plots
-  //       .map((_index) => tokenBN(_index, Bean))
-  //       .sort((a, b) => a.minus(b).toNumber())
-  //   );
-  //   plots.forEach((indexBN) => {
-  //     const index = indexBN.toString();
-  //     if (beansClaimed.isLessThan(this.plots[index])) {
-  //       // ----------------------------------------
-  //       // A Plot was partially Harvested. Example:
-  //       // Event: Sow
-  //       //  index  = 10
-  //       //  amount = 10
-  //       //
-  //       // I call harvest when harvestableIndex = 14 (I harvest 10,11,12,13)
-  //       //
-  //       // Event: Harvest
-  //       //  args.beans = 4
-  //       //  args.plots = [10]
-  //       //  beansClaimed  = 4
-  //       //  partialIndex  = 4 + 10 = 14
-  //       //  partialAmount = 10 - 4 = 6
-  //       //
-  //       // Add Plot with 6 Pods at index 14
-  //       // Remove Plot at index 10.
-  //       // ----------------------------------------
-  //       const partialIndex  = beansClaimed.plus(indexBN);
-  //       const partialAmount = this.plots[index].minus(beansClaimed);
-  //       this.plots = {
-  //         ...this.plots,
-  //         [partialIndex.toString()]: partialAmount,
-  //       };
-  //     } else {
-  //       beansClaimed = beansClaimed.minus(this.plots[index]);
-  //     }
-  //     delete this.plots[index];
-  //   });
-  // }
+  Harvest(event: Simplify<HarvestEvent>) {
+    let beansClaimed = tokenBN(event.args.beans, Bean);
+    const plots = event.args.plots.map((_index) => tokenBN(_index, Bean)).sort((a, b) => a.minus(b).toNumber());
+    plots.forEach((indexBN) => {
+      const index = indexBN.toString();
+      if (beansClaimed.isLessThan(this.plots[index])) {
+        // ----------------------------------------
+        // A Plot was partially Harvested. Example:
+        // Event: Sow
+        //  index  = 10
+        //  amount = 10
+        //
+        // I call harvest when harvestableIndex = 14 (I harvest 10,11,12,13)
+        //
+        // Event: Harvest
+        //  args.beans = 4
+        //  args.plots = [10]
+        //  beansClaimed  = 4
+        //  partialIndex  = 4 + 10 = 14
+        //  partialAmount = 10 - 4 = 6
+        //
+        // Add Plot with 6 Pods at index 14
+        // Remove Plot at index 10.
+        // ----------------------------------------
+        const partialIndex = beansClaimed.plus(indexBN);
+        const partialAmount = this.plots[index].minus(beansClaimed);
+        this.plots = {
+          ...this.plots,
+          [partialIndex.toString()]: partialAmount
+        };
+      } else {
+        beansClaimed = beansClaimed.minus(this.plots[index]);
+      }
+      delete this.plots[index];
+    });
+  }
 
-  // PlotTransfer(event: Simplify<PlotTransferEvent>) {
-  //   // Numerical "index" of the Plot. Absolute, with respect to Pod 0.
-  //   const transferIndex   = tokenBN(event.args.id, Bean);
-  //   const podsTransferred = tokenBN(event.args.pods, Bean);
+  PlotTransfer(event: Simplify<PlotTransferEvent>) {
+    // Numerical "index" of the Plot. Absolute, with respect to Pod 0.
+    const transferIndex = tokenBN(event.args.id, Bean);
+    const podsTransferred = tokenBN(event.args.pods, Bean);
 
-  //   if (event.args.to.toLowerCase() === this.account) {
-  //     // This account received a Plot
-  //     this.plots[transferIndex.toString()] = podsTransferred;
-  //   }
-  //   else {
-  //     // This account sent a Plot
-  //     const indexStr = transferIndex.toString();
+    if (event.args.to.toLowerCase() === this.account) {
+      // This account received a Plot
+      this.plots[transferIndex.toString()] = podsTransferred;
+    } else {
+      // This account sent a Plot
+      const indexStr = transferIndex.toString();
 
-  //     // ----------------------------------------
-  //     // The PlotTransfer event doesn't contain info
-  //     // about the `start` position of a Transfer.
-  //     // Say for example I have the following plot:
-  //     //
-  //     //  0       9 10         20              END
-  //     // [---------[0123456789)-----------------]
-  //     //                 ^
-  //     // PlotTransfer   [56789)
-  //     //                 15    20
-  //     //
-  //     // PlotTransfer(from=0x, to=0x, id=15, pods=5)
-  //     // This means we send Pods: 15, 16, 17, 18, 19
-  //     //
-  //     // However this Plot doesn't exist yet in our
-  //     // cache. To find it we search for the Plot
-  //     // beginning at 10 and ending at 20, then
-  //     // split it depending on params provided in
-  //     // the PlotTransfer event.
-  //     // ----------------------------------------
-  //     if (this.plots[indexStr] !== undefined) {
-  //       // A known Plot was sent.
-  //       if (!podsTransferred.isEqualTo(this.plots[indexStr])) {
-  //         const newStartIndex = transferIndex.plus(podsTransferred);
-  //         this.plots[newStartIndex.toString()] = this.plots[indexStr].minus(podsTransferred);
-  //       }
-  //       delete this.plots[indexStr];
-  //     }
-  //     else {
-  //       // A Plot was partially sent from a non-zero
-  //       // starting index. Find the containing Plot
-  //       // in our cache.
-  //       let i = 0;
-  //       let found = false;
-  //       const plotIndices = Object.keys(this.plots);
-  //       while (found === false && i < plotIndices.length) {
-  //         // Setup the boundaries of this Plot
-  //         const startIndex = BN(plotIndices[i]);
-  //         const endIndex   = startIndex.plus(this.plots[startIndex.toString()]);
-  //         // Check if the Transfer happened within this Plot
-  //         if (startIndex.isLessThanOrEqualTo(transferIndex)
-  //            && endIndex.isGreaterThan(transferIndex)) {
-  //           // ----------------------------------------
-  //           // Slice #1. This is the part that
-  //           // the user keeps (they sent the other part).
-  //           //
-  //           // Following the above example:
-  //           //  transferIndex   = 15
-  //           //  podsTransferred = 5
-  //           //  startIndex      = 10
-  //           //  endIndex        = 20
-  //           //
-  //           // This would update the existing Plot such that:
-  //           //  this.plots[10] = (15 - 10) = 5
-  //           // containing Pods 10, 11, 12, 13, 14
-  //           // ----------------------------------------
-  //           if (transferIndex.eq(startIndex)) {
-  //             delete this.plots[startIndex.toString()];
-  //           } else {
-  //             this.plots[startIndex.toString()] = transferIndex.minus(startIndex);
-  //           }
+      // ----------------------------------------
+      // The PlotTransfer event doesn't contain info
+      // about the `start` position of a Transfer.
+      // Say for example I have the following plot:
+      //
+      //  0       9 10         20              END
+      // [---------[0123456789)-----------------]
+      //                 ^
+      // PlotTransfer   [56789)
+      //                 15    20
+      //
+      // PlotTransfer(from=0x, to=0x, id=15, pods=5)
+      // This means we send Pods: 15, 16, 17, 18, 19
+      //
+      // However this Plot doesn't exist yet in our
+      // cache. To find it we search for the Plot
+      // beginning at 10 and ending at 20, then
+      // split it depending on params provided in
+      // the PlotTransfer event.
+      // ----------------------------------------
+      if (this.plots[indexStr] !== undefined) {
+        // A known Plot was sent.
+        if (!podsTransferred.isEqualTo(this.plots[indexStr])) {
+          const newStartIndex = transferIndex.plus(podsTransferred);
+          this.plots[newStartIndex.toString()] = this.plots[indexStr].minus(podsTransferred);
+        }
+        delete this.plots[indexStr];
+      } else {
+        // A Plot was partially sent from a non-zero
+        // starting index. Find the containing Plot
+        // in our cache.
+        let i = 0;
+        let found = false;
+        const plotIndices = Object.keys(this.plots);
+        while (found === false && i < plotIndices.length) {
+          // Setup the boundaries of this Plot
+          const startIndex = BN(plotIndices[i]);
+          const endIndex = startIndex.plus(this.plots[startIndex.toString()]);
+          // Check if the Transfer happened within this Plot
+          if (startIndex.isLessThanOrEqualTo(transferIndex) && endIndex.isGreaterThan(transferIndex)) {
+            // ----------------------------------------
+            // Slice #1. This is the part that
+            // the user keeps (they sent the other part).
+            //
+            // Following the above example:
+            //  transferIndex   = 15
+            //  podsTransferred = 5
+            //  startIndex      = 10
+            //  endIndex        = 20
+            //
+            // This would update the existing Plot such that:
+            //  this.plots[10] = (15 - 10) = 5
+            // containing Pods 10, 11, 12, 13, 14
+            // ----------------------------------------
+            if (transferIndex.eq(startIndex)) {
+              delete this.plots[startIndex.toString()];
+            } else {
+              this.plots[startIndex.toString()] = transferIndex.minus(startIndex);
+            }
 
-  //           // ----------------------------------------
-  //           // Slice #2. Handles the below case where
-  //           // the amount sent doesn't reach the end
-  //           // of the Plot (i.e. I sent Pods in the middle.
-  //           //
-  //           //  0       9 10         20              END
-  //           // [---------[0123456789)-----------------]
-  //           //                 ^
-  //           // PlotTransfer   [567)
-  //           //                 15  18
-  //           //
-  //           //  transferIndex   = 15
-  //           //  podsTransferred = 3
-  //           //  startIndex      = 10
-  //           //  endIndex        = 20
-  //           //
-  //           // PlotTransfer(from=0x, to=0x, id=15, pods=3)
-  //           // This means we send Pods: 15, 16, 17.
-  //           // ----------------------------------------
-  //           if (!transferIndex.isEqualTo(endIndex)) {
-  //             // s2 = 15 + 3 = 18
-  //             // Requires another split since 18 != 20
-  //             const s2 = transferIndex.plus(podsTransferred);
-  //             const requiresAnotherSplit = !s2.isEqualTo(endIndex);
-  //             if (requiresAnotherSplit) {
-  //               // Create a new plot at s2=18 with 20-18 Pods.
-  //               const s2Str = s2.toString();
-  //               this.plots[s2Str] = endIndex.minus(s2);
-  //               if (this.plots[s2Str].isEqualTo(0)) {
-  //                 delete this.plots[s2Str];
-  //               }
-  //             }
-  //           }
-  //           found = true;
-  //         }
-  //         i += 1;
-  //       }
-  //     }
-  //   }
-  // }
+            // ----------------------------------------
+            // Slice #2. Handles the below case where
+            // the amount sent doesn't reach the end
+            // of the Plot (i.e. I sent Pods in the middle.
+            //
+            //  0       9 10         20              END
+            // [---------[0123456789)-----------------]
+            //                 ^
+            // PlotTransfer   [567)
+            //                 15  18
+            //
+            //  transferIndex   = 15
+            //  podsTransferred = 3
+            //  startIndex      = 10
+            //  endIndex        = 20
+            //
+            // PlotTransfer(from=0x, to=0x, id=15, pods=3)
+            // This means we send Pods: 15, 16, 17.
+            // ----------------------------------------
+            if (!transferIndex.isEqualTo(endIndex)) {
+              // s2 = 15 + 3 = 18
+              // Requires another split since 18 != 20
+              const s2 = transferIndex.plus(podsTransferred);
+              const requiresAnotherSplit = !s2.isEqualTo(endIndex);
+              if (requiresAnotherSplit) {
+                // Create a new plot at s2=18 with 20-18 Pods.
+                const s2Str = s2.toString();
+                this.plots[s2Str] = endIndex.minus(s2);
+                if (this.plots[s2Str].isEqualTo(0)) {
+                  delete this.plots[s2Str];
+                }
+              }
+            }
+            found = true;
+          }
+          i += 1;
+        }
+      }
+    }
+  }
 
   // parsePlots(_harvestableIndex: BigNumber) {
   //   return EventProcessor._parsePlots(

--- a/projects/ui/src/state/beanstalk/field/index.ts
+++ b/projects/ui/src/state/beanstalk/field/index.ts
@@ -1,19 +1,19 @@
-import BigNumber from 'bignumber.js';
+import BigNumberJS from 'bignumber.js';
 
 export type BeanstalkField = {
   /**
    * The number of Pods that have become Harvestable.
    */
-  harvestableIndex: BigNumber;
+  harvestableIndex: BigNumberJS;
   /**
    * The total number of Pods ever minted.
    */
-  podIndex: BigNumber;
+  podIndex: BigNumberJS;
   /**
    * The current length of the Pod Line.
    * podLine = podIndex - harvestableIndex.
    */
-  podLine: BigNumber;
+  podLine: BigNumberJS;
   /**
    * The total number of Pods ever minted.
    * `totalPods = podIndex + harvestableIndex`
@@ -22,7 +22,7 @@ export type BeanstalkField = {
   /**
    * The amount of available Soil.
    */
-  soil: BigNumber;
+  soil: BigNumberJS;
   /**
    * Facets of the Weather.
    * The commonly-addressed numerical value for "Weather" is
@@ -30,15 +30,15 @@ export type BeanstalkField = {
    * change in the Weather yield and available Soil over time.
    */
   weather: {
-    lastDSoil: BigNumber;
-    lastSowTime: BigNumber;
-    thisSowTime: BigNumber;
+    lastDSoil: BigNumberJS;
+    lastSowTime: BigNumberJS;
+    thisSowTime: BigNumberJS;
   };
 
   temperature: {
     /** The max temperature for this season. */
-    max: BigNumber;
+    max: BigNumberJS;
     /** adjusted temperature for this season */
-    scaled: BigNumber;
+    scaled: BigNumberJS;
   };
 };

--- a/projects/ui/src/state/farmer/field/index.ts
+++ b/projects/ui/src/state/farmer/field/index.ts
@@ -1,10 +1,11 @@
-import BigNumber from 'bignumber.js';
+import BigNumberJS from 'bignumber.js';
 import { PlotMap } from '~/util';
 
 /// FIXME: "Field" or "FarmerField";
 export type FarmerField = {
-  plots: PlotMap<BigNumber>;
-  pods: BigNumber;
-  harvestablePlots: PlotMap<BigNumber>;
-  harvestablePods: BigNumber;
+  plots: PlotMap<BigNumberJS>;
+  pods: BigNumberJS;
+
+  harvestablePlots: PlotMap<BigNumberJS>;
+  harvestablePods: BigNumberJS;
 };


### PR DESCRIPTION
Reintroduce the Field event processor; migrate from the previous BigNumberJS & object approach to ethers.BigNumber and Maps.

Reintroduce helper function parsePlots to split plots into harvestable & non-harvestable. Add test for this.

Use the processor in the farmer/field/updater and wrangle the ethers.BigNumbers into BigNumberJS which is what the UI components expect currently. Not pretty but functional. Tested manually on some of my accounts.

`yarn run jest processor.test`