### PR TITLE
Subgraph - Bean and Basin USD Volume

### DIFF
--- a/projects/subgraph-basin/schema.graphql
+++ b/projects/subgraph-basin/schema.graphql
@@ -131,6 +131,12 @@ type Well @entity {
   " Total number of trades (swaps) "
   cumulativeSwapCount: Int!
 
+  " Current rolling 24 volume in USD "
+  rollingDailyVolumeUSD: BigDecimal!
+
+  " Current rolling weekly volume in USD "
+  rollingWeeklyVolumeUSD: BigDecimal!
+
   " Day ID of the most recent daily snapshot "
   lastSnapshotDayID: Int!
 

--- a/projects/subgraph-basin/src/utils/Well.ts
+++ b/projects/subgraph-basin/src/utils/Well.ts
@@ -49,6 +49,8 @@ export function createWell(wellAddress: Address, implementation: Address, inputT
   well.cumulativeDepositCount = 0;
   well.cumulativeWithdrawCount = 0;
   well.cumulativeSwapCount = 0;
+  well.rollingDailyVolumeUSD = ZERO_BD;
+  well.rollingWeeklyVolumeUSD = ZERO_BD;
   well.lastSnapshotDayID = 0;
   well.lastSnapshotHourID = 0;
   well.lastUpdateTimestamp = ZERO_BI;
@@ -286,6 +288,24 @@ export function takeWellHourlySnapshot(wellAddress: Address, hourID: i32, timest
   newSnapshot.lastUpdateTimestamp = timestamp;
   newSnapshot.lastUpdateBlockNumber = blockNumber;
   newSnapshot.save();
+
+  // Update the rolling daily and weekly volumes
+  well.rollingDailyVolumeUSD = newSnapshot.deltaVolumeUSD;
+  well.rollingWeeklyVolumeUSD = newSnapshot.deltaVolumeUSD;
+  for (let i = 1; i < 168; i++) {
+    let snapshot = WellHourlySnapshot.load(wellAddress.concatI32(hourID - i));
+    if (snapshot == null) {
+      // We hit the last snapshot to total
+      break;
+    }
+    if (i < 24) {
+      well.rollingDailyVolumeUSD = well.rollingDailyVolumeUSD.plus(snapshot.deltaVolumeUSD);
+      well.rollingWeeklyVolumeUSD = well.rollingWeeklyVolumeUSD.plus(snapshot.deltaVolumeUSD);
+    } else {
+      well.rollingWeeklyVolumeUSD = well.rollingWeeklyVolumeUSD.plus(snapshot.deltaVolumeUSD);
+    }
+  }
+  well.save();
 }
 
 export function loadOrCreateWellHourlySnapshot(

--- a/projects/subgraph-basin/src/utils/Well.ts
+++ b/projects/subgraph-basin/src/utils/Well.ts
@@ -94,6 +94,12 @@ export function updateWellVolumes(
 
   let usdVolume = toDecimal(amountIn, swapToken.decimals).times(swapToken.lastPriceUSD);
 
+  // Remove liquidity one token has no input token amount to calculate volume.
+  if (amountIn == ZERO_BI) {
+    swapToken = loadToken(toToken);
+    usdVolume = toDecimal(amountOut.div(BigInt.fromI32(2)), swapToken.decimals).times(swapToken.lastPriceUSD);
+  }
+
   // Update fromToken amounts
 
   let volumeReserves = well.cumulativeVolumeReserves;


### PR DESCRIPTION
Bugs were present in both the Bean and Basin subgraphs when adding volume amounts for removing liquidity as a single token. This updates it to correct the issue.

Bean deployment ID: QmPo8bcqdgvTks3ZzpFhHVudf2eahRhf56k6Jno76aoCPX
Basin deployment ID: QmcRJk2XJfwHScUV8YJqHnoJobsw6bCG958eNcewAEtKWZ