### PR TITLE
Bean UI - Balances - TokenBalanceTable.tsx Circulating Balance text

### DIFF
--- a/projects/ui/src/components/Balances/TokenBalanceTable.tsx
+++ b/projects/ui/src/components/Balances/TokenBalanceTable.tsx
@@ -95,7 +95,13 @@ const TokenBalanceTable: React.FC<{
           </>
         </Stack>
       ) : (
-        <Stack height="100%" alignItems="center" justifyContent="center" pb={2}>
+        <Stack
+          height="100%"
+          alignItems="center"
+          justifyContent="center"
+          pb={2}
+          px={2}
+        >
           <Typography color="text.tertiary">
             {`You don't have any tokens in your ${pageName} Balance`}
           </Typography>


### PR DESCRIPTION
TokenBalanceTable.tsx:

- when the rows.length ternary operator is false, the text in the Circulating Balance stack ("You don't have any tokens in your Circulating Balance") needs x-padding below 400px screen width.

- adds px={2} to the Stack when the ternary operator is false, i.e. rows.length ! > 0

**NB:** this increases the height of both Stacks (Farm Balance, Circulating Balance) by one line when screen width > 1199px.