### PR TITLE
Bean Subgraph - Split Cross Entity

### DIFF
--- a/projects/subgraph-bean/schema.graphql
+++ b/projects/subgraph-bean/schema.graphql
@@ -37,6 +37,9 @@ type Bean @entity {
   "Cumulative number of crosses"
   crosses: Int!
 
+  "Detailed cross events during this snapshot"
+  crossEvents: [BeanCross!]! @derivedFrom(field: "bean")
+
   "Last timestamp a cross was seen"
   lastCross: BigInt!
 
@@ -100,7 +103,7 @@ type BeanHourlySnapshot @entity {
   deltaCrosses: Int!
 
   "Detailed cross events during this snapshot"
-  crossEvents: [Cross!]! @derivedFrom(field: "hourlySnapshot")
+  crossEvents: [BeanCross!]! @derivedFrom(field: "hourlySnapshot")
 
   "Season associated with this snapshot"
   season: Int!
@@ -130,24 +133,32 @@ type BeanDailySnapshot @entity {
   deltaVolumeUSD: BigDecimal!
   deltaLiquidityUSD: BigDecimal!
   deltaCrosses: Int!
-  crossEvents: [Cross!]! @derivedFrom(field: "dailySnapshot")
+  crossEvents: [BeanCross!]! @derivedFrom(field: "dailySnapshot")
   season: Int!
   timestamp: BigInt!
   blockNumber: BigInt!
 }
 
-type Cross @entity {
+type BeanCross @entity {
+  id: ID!
+  bean: Bean!
+  price: BigDecimal!
+  timestamp: BigInt!
+  timeSinceLastCross: BigInt!
+  above: Boolean!
+  hourlySnapshot: BeanHourlySnapshot!
+  dailySnapshot: BeanDailySnapshot!
+}
+
+type PoolCross @entity {
   id: ID!
   pool: Pool!
   price: BigDecimal!
   timestamp: BigInt!
   timeSinceLastCross: BigInt!
   above: Boolean!
-  overall: Boolean!
-  hourlySnapshot: BeanHourlySnapshot!
-  dailySnapshot: BeanDailySnapshot!
-  poolHourlySnapshot: PoolHourlySnapshot!
-  poolDailySnapshot: PoolDailySnapshot!
+  hourlySnapshot: PoolHourlySnapshot!
+  dailySnapshot: PoolDailySnapshot!
 }
 
 type Pool @entity {
@@ -160,7 +171,9 @@ type Pool @entity {
   volumeUSD: BigDecimal!
   liquidityUSD: BigDecimal!
   crosses: Int!
-  crossEvents: [Cross!]! @derivedFrom(field: "pool")
+  "Last timestamp a cross was seen for this pool"
+  lastCross: BigInt!
+  crossEvents: [PoolCross!]! @derivedFrom(field: "pool")
   deltaBeans: BigInt!
   hourlySnapshot: [PoolHourlySnapshot!]! @derivedFrom(field: "pool")
   dailySnapshot: [PoolDailySnapshot!]! @derivedFrom(field: "pool")
@@ -182,7 +195,7 @@ type PoolHourlySnapshot @entity {
   deltaVolumeUSD: BigDecimal!
   deltaLiquidityUSD: BigDecimal!
   deltaCrosses: Int!
-  crossEvents: [Cross!]! @derivedFrom(field: "poolHourlySnapshot")
+  crossEvents: [PoolCross!]! @derivedFrom(field: "hourlySnapshot")
   season: Int!
   createdAt: BigInt!
   updatedAt: BigInt!
@@ -204,7 +217,7 @@ type PoolDailySnapshot @entity {
   deltaVolumeUSD: BigDecimal!
   deltaLiquidityUSD: BigDecimal!
   deltaCrosses: Int!
-  crossEvents: [Cross!]! @derivedFrom(field: "poolDailySnapshot")
+  crossEvents: [PoolCross!]! @derivedFrom(field: "dailySnapshot")
   season: Int!
   createdAt: BigInt!
   updatedAt: BigInt!

--- a/projects/subgraph-bean/src/Bean3CRVHandler.ts
+++ b/projects/subgraph-bean/src/Bean3CRVHandler.ts
@@ -13,6 +13,7 @@ import { BEANSTALK_PRICE, BEAN_ERC20, CURVE_PRICE } from "../../subgraph-core/ut
 import { toDecimal, ZERO_BD, ZERO_BI } from "../../subgraph-core/utils/Decimals";
 import { getPoolLiquidityUSD, loadOrCreatePool, setPoolReserves, updatePoolPrice, updatePoolValues } from "./utils/Pool";
 import { BeanstalkPrice } from "../generated/Bean3CRV/BeanstalkPrice";
+import { checkBeanCross } from "./utils/Cross";
 
 export function handleTokenExchange(event: TokenExchange): void {
   handleSwap(
@@ -120,7 +121,8 @@ function handleLiquidityChange(
   updateBeanValues(BEAN_ERC20.toHexString(), timestamp, beanPrice, ZERO_BI, volumeBean, volumeUSD, deltaLiquidityUSD);
 
   updatePoolValues(poolAddress, timestamp, blockNumber, volumeBean, volumeUSD, deltaLiquidityUSD, curve.value.deltaB);
-  updatePoolPrice(poolAddress, timestamp, blockNumber, newPrice, oldBeanPrice, beanPrice);
+  updatePoolPrice(poolAddress, timestamp, blockNumber, newPrice);
+  checkBeanCross(BEAN_ERC20.toHexString(), timestamp, blockNumber, oldBeanPrice, beanPrice);
 }
 
 function handleSwap(
@@ -170,5 +172,6 @@ function handleSwap(
   updateBeanValues(BEAN_ERC20.toHexString(), timestamp, beanPrice, ZERO_BI, volumeBean, volumeUSD, deltaLiquidityUSD);
 
   updatePoolValues(poolAddress, timestamp, blockNumber, volumeBean, volumeUSD, deltaLiquidityUSD, curve.value.deltaB);
-  updatePoolPrice(poolAddress, timestamp, blockNumber, newPrice, oldBeanPrice, beanPrice);
+  updatePoolPrice(poolAddress, timestamp, blockNumber, newPrice);
+  checkBeanCross(BEAN_ERC20.toHexString(), timestamp, blockNumber, oldBeanPrice, beanPrice);
 }

--- a/projects/subgraph-bean/src/Bean3CRVHandler_V1.ts
+++ b/projects/subgraph-bean/src/Bean3CRVHandler_V1.ts
@@ -21,6 +21,7 @@ import { loadOrCreatePool, setPoolReserves, updatePoolPrice, updatePoolValues } 
 import { CalculationsCurve } from "../generated/Bean3CRV-V1/CalculationsCurve";
 import { Bean3CRV } from "../generated/Bean3CRV-V1/Bean3CRV";
 import { ERC20 } from "../generated/Bean3CRV-V1/ERC20";
+import { checkBeanCross } from "./utils/Cross";
 
 export function handleTokenExchange(event: TokenExchange): void {
   // Do not index post-exploit data
@@ -180,7 +181,8 @@ function handleLiquidityChange(
 
   updateBeanValues(BEAN_ERC20_V1.toHexString(), timestamp, newPrice, ZERO_BI, volumeBean, volumeUSD, deltaLiquidityUSD);
   updatePoolValues(poolAddress, timestamp, blockNumber, volumeBean, volumeUSD, deltaLiquidityUSD, deltaB);
-  updatePoolPrice(poolAddress, timestamp, blockNumber, newPrice, oldBeanPrice, newPrice);
+  updatePoolPrice(poolAddress, timestamp, blockNumber, newPrice);
+  checkBeanCross(BEAN_ERC20_V1.toHexString(), timestamp, blockNumber, oldBeanPrice, newPrice);
 }
 
 function handleSwap(
@@ -262,5 +264,6 @@ function handleSwap(
   let volumeUSD = toDecimal(volumeBean).times(newPrice);
   updateBeanValues(BEAN_ERC20_V1.toHexString(), timestamp, newPrice, ZERO_BI, volumeBean, volumeUSD, deltaLiquidityUSD);
   updatePoolValues(poolAddress, timestamp, blockNumber, volumeBean, volumeUSD, deltaLiquidityUSD, deltaB);
-  updatePoolPrice(poolAddress, timestamp, blockNumber, newPrice, oldBeanPrice, newPrice);
+  updatePoolPrice(poolAddress, timestamp, blockNumber, newPrice);
+  checkBeanCross(BEAN_ERC20_V1.toHexString(), timestamp, blockNumber, oldBeanPrice, newPrice);
 }

--- a/projects/subgraph-bean/src/UniswapV2Handler.ts
+++ b/projects/subgraph-bean/src/UniswapV2Handler.ts
@@ -5,6 +5,7 @@ import { BEAN_ERC20_V1, WETH, WETH_USDC_PAIR } from "../../subgraph-core/utils/C
 import { toBigInt, toDecimal, ZERO_BD, ZERO_BI } from "../../subgraph-core/utils/Decimals";
 import { loadOrCreatePool, setPoolReserves, updatePoolPrice, updatePoolReserves, updatePoolValues } from "./utils/Pool";
 import { loadOrCreateToken } from "./utils/Token";
+import { checkBeanCross } from "./utils/Cross";
 
 // export function handleMint(event: Mint): void {
 //   updatePoolReserves(event.address.toHexString(), event.params.amount0, event.params.amount1, event.block.number);
@@ -93,7 +94,9 @@ export function handleSync(event: Sync): void {
 
   let currentBeanPrice = wethBalance.times(weth.lastPriceUSD).div(beanBalance);
 
-  updatePoolPrice(event.address.toHexString(), event.block.timestamp, event.block.number, currentBeanPrice, oldBeanPrice, currentBeanPrice);
+  updatePoolPrice(event.address.toHexString(), event.block.timestamp, event.block.number, currentBeanPrice);
+
+  checkBeanCross(BEAN_ERC20_V1.toHexString(), event.block.timestamp, event.block.number, oldBeanPrice, currentBeanPrice);
 
   setPoolReserves(event.address.toHexString(), [reserves.value.value0, reserves.value.value1], event.block.number);
 

--- a/projects/subgraph-bean/src/utils/Cross.ts
+++ b/projects/subgraph-bean/src/utils/Cross.ts
@@ -1,57 +1,110 @@
 import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
-import { Cross } from "../../generated/schema";
+import { BeanCross, PoolCross } from "../../generated/schema";
 import { loadBean, loadOrCreateBeanDailySnapshot, loadOrCreateBeanHourlySnapshot } from "./Bean";
 import { dayFromTimestamp, hourFromTimestamp } from "../../../subgraph-core/utils/Dates";
 import { ONE_BD, ZERO_BD, ZERO_BI } from "../../../subgraph-core/utils/Decimals";
-import { incrementPoolCross, loadOrCreatePool } from "./Pool";
+import { loadOrCreatePool, loadOrCreatePoolDailySnapshot, loadOrCreatePoolHourlySnapshot } from "./Pool";
 import { BEAN_ERC20_V1 } from "../../../subgraph-core/utils/Constants";
 
-export function loadOrCreateCross(id: i32, pool: string, timestamp: BigInt): Cross {
-  let cross = Cross.load(id.toString());
+export function loadOrCreateBeanCross(id: i32, bean: string, timestamp: BigInt): BeanCross {
+  let cross = BeanCross.load(id.toString());
   if (cross == null) {
     let hour = hourFromTimestamp(timestamp).toString();
     let day = dayFromTimestamp(timestamp).toString();
-    cross = new Cross(id.toString());
+    cross = new BeanCross(id.toString());
+    cross.bean = bean;
+    cross.price = ZERO_BD;
+    cross.timestamp = timestamp;
+    cross.timeSinceLastCross = ZERO_BI;
+    cross.above = false;
+    cross.hourlySnapshot = hour;
+    cross.dailySnapshot = day;
+    cross.save();
+  }
+  return cross as BeanCross;
+}
+
+export function loadOrCreatePoolCross(id: i32, pool: string, timestamp: BigInt): PoolCross {
+  let crossID = pool + "-" + id.toString();
+  let cross = PoolCross.load(crossID);
+  if (cross == null) {
+    let hour = hourFromTimestamp(timestamp).toString();
+    let day = dayFromTimestamp(timestamp).toString();
+    cross = new PoolCross(crossID);
     cross.pool = pool;
     cross.price = ZERO_BD;
     cross.timestamp = timestamp;
     cross.timeSinceLastCross = ZERO_BI;
     cross.above = false;
-    cross.overall = false;
     cross.hourlySnapshot = hour;
     cross.dailySnapshot = day;
-    cross.poolHourlySnapshot = pool + "-" + hour;
-    cross.poolDailySnapshot = pool + "-" + day;
     cross.save();
   }
-  return cross as Cross;
+  return cross as PoolCross;
 }
 
-export function checkCrossAndUpdate(
-  pool: string,
-  timestamp: BigInt,
-  blockNumber: BigInt,
-  oldPrice: BigDecimal,
-  newPrice: BigDecimal,
-  beanOld: BigDecimal,
-  beanNew: BigDecimal
-): void {
+export function checkPoolCross(pool: string, timestamp: BigInt, blockNumber: BigInt, oldPrice: BigDecimal, newPrice: BigDecimal): void {
   let poolInfo = loadOrCreatePool(pool, blockNumber);
   let token = poolInfo.bean;
   let bean = loadBean(token);
-  let beanHourly = loadOrCreateBeanHourlySnapshot(token, timestamp, bean.lastSeason);
-  let beanDaily = loadOrCreateBeanDailySnapshot(token, timestamp);
-  let crossID = "";
+  let poolHourly = loadOrCreatePoolHourlySnapshot(token, timestamp, BigInt.fromI32(bean.lastSeason));
+  let poolDaily = loadOrCreatePoolDailySnapshot(token, timestamp, blockNumber);
 
   if (oldPrice >= ONE_BD && newPrice < ONE_BD) {
-    let cross = loadOrCreateCross(bean.crosses, pool, timestamp);
-    crossID = cross.id;
+    let cross = loadOrCreatePoolCross(poolInfo.crosses, pool, timestamp);
+
+    cross.price = newPrice;
+    cross.timeSinceLastCross = timestamp.minus(poolInfo.lastCross);
+    cross.above = false;
+    cross.save();
+
+    poolInfo.lastCross = timestamp;
+    poolInfo.crosses += 1;
+    poolInfo.save();
+
+    poolHourly.crosses += 1;
+    poolHourly.deltaCrosses += 1;
+    poolHourly.save();
+
+    poolDaily.crosses += 1;
+    poolDaily.deltaCrosses += 1;
+    poolDaily.save();
+  } else if (oldPrice < ONE_BD && newPrice >= ONE_BD) {
+    let cross = loadOrCreatePoolCross(poolInfo.crosses, pool, timestamp);
+
+    cross.price = newPrice;
+    cross.timeSinceLastCross = timestamp.minus(poolInfo.lastCross);
+    cross.above = true;
+    cross.save();
+
+    poolInfo.lastCross = timestamp;
+    poolInfo.crosses += 1;
+    poolInfo.save();
+
+    poolHourly.crosses += 1;
+    poolHourly.deltaCrosses += 1;
+    poolHourly.save();
+
+    poolDaily.crosses += 1;
+    poolDaily.deltaCrosses += 1;
+    poolDaily.save();
+  }
+}
+
+export function checkBeanCross(token: string, timestamp: BigInt, blockNumber: BigInt, oldPrice: BigDecimal, newPrice: BigDecimal): void {
+  let bean = loadBean(token);
+  let beanHourly = loadOrCreateBeanHourlySnapshot(token, timestamp, bean.lastSeason);
+  let beanDaily = loadOrCreateBeanDailySnapshot(token, timestamp);
+
+  if (oldPrice >= ONE_BD && newPrice < ONE_BD) {
+    let cross = loadOrCreateBeanCross(bean.crosses, token, timestamp);
 
     cross.price = newPrice;
     cross.timeSinceLastCross = timestamp.minus(bean.lastCross);
     cross.above = false;
     cross.save();
 
+    bean.lastCross = timestamp;
     bean.crosses += 1;
     bean.save();
 
@@ -62,19 +115,15 @@ export function checkCrossAndUpdate(
     beanDaily.crosses += 1;
     beanDaily.deltaCrosses += 1;
     beanDaily.save();
-
-    incrementPoolCross(pool, timestamp, blockNumber);
-  }
-
-  if (oldPrice < ONE_BD && newPrice >= ONE_BD) {
-    let cross = loadOrCreateCross(bean.crosses, pool, timestamp);
-    crossID = cross.id;
+  } else if (oldPrice < ONE_BD && newPrice >= ONE_BD) {
+    let cross = loadOrCreateBeanCross(bean.crosses, token, timestamp);
 
     cross.price = newPrice;
     cross.timeSinceLastCross = timestamp.minus(bean.lastCross);
     cross.above = true;
     cross.save();
 
+    bean.lastCross = timestamp;
     bean.crosses += 1;
     bean.save();
 
@@ -85,23 +134,6 @@ export function checkCrossAndUpdate(
     beanDaily.crosses += 1;
     beanDaily.deltaCrosses += 1;
     beanDaily.save();
-
-    incrementPoolCross(pool, timestamp, blockNumber);
-  }
-
-  // We had a cross. Check if Bean crossed as well.
-  if (crossID != "") {
-    // Check cross logic against Bean values and not the pool values.
-    if ((beanOld >= ONE_BD && beanNew < ONE_BD) || (beanOld < ONE_BD && beanNew >= ONE_BD)) {
-      // This should never be null since we pulled the ID from the creation earlier.
-      let cross = Cross.load(crossID);
-      if (cross == null) return;
-      bean.lastCross = timestamp;
-      bean.save();
-
-      cross.overall = true;
-      cross.save();
-    }
   }
 }
 


### PR DESCRIPTION
Previously there was only one pool to track peg crosses, and the overall Bean peg was tied to that one pool. With the introduction of the Bean:ETH well, the overall Bean price can cross peg independently of an individual pool have a cross at the same time.

Schema changes:
- `Cross` entity removed and replaced by the following two entities
- `BeanCross` entity added to track the overall Bean peg cross. This uses the liquidity weighted price returned by the current price contract.
- `PoolCross` entity added to track individual peg crosses within a pool. Each pool has their own incremental counter for the number crosses observed.