### PR TITLE
add owner() function

### DIFF
--- a/protocol/contracts/C.sol
+++ b/protocol/contracts/C.sol
@@ -75,6 +75,8 @@ library C {
     // Use external contract for block.basefee as to avoid upgrading existing contracts to solidity v8
     address private constant BASE_FEE_CONTRACT = 0x84292919cB64b590C0131550483707E43Ef223aC;
 
+    address internal constant BEANSTALK_COMMUNITY_MULTISIG = 0xa9bA2C40b263843C04d344727b954A545c81D043;
+
     //////////////////// Well ////////////////////
 
     uint256 internal constant WELL_MINIMUM_BEAN_BALANCE = 1000_000_000; // 1,000 Beans

--- a/protocol/contracts/beanstalk/metadata/MetadataFacet.sol
+++ b/protocol/contracts/beanstalk/metadata/MetadataFacet.sol
@@ -5,7 +5,7 @@
 pragma solidity ^0.7.6;
 pragma experimental ABIEncoderV2;
 
-import "./MetadataImage.sol";
+import {MetadataImage, LibStrings, LibBytes64, C} from "./MetadataImage.sol";
 import {LibBytes} from "contracts/libraries/LibBytes.sol";
 import {LibTokenSilo} from "contracts/libraries/Silo/LibTokenSilo.sol";
 
@@ -55,11 +55,28 @@ contract MetadataFacet is MetadataImage {
         ));
     }
 
+    /**
+     * @notice Returns the name of the ERC1155.
+     */
     function name() external pure returns (string memory){
         return "Beanstalk Silo Deposits";
     }
 
+    /**
+     * @notice Returns the symbol of the ERC1155.
+     */
     function symbol() external pure returns (string memory){
         return "DEPOSIT";
+    }
+
+    /**
+     * @notice Returns the owner of the ERC1155.
+     * @dev The owner is the Beanstalk Community Multisig.
+     * This uses a constant as changing owners would require a BIP to be passed.
+     * The owner cannot change the ERC1155 functionality, but NFT marketplaces
+     * may use this to give permission to update details on their website (e.g. OpenSea)
+     */
+    function owner() external pure returns (address){
+        return C.BEANSTALK_COMMUNITY_MULTISIG;
     }
 }


### PR DESCRIPTION
Adds owner() function. Although there is no `onlyOwner()` modifier, some nft marketplaces uses owner() to give permissions to edit the collection details. Currently set to the BCM as a constant, due to the fact that changing the owner would require a BIP, and thus would be redundant to add additional functionality to transfer ownership of the beanstalk deposits. 