### PR TITLE
[INCLUDED IN GAUGE] Unripe λ → λ Conversions

### DIFF
--- a/protocol/contracts/beanstalk/barn/UnripeFacet.sol
+++ b/protocol/contracts/beanstalk/barn/UnripeFacet.sol
@@ -9,31 +9,30 @@ import "@openzeppelin/contracts/cryptography/MerkleProof.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
-import {IBean} from "contracts/interfaces/IBean.sol";
-import {LibDiamond} from "contracts/libraries/LibDiamond.sol";
-import {LibUnripe} from "contracts/libraries/LibUnripe.sol";
-import {LibTransfer} from "contracts/libraries/Token/LibTransfer.sol";
-import "contracts/C.sol";
-import "contracts/beanstalk/ReentrancyGuard.sol";
+import {IBean} from "~/interfaces/IBean.sol";
+import {LibDiamond} from "~/libraries/LibDiamond.sol";
+import {LibUnripe} from "~/libraries/LibUnripe.sol";
+import {LibTransfer} from "~/libraries/Token/LibTransfer.sol";
+import "~/C.sol";
+import "~/beanstalk/ReentrancyGuard.sol";
+import "~/libraries/LibChop.sol";
 
-/// @author ZrowGz, Publius
-/// @title VestingFacet
-/// @notice Manage the logic of the vesting process for the Barnraised Funds
+/**
+ * @title UnripeFacet
+ * @author ZrowGz, Publius , deadmanwalking
+ * @notice @notice Manage the logic of the vesting process for the Barnraised Funds
+ */
 
 contract UnripeFacet is ReentrancyGuard {
     using SafeERC20 for IERC20;
     using LibTransfer for IERC20;
     using SafeMath for uint256;
 
-    uint256 constant DECIMALS = 1e6;
-
     event AddUnripeToken(
         address indexed unripeToken,
         address indexed underlyingToken,
         bytes32 merkleRoot
     );
-
-    event ChangeUnderlying(address indexed token, int256 underlying);
 
     event Chop(
         address indexed account,
@@ -42,33 +41,49 @@ contract UnripeFacet is ReentrancyGuard {
         uint256 underlying
     );
 
+    event ChangeUnderlying(address indexed token, int256 underlying);
+
     event Pick(
         address indexed account,
         address indexed token,
         uint256 amount
     );
 
+    /**
+     * @notice Chops an unripe asset into its ripe counterpart according to the recapitalization % 
+     * @param unripeToken The address of the unripe token to be chopped into its ripe counterpart
+     * @param amount The amount of the of the unripe token to be chopped into its ripe counterpart
+     * @param fromMode Enum value to distinguish the type of account used to charge the funds before chopping.
+     * @param toMode Enum value to distinguish the type of account used to credit the funds after chopping.
+     * fromMode can be EXTERNAL,INTERNAL, EXTERNAL_INTERNAL,INTERNAL_TOLERANT.
+     * toMode can be EXTERNAL or INTERNAL.
+     * @return underlyingAmount the amount of ripe tokens received after the chop
+     */
     function chop(
         address unripeToken,
         uint256 amount,
         LibTransfer.From fromMode,
         LibTransfer.To toMode
-    ) external payable nonReentrant returns (uint256 underlyingAmount) {
-        uint256 unripeSupply = IERC20(unripeToken).totalSupply();
-
+    ) external payable nonReentrant returns (uint256) {
+        // burn the token from the msg.sender address
         amount = LibTransfer.burnToken(IBean(unripeToken), amount, msg.sender, fromMode);
-
-        underlyingAmount = _getPenalizedUnderlying(unripeToken, amount, unripeSupply);
-
-        LibUnripe.decrementUnderlying(unripeToken, underlyingAmount);
-
-        address underlyingToken = s.u[unripeToken].underlyingToken;
-
+        // get ripe address and ripe amount
+        (address underlyingToken, uint256 underlyingAmount) = LibChop.chop(unripeToken, amount);
+        // send the corresponding amount of ripe token to the user address
         IERC20(underlyingToken).sendToken(underlyingAmount, msg.sender, toMode);
-
+        // emit the event
         emit Chop(msg.sender, unripeToken, amount, underlyingAmount);
+        return underlyingAmount;
     }
 
+
+    /**
+     * @notice Enbles a user to collect their share of unripe tokens.
+     * @param token The address of the unripe token to be collected.
+     * @param amount The amount of the of the unripe token to be collected.
+     * @param proof The merkle proof used to validate the claim in order to prevent miltiple picks from occuring.
+     * @param mode Enum value to distinguish the type of account used to credit the unripe tokens after collecting.
+     */
     function pick(
         address token,
         uint256 amount,
@@ -94,6 +109,11 @@ contract UnripeFacet is ReentrancyGuard {
         emit Pick(msg.sender, token, amount);
     }
 
+   /**
+     * @notice Getter function to check if an account has claimed (picked) their share of unripe tokens.
+     * @param account The address of the account.
+     * @param token The address of the unripe token.
+     */
     function picked(address account, address token)
         public
         view
@@ -102,54 +122,64 @@ contract UnripeFacet is ReentrancyGuard {
         return s.unripeClaimed[token][account];
     }
 
+    /**
+     * @notice Getter function to get the corresponding underlying amount of ripe
+     * tokens from its unripe counterpart.
+     * @param unripeToken The address of the unripe token.
+     * @param amount The amount of the unripe token.
+     * @return redeem The amount of ripe tokens received from the unripe ones.
+     */
     function getUnderlying(address unripeToken, uint256 amount)
         public
         view
         returns (uint256 redeem)
     {
-        return _getUnderlying(unripeToken, amount, IERC20(unripeToken).totalSupply());
+        return LibUnripe.unripeToUnderlying(unripeToken, amount);
     }
 
-    function _getUnderlying(address unripeToken, uint256 amount, uint256 supply)
-        private
-        view
-        returns (uint256 redeem)
-    {
-        redeem = s.u[unripeToken].balanceOfUnderlying.mul(amount).div(
-            supply
-        );
-    }
-
+    /**
+     * @notice Getter function to get the corresponding penalty associated with an unripe asset.
+     * @param unripeToken The address of the unripe token.
+     * @return penalty The current penalty for converting unripe --> ripe
+     */
     function getPenalty(address unripeToken)
         external
         view
         returns (uint256 penalty)
     {
-        return getPenalizedUnderlying(unripeToken, DECIMALS);
+        return getPenalizedUnderlying(unripeToken, LibUnripe.DECIMALS);
     }
 
+    /**
+     * @notice Getter function to get the corresponding amount 
+     * of ripe tokens from a set amount of unripe tokens according to current state.
+     * @param unripeToken The address of the unripe token.
+     * @param amount The amount of the unripe token.
+     * @return redeem The amount of the corresponding ripe tokens
+     */
     function getPenalizedUnderlying(address unripeToken, uint256 amount)
         public
         view
         returns (uint256 redeem)
     {
-        return _getPenalizedUnderlying(unripeToken, amount, IERC20(unripeToken).totalSupply());
+        return LibChop._getPenalizedUnderlying(unripeToken, amount);
     }
 
-    function _getPenalizedUnderlying(address unripeToken, uint256 amount, uint256 supply)
-        public
-        view
-        returns (uint256 redeem)
-    {
-        require(isUnripe(unripeToken), "not vesting");
-        uint256 sharesBeingRedeemed = getRecapPaidPercentAmount(amount);
-        redeem = _getUnderlying(unripeToken, sharesBeingRedeemed, supply);
+    /**
+     * @notice Getter function to check if a token is unripe or not.
+     * @param unripeToken The address of the unripe token.
+     * @return unripe Whether the token is unripe or not.
+     */
+    function isUnripe(address unripeToken) external view returns (bool unripe) {
+        unripe = LibChop.isUnripe(unripeToken);
     }
 
-    function isUnripe(address unripeToken) public view returns (bool unripe) {
-        unripe = s.u[unripeToken].underlyingToken != address(0);
-    }
-
+    /**
+     * @notice Getter function to get the balance of an underlying unripe asset from an account.
+     * @param unripeToken The address of the unripe token.
+     * @param account The address of the account to check.
+     * @return underlying The amount of the underlying asset.
+     */
     function balanceOfUnderlying(address unripeToken, address account)
         external
         view
@@ -159,6 +189,13 @@ contract UnripeFacet is ReentrancyGuard {
             getUnderlying(unripeToken, IERC20(unripeToken).balanceOf(account));
     }
 
+    /**
+     * @notice Getter function to get the balance of ripe tokens that can be credited to an account
+     * according to the accounts' balance of an unripe token, if that account decided to convert.
+     * @param unripeToken The address of the unripe token.
+     * @param account The address of the account to check.
+     * @return underlying The theoretical amount of the ripe asset in the account.
+     */
     function balanceOfPenalizedUnderlying(address unripeToken, address account)
         external
         view
@@ -171,6 +208,11 @@ contract UnripeFacet is ReentrancyGuard {
             );
     }
 
+    /**
+     * @notice Getter function to get the percent funded of an unripe token.
+     * @param unripeToken The address of the unripe token.
+     * @return percent The recap % of the token.
+     */
     function getRecapFundedPercent(address unripeToken)
         public
         view
@@ -183,27 +225,34 @@ contract UnripeFacet is ReentrancyGuard {
         }
         revert("not vesting");
     }
-
+    
+    /**
+     * @notice Getter function to get the % penalty of converting from unripe to ripe.
+     * @param unripeToken The address of the unripe token.
+     * @return penalty The penalty %.
+     */
     function getPercentPenalty(address unripeToken)
         external
         view
         returns (uint256 penalty)
     {
-        return getRecapPaidPercentAmount(getRecapFundedPercent(unripeToken));
+        return LibChop.getRecapPaidPercentAmount(getRecapFundedPercent(unripeToken));
     }
-
+    
+    /**
+     * @notice Getter function to get the % of the recapitalization of an unripe asset.
+     * @return penalty The penalty % stemming from the recap.
+     */
     function getRecapPaidPercent() external view returns (uint256 penalty) {
-        penalty = getRecapPaidPercentAmount(DECIMALS);
+        penalty = LibChop.getRecapPaidPercentAmount(LibUnripe.DECIMALS);
     }
 
-    function getRecapPaidPercentAmount(uint256 amount)
-        private
-        view
-        returns (uint256 penalty)
-    {
-        return s.fertilizedIndex.mul(amount).div(s.unfertilizedIndex);
-    }
-
+    /**
+     * @notice Getter function to get the corresponing amount a of ripe asset when converting
+     * from its unripe counterpart.
+     * @param unripeToken The address of the unripe token.
+     * @return underlyingPerToken The underlying ripe token per unripe token. 
+     */
     function getUnderlyingPerUnripeToken(address unripeToken)
         external
         view
@@ -212,10 +261,15 @@ contract UnripeFacet is ReentrancyGuard {
         underlyingPerToken = s
             .u[unripeToken]
             .balanceOfUnderlying
-            .mul(DECIMALS)
+            .mul(LibUnripe.DECIMALS)
             .div(IERC20(unripeToken).totalSupply());
     }
 
+    /**
+     * @notice Getter function to get the total underlying amount of an unripe token.
+     * @param unripeToken The address of the unripe token.
+     * @return underlying The total balance of the token. 
+     */
     function getTotalUnderlying(address unripeToken)
         external
         view
@@ -224,6 +278,13 @@ contract UnripeFacet is ReentrancyGuard {
         return s.u[unripeToken].balanceOfUnderlying;
     }
 
+
+    /**
+     * @notice Adds an unripe token to the list of unripe tokens.
+     * @param unripeToken The address of the unripe token to be added.
+     * @param underlyingToken The address of the underlying token.
+     * @param root The merkle root , later used to verify claims.
+     */
     function addUnripeToken(
         address unripeToken,
         address underlyingToken,
@@ -235,6 +296,11 @@ contract UnripeFacet is ReentrancyGuard {
         emit AddUnripeToken(unripeToken, underlyingToken, root);
     }
 
+    /**
+     * @notice Getter function to get the underlying token of an unripe token.
+     * @param unripeToken The address of the unripe token.
+     * @return underlyingToken The address of the underlying token.
+     */
     function getUnderlyingToken(address unripeToken)
         external
         view

--- a/protocol/contracts/libraries/Convert/LibChopConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibChopConvert.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.7.6;
+pragma experimental ABIEncoderV2;
+
+import "~/libraries/Token/LibTransfer.sol";
+import "./LibConvertData.sol";
+import "~/libraries/LibChop.sol";
+import "../../C.sol";
+import {IBean} from "../../interfaces/IBean.sol";
+
+/**
+ * @title LibChopConvert
+ * @author deadmanwalking
+ */
+library LibChopConvert {
+    using LibConvertData for bytes;
+
+    /**
+     * @notice Converts an unripe asset into its ripe counterpart
+     * @param convertData The encoded data containing the info for the convert
+     * @return tokenOut The address of the ripe token to be returned after the convert
+     * @return tokenIn The address of the unripe token to be converted
+     * @return amountOut The amount of the ripe asset credited after the convert
+     * @return amountIn The amount of the unripe asset to be converted
+     */
+    function convertUnripeToRipe(bytes memory convertData)
+        internal
+        returns (
+            address tokenOut,
+            address tokenIn,
+            uint256 amountOut,
+            uint256 amountIn
+        )
+    {
+        // Decode convertdata
+        (amountIn, tokenIn) = convertData.lambdaConvert();
+        // LibChop.chop just decrements the amount of unripe beans in circulation from the storage
+        (tokenOut, amountOut) = LibChop.chop(tokenIn, amountIn);
+        // UrBEAN still needs to be burned directly (not from an address) 
+        IBean(tokenIn).burn(amountIn);
+    }
+
+    /**
+     * @notice Retruns the final amount of ripe assets converted from its unripe counterpart
+     * @param tokenIn The address of the unripe token converted
+     * @param amountIn The amount of the unripe asset converted
+     */
+    function getRipeOut(address tokenIn, uint256 amountIn) internal view returns(uint256 amount) {
+        // tokenIn == unripe bean address
+        amount = LibChop._getPenalizedUnderlying(tokenIn, amountIn);
+    }
+}

--- a/protocol/contracts/libraries/Convert/LibConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibConvert.sol
@@ -9,6 +9,7 @@ import {LibUnripeConvert} from "./LibUnripeConvert.sol";
 import {LibLambdaConvert} from "./LibLambdaConvert.sol";
 import {LibConvertData} from "./LibConvertData.sol";
 import {LibWellConvert} from "./LibWellConvert.sol";
+import {LibChopConvert} from "./LibChopConvert.sol";
 import {LibWell} from "contracts/libraries/Well/LibWell.sol";
 import {C} from "contracts/C.sol";
 
@@ -58,6 +59,9 @@ library LibConvert {
         } else if (kind == LibConvertData.ConvertKind.WELL_LP_TO_BEANS) {
             (tokenOut, tokenIn, amountOut, amountIn) = LibWellConvert
                 .convertLPToBeans(convertData);
+        } else if (kind == LibConvertData.ConvertKind.UNRIPE_TO_RIPE) {
+            (tokenOut, tokenIn, amountOut, amountIn) = LibChopConvert
+                .convertUnripeToRipe(convertData);
         } else {
             revert("Convert: Invalid payload");
         }
@@ -76,14 +80,6 @@ library LibConvert {
         if (tokenIn == C.BEAN && tokenOut == C.CURVE_BEAN_METAPOOL)
             return LibCurveConvert.beansToPeg(C.CURVE_BEAN_METAPOOL);
         
-        /// urBEAN:3CRV LP -> urBEAN
-        if (tokenIn == C.UNRIPE_LP && tokenOut == C.UNRIPE_BEAN)
-            return LibUnripeConvert.lpToPeg();
-
-        /// urBEAN -> urBEAN:3CRV LP
-        if (tokenIn == C.UNRIPE_BEAN && tokenOut == C.UNRIPE_LP)
-            return LibUnripeConvert.beansToPeg();
-
         // Lambda -> Lambda
         if (tokenIn == tokenOut) 
             return type(uint256).max;
@@ -95,6 +91,26 @@ library LibConvert {
         // Well LP Token -> Bean
         if (tokenIn.isWell() && tokenOut == C.BEAN)
             return LibWellConvert.lpToPeg(tokenIn);
+
+        // urBEAN3CRV Convert
+        if (tokenIn == C.UNRIPE_LP){
+            // urBEAN:3CRV -> urBEAN
+            if(tokenOut == C.UNRIPE_BEAN)
+                return LibUnripeConvert.lpToPeg();
+            // UrBEAN:3CRV -> BEAN:3CRV
+            if(tokenOut == C.CURVE_BEAN_METAPOOL)
+                return type(uint256).max;
+        }
+
+        // urBEAN Convert
+        if (tokenIn == C.UNRIPE_BEAN){
+            // urBEAN -> urBEAN:3CRV LP
+            if(tokenOut == C.UNRIPE_LP)
+                return LibUnripeConvert.beansToPeg();
+            // UrBEAN -> BEAN
+            if(tokenOut == C.BEAN)
+                return type(uint256).max;
+        }
 
         revert("Convert: Tokens not supported");
     }
@@ -131,6 +147,14 @@ library LibConvert {
         // Well LP Token -> Bean
         if (tokenIn.isWell() && tokenOut == C.BEAN)
             return LibWellConvert.getBeanAmountOut(tokenIn, amountIn);
+
+        // UrBEAN -> Bean
+        if (tokenIn == C.UNRIPE_BEAN && tokenOut == C.BEAN)
+            return LibChopConvert.getRipeOut(tokenIn, amountIn);
+
+        // UrBEAN:3CRV -> BEAN:3CRV
+        if (tokenIn == C.UNRIPE_LP && tokenOut == C.CURVE_BEAN_METAPOOL)
+            return LibChopConvert.getRipeOut(tokenIn, amountIn);
 
         revert("Convert: Tokens not supported");
     }

--- a/protocol/contracts/libraries/Convert/LibConvertData.sol
+++ b/protocol/contracts/libraries/Convert/LibConvertData.sol
@@ -16,7 +16,8 @@ library LibConvertData {
         UNRIPE_LP_TO_UNRIPE_BEANS,
         LAMBDA_LAMBDA,
         BEANS_TO_WELL_LP,
-        WELL_LP_TO_BEANS
+        WELL_LP_TO_BEANS,
+        UNRIPE_TO_RIPE
     }
 
     /// @notice Decoder for the Convert Enum

--- a/protocol/contracts/libraries/LibChop.sol
+++ b/protocol/contracts/libraries/LibChop.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.7.6;
+pragma experimental ABIEncoderV2;
+
+import "~/libraries/LibUnripe.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IBean} from "~/interfaces/IBean.sol";
+import {LibAppStorage} from "./LibAppStorage.sol";
+
+/**
+ * @title LibChop
+ * @author deadmanwalking
+ */
+library LibChop {
+
+    using SafeMath for uint256;
+
+    /**
+     * @notice Chops an unripe asset into its ripe counterpart according to the recapitalization % 
+     * @param unripeToken The address of the unripe token to be converted into its ripe counterpart
+     * @param amount The amount of the of the unripe token to be converted into its ripe counterpart
+     * @return underlyingToken The address of ripe asset received after the chop.
+     * @return underlyingAmount The amount of ripe asset received after the chop.
+     */
+    function chop(
+        address unripeToken,
+        uint256 amount
+    ) internal returns (address underlyingToken, uint256 underlyingAmount) {
+        // get access to Beanstalk state
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        underlyingAmount = _getPenalizedUnderlying(unripeToken, amount);
+
+        LibUnripe.decrementUnderlying(unripeToken, underlyingAmount);
+
+        underlyingToken = s.u[unripeToken].underlyingToken;
+
+    }
+
+    /**
+     * @param unripeToken The address of the unripe token 
+     * @param amount The amount of the of the unripe token
+     * @return redeem the amount of ripe underlying assets that can be redeemed from the unripe ones
+     */
+    function _getPenalizedUnderlying(address unripeToken, uint256 amount)
+        internal
+        view
+        returns (uint256 redeem)
+    {
+        require(isUnripe(unripeToken), "not vesting");
+        redeem = LibUnripe.unripeToUnderlying(unripeToken, getRecapPaidPercentAmount(amount));
+    }
+
+    /**
+     * @param unripeToken The address of the token to check
+     * @return unripe whether the token is unripe
+     */
+     function isUnripe(address unripeToken) internal view returns (bool unripe) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        unripe = s.u[unripeToken].underlyingToken != address(0);
+    }
+
+    /**
+     * @notice Calculates the penalty for chopping an unripe asset to its ripe counterpart
+     * @param amount The amount of the unripe token to chop
+     * @return penalty the penalty for chopping 
+     */
+    function getRecapPaidPercentAmount(uint256 amount)
+        internal
+        view
+        returns (uint256 penalty)
+    {
+        // get access to Beanstalk state
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        return s.fertilizedIndex.mul(amount).div(s.unfertilizedIndex);
+    }
+
+}

--- a/protocol/contracts/libraries/LibUnripe.sol
+++ b/protocol/contracts/libraries/LibUnripe.sol
@@ -11,6 +11,9 @@ import {C} from "../C.sol";
 /**
  * @title LibUnripe
  * @author Publius
+ * @notice Provides utility functions for handling unripe assets including:
+ * adding ,removing , estimating conversions
+ * and evalutating recapitalization percentages.
  */
 library LibUnripe {
     using SafeMath for uint256;
@@ -19,6 +22,10 @@ library LibUnripe {
 
     uint256 constant DECIMALS = 1e6;
 
+    /**
+     * @notice Gets the percentage of beans recapitalized after the exploit.
+     * @return percent The percentage of beans recapitalized.
+     */
     function percentBeansRecapped() internal view returns (uint256 percent) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return
@@ -27,6 +34,10 @@ library LibUnripe {
             );
     }
 
+    /**
+     * @notice Gets the percentage of LP recapitalized after the exploit.
+     * @return percent The percentage of LP recapitalized.
+     */ 
     function percentLPRecapped() internal view returns (uint256 percent) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return
@@ -35,6 +46,11 @@ library LibUnripe {
             );
     }
 
+    /**
+     * @notice Increments the balance of an underlying asset in storage.
+     * @param token The address of the unripe token.
+     * @param amount The amount of the of the unripe token to be added to the storage reserves
+     */
     function incrementUnderlying(address token, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.u[token].balanceOfUnderlying = s.u[token].balanceOfUnderlying.add(
@@ -43,6 +59,11 @@ library LibUnripe {
         emit ChangeUnderlying(token, int256(amount));
     }
 
+    /**
+     * @notice Decrements the balance of an underlying asset in storage.
+     * @param token The address of the unripe token.
+     * @param amount The amount of the of the unripe token to be removed from storage reserves
+     */
     function decrementUnderlying(address token, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.u[token].balanceOfUnderlying = s.u[token].balanceOfUnderlying.sub(
@@ -51,6 +72,12 @@ library LibUnripe {
         emit ChangeUnderlying(token, -int256(amount));
     }
 
+    /**
+     * @notice Calculates the amount of ripe assets received from converting or chopping an unripe asset.
+     * @param unripeToken The address of the unripe token.
+     * @param unripe The amount of the of the unripe token to be taken as input.
+     * @return underlying The amount of the of the ripe token to be credited from its unripe counterpart.
+     */
     function unripeToUnderlying(address unripeToken, uint256 unripe)
         internal
         view
@@ -62,6 +89,12 @@ library LibUnripe {
         );
     }
 
+    /**
+     * @notice Calculates the amount of unripe that correspond to the underlying.
+     * @param unripeToken The address of the unripe token.
+     * @param underlying The amount of the of the underlying token to be taken as input.
+     * @return unripe The amount of the of the unripe token to be credited from its ripe counterpart.
+     */
     function underlyingToUnripe(address unripeToken, uint256 underlying)
         internal
         view
@@ -73,6 +106,12 @@ library LibUnripe {
         );
     }
 
+    /**
+     * Adds the underlying amount of the unripe token to reserves and
+     * conditionally updates the recapitalization percentages
+     * @param token The address of the unripe token to be added.
+     * @param underlying The amount of the of the underlying token to be taken as input.
+     */
     function addUnderlying(address token, uint256 underlying) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         if (token == C.UNRIPE_LP) {
@@ -84,6 +123,12 @@ library LibUnripe {
         incrementUnderlying(token, underlying);
     }
 
+    /**
+     * Removes the underlying amount of the unripe token to reserves and
+     * conditionally updates the recapitalization percentages
+     * @param token The address of the unripe token to be removed.
+     * @param underlying The amount of the of the underlying token to be removed.
+     */
     function removeUnderlying(address token, uint256 underlying) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         if (token == C.UNRIPE_LP) {

--- a/protocol/test/ConvertUnripe.test.js
+++ b/protocol/test/ConvertUnripe.test.js
@@ -438,5 +438,81 @@ describe('Unripe Convert', function () {
         expect(await this.silo.totalStalk()).to.eq(toStalk('200'));
       });
     });
+
+  // Unripe to Ripe test
+  describe('convert unripe beans to beans', async function () {
+
+    beforeEach(async function () {
+      // GO TO SEASON 10
+      await this.season.teleportSunrise(10);
+      this.season.deployStemsUpgrade();
+    });
+
+    describe('basic urBEAN-->BEAN convert', function () {
+      
+      // PERFORM A DEPOSIT AND A CONVERT BEFORE EVERY TEST
+      beforeEach(async function () {
+        // user deposits 200 UrBEAN to the silo from external account
+        await this.silo.connect(user).deposit(this.unripeBean.address, to6('200'), EXTERNAL);
+        // GO FORWARD 1 SEASON AND DONT DISTRIBUTE ANY REWARDS TO SILO
+        // season 11
+        await this.season.siloSunrise(0);
+        // SET FERT PARAMS
+        await this.fertilizer.connect(owner).setPenaltyParams(to6('100'), to6('100'))
+        // INTERACTING WITH THE CONVERT FACET CONVERT(bytes calldata convertData, int96[] memory stems,uint256[] memory amounts) FUNCTION
+        this.result = await this.convert.connect(user).convert(ConvertEncoder.convertUnripeToRipe(to6('100') , this.unripeBean.address) , ['0'], [to6('100')] );
+      });
+
+      // CHECK TO SEE THAT RECAP AND PENALTY VALUES ARE UPDATED AFTER THE CONVERT
+      it('getters', async function () {
+        expect(await this.unripe.getRecapPaidPercent()).to.be.equal(to6('0.01'))
+        expect(await this.unripe.getUnderlyingPerUnripeToken(UNRIPE_BEAN)).to.be.equal('101000')
+        expect(await this.unripe.getPenalty(UNRIPE_BEAN)).to.be.equal(to6('0.00101'))
+        expect(await this.unripe.getTotalUnderlying(UNRIPE_BEAN)).to.be.equal(to6('999.90'))
+        expect(await this.unripe.isUnripe(UNRIPE_BEAN)).to.be.equal(true)
+        // same fert , less supply --> penalty goes down
+        expect(await this.unripe.getPenalizedUnderlying(UNRIPE_BEAN, to6('1'))).to.be.equal(to6('0.00101'))
+        expect(await this.unripe.getUnderlying(UNRIPE_BEAN, to6('1'))).to.be.equal(to6('0.1010'))
+      })
+
+      // TOTALS
+      it('properly updates total values', async function () {
+        // UNRIPE BEAN DEPOSIT TEST
+        expect(await this.silo.getTotalDeposited(this.unripeBean.address)).to.eq(to6('100'));
+        // RIPE BEAN CONVERTED TEST
+        expect(await this.silo.getTotalDeposited(this.bean.address)).to.eq(to6('0.1'));
+        // TOTAL STALK TEST
+        expect(await this.silo.totalStalk()).to.eq(toStalk('20.004'));
+        // VERIFY urBEANS ARE BURNED
+        expect(await this.unripeBean.totalSupply()).to.be.equal(to6('9900'))
+      });
+
+      // USER VALUES TEST
+      it('properly updates user values', async function () {
+        // USER STALK TEST
+        // 1 urBEAN yeilds 2/10000 grown stalk every season witch is claimable with mow()
+        // after every silo interaction(here --> convert).
+        // Since we go forward a season after the deposit, the user should now have 400/10000 grown stalk 
+        // not affected by the unripe --> ripe convert
+        expect(await this.silo.balanceOfStalk(userAddress)).to.eq(toStalk('20.004'));
+      });
+
+      // USER DEPOSITS TEST
+      it('properly updates user deposits', async function () {
+        expect((await this.silo.getDeposit(userAddress, this.unripeBean.address, 0))[0]).to.eq(to6('100'));
+        expect((await this.silo.getDeposit(userAddress, this.bean.address, 0))[0]).to.eq(to6('0.1'));
+      });
+
+      // EVENTS TEST
+      it('emits events', async function () {
+        await expect(this.result).to.emit(this.silo, 'RemoveDeposits')
+          .withArgs(userAddress, this.unripeBean.address, [0], [to6('100')], to6('100'), [to6('10')]);
+        await expect(this.result).to.emit(this.silo, 'AddDeposit')
+          .withArgs(userAddress, this.bean.address, 0 , to6('0.1'), to6('10'));
+        await expect(this.result).to.emit(this.convert, 'Convert')
+          .withArgs(userAddress, this.unripeBean.address, this.bean.address, to6('100') , to6('0.1'));
+      });
+    });
+  });
   });
 });

--- a/protocol/test/utils/encoder.js
+++ b/protocol/test/utils/encoder.js
@@ -7,7 +7,8 @@ const ConvertKind = {
   UNRIPE_LP_TO_BEANS: 3,
   LAMBDA_LAMBDA: 4,
   BEANS_TO_WELL_LP: 5,
-  WELL_LP_TO_BEANS: 6
+  WELL_LP_TO_BEANS: 6,
+  UNRIPE_TO_RIPE: 7
 }
 
 class ConvertEncoder {
@@ -70,6 +71,17 @@ class ConvertEncoder {
     defaultAbiCoder.encode(
     ['uint256', 'uint256', 'uint256', 'address'],
     [ConvertKind.BEANS_TO_WELL_LP, beans, minLP, address]
+  );
+
+  /**
+   * Encodes the userData parameter for performing an Unripe-->Ripe convert
+   * @param unripeAmount - the amount of unripe beans to be converted
+   * @param unripeToken - the address of the unripe asset
+   */
+  static convertUnripeToRipe = (unripeAmount, unripeToken) =>
+  defaultAbiCoder.encode(
+    ['uint256', 'uint256', 'address'],
+    [ConvertKind.UNRIPE_TO_RIPE, unripeAmount, unripeToken]
   );
 }
 


### PR DESCRIPTION
## Summary 
Introduce the ability for users to convert unripe assets into their ripe counterpart.

## Problem
Currently, the only way to redeem unripe assets is by withdrawing from the silo, and calling `chop()`. This creates an inefficiency in which users wanting to redeem early lose the opportunity cost associated with grown stalk. In light of the unripe seed rewards changing, allowing users to redeem their unripe assets without losing stalk allows farmers to weigh stalk growth vs higher redemption %. 

## Proposed Solution
- Add new convert type in `LibDataConvert` :heavy_check_mark:

- Modified `LibConvert` to include new convert type :heavy_check_mark:

- Implemented `LibChop` and modified `chop(...)` and `_getPenalizedUnderlying(...) ` to use `LibChop` :heavy_check_mark:

- Implemented `LibChopConvert`  with the `convertUnripeBeansToBeans(...)` and `getBeanAmountOut(...)` functions which wrap `LibChop` functions :heavy_check_mark:

- Added tests to challenge the new convert functionallity. :heavy_check_mark: