### PR TITLE
Subgraph - Basin: Remove single token reserves update

### DIFF
--- a/projects/subgraph-basin/src/WellHandler.ts
+++ b/projects/subgraph-basin/src/WellHandler.ts
@@ -94,8 +94,6 @@ export function handleRemoveLiquidityOneToken(event: RemoveLiquidityOneToken): v
     event.block.number
   );
 
-  updateWellTokenBalances(event.address, indexedBalances, event.block.timestamp, event.block.number);
-
   updateWellLiquidityTokenBalance(event.address, ZERO_BI.minus(event.params.lpAmountIn), event.block.timestamp, event.block.number);
 
   updateWellTokenUSDPrices(event.address, event.block.number);


### PR DESCRIPTION
Both the `updateWellVolumes` and `updateWellTokenBalances` functions update the overall reserves of the well based on amounts emitted by the events. This introduced a bug where when a `Shift` event is emitted with the new absolute reserve values the input amounts were incorrect if a `RemoveLiquidityOneToken` event was processed prior.

New deployment id: QmQYnky1aQahppvTti18QShu7PS47DTPxVH7Y8CV8TSrxA