### PR TITLE
UI: When converting, ignore small ratio diffs and prioritize Season

### DIFF
--- a/projects/ui/src/lib/Beanstalk/Silo/Convert.ts
+++ b/projects/ui/src/lib/Beanstalk/Silo/Convert.ts
@@ -1,8 +1,7 @@
 import BigNumber from 'bignumber.js';
-import { defaultAbiCoder } from 'ethers/lib/utils';
 import { Token } from '~/classes';
 import { DepositCrate } from '~/state/farmer/silo';
-import { sortCratesByBDVRatio, sortCratesBySeason } from './Utils';
+import { sortConvertCratesByBest, sortCratesBySeason } from './Utils';
 import { STALK_PER_SEED_PER_SEASON } from '~/util';
 
 export enum ConvertKind {
@@ -47,7 +46,7 @@ export function selectCratesToConvert(
     : /// LP -> BEAN: use the crates with the lowest [BDV/Amount] ratio first.
       /// Since LP deposits can have varying BDV, the best option for the Farmer
       /// is to increase the BDV of their existing lowest-BDV crates.
-      sortCratesByBDVRatio<DepositCrate>(depositedCrates, 'asc');
+      sortConvertCratesByBest<DepositCrate>(depositedCrates);
 
   /// FIXME: symmetry with `Withdraw`
   sortedCrates.some((crate) => {

--- a/projects/ui/src/lib/Beanstalk/Silo/Utils.ts
+++ b/projects/ui/src/lib/Beanstalk/Silo/Utils.ts
@@ -25,3 +25,33 @@ export function sortCratesByBDVRatio<T extends DepositCrate>(
     return m * _b.minus(_a).toNumber();
   });
 }
+
+/**
+ * Order crates by what's best to convert. 
+ * 
+ * Pre Silo V3, the season sorting is important to minimize potential stalk loss.
+ * After Silo V3, BDV ratio is the only thing that matters.
+ */
+export function sortConvertCratesByBest<T extends DepositCrate>(
+  crates: T[],
+) {
+  return [...crates].sort((a, b) => {
+    // Calculate the BDV ratio for each crate.
+    // Fix to 4 decimal places to avoid small rounding differences from resorting.
+    const _a = Number(a.bdv.div(a.amount).toPrecision(4));
+    const _b = Number(b.bdv.div(b.amount).toPrecision(4));
+
+    // sorting a - b puts lowest ratio crates first, which is desirable
+    const delta = _a - _b;
+
+    // If the BDV ratio is the same, sort more recent seasons (higher numbers) first.
+    // All else equal, pre-Silo V3 users would rather convert more recent crates.
+    if (delta === 0) {
+      // sorting b.season - a.season sorts higher (more recent) seasons first,
+      // which is desirable
+      return b.season.minus(a.season).toNumber();
+    }
+
+    return delta;
+  });
+}


### PR DESCRIPTION
Since LP deposits can have varying BDV, the best option for the Farmer during a convert is to increase the BDV of their existing lowest-BDV crates.

The UI currently selects crates to convert purely on the basis of this ratio. However, if the `bdv/amount` ratio is similar for two crates, it is optimal for the farmer to select the crate with the higher season pre-Silo V3 to minimize potential stalk loss, since older crates can't be converted into seasons less than 1.

This PR upgrades the selection function to prioritize `amount/bdv` ratio up to 4 decimal places. If two crates have the same ratio to 4 decimal places, the selection process sorts more recent deposits first.