### PR TITLE
Bean UI  - balances header.tsx layout adjustment

### DIFF
--- a/projects/dex-ui/src/components/BottomDrawer.tsx
+++ b/projects/dex-ui/src/components/BottomDrawer.tsx
@@ -52,6 +52,9 @@ const Background = styled.div<Props>`
   transition: all 0.3s ease-in-out;
   opacity: ${({ showDrawer }) => (showDrawer ? "1" : "0")};
   display: ${({ showDrawer }) => (showDrawer ? "flex" : "none")};
+  @media (min-width: ${size.mobile}) {
+    display: none;
+  }
 `;
 
 const Container = styled.div<Props>`

--- a/projects/dex-ui/src/pages/Well.tsx
+++ b/projects/dex-ui/src/pages/Well.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useEffect, useState } from "react";
+import React, { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useWell } from "src/wells/useWell";
 import { getPrice } from "src/utils/price/usePrice";
@@ -95,6 +95,7 @@ export const Well = () => {
     setIsSticky(!entry.isIntersecting); // Not sure why inverting isIntersecting gives me the desired behaviour
   };
 
+  const observer = useRef<IntersectionObserver | null>();
   const containerRef = useCallback((node: any) => {
     if (node === null) return;
 
@@ -104,13 +105,17 @@ export const Well = () => {
       threshold: 1.0
     };
 
-    const observer = new IntersectionObserver(callbackFunction, options);
-    observer.observe(node);
+    if (!observer.current) {
+      observer.current = new IntersectionObserver(callbackFunction, options);
+    }
 
-    return () => {
-      observer.unobserve(node);
-    };
+    observer.current.observe(node);
+
   }, []);
+
+  useEffect(() => () => {
+    if (observer.current) observer.current.disconnect();
+  }, [])
   // Code above detects if the component with the Add/Remove Liq + Swap buttons is sticky
 
   if (loading)

--- a/projects/ui/src/components/Balances/Header.tsx
+++ b/projects/ui/src/components/Balances/Header.tsx
@@ -82,9 +82,10 @@ const BalancesHeader: React.FC<{}> = () => {
         width="100%"
         justifyContent="space-between"
       >
-        {/* STALK */}
-        <HeaderItem {...tokensProps.stalk} alignItems="flex-start" />
         <Row width="100%" justifyContent="space-evenly">
+          {/* STALK */}
+          <HeaderItem {...tokensProps.stalk} alignItems="flex-start" />
+          <VerticalDivider />
           {/* SEEDS */}
           <HeaderItem {...tokensProps.seeds} />
           <VerticalDivider />


### PR DESCRIPTION
Layout of "Stalk, Seeds, Pods, Sprouts" on Balances is a bit off.

- moved Stalk HeaderItem into inner Row
- added VerticalDivider

"Stalk, Seeds, Pods, Sprouts" now centered, and (added bonus) I can now see Stalk tool-tip text on hover.
