### PR TITLE
EBIP-13

### DIFF
--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -79,6 +79,8 @@ contract ConvertFacet is ReentrancyGuard {
             convertData
         );
 
+        require(fromAmount > 0, "Convert: From amount is 0.");
+
         LibSilo._mow(msg.sender, fromToken);
         LibSilo._mow(msg.sender, toToken);
 

--- a/protocol/contracts/libraries/Convert/LibCurveConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibCurveConvert.sol
@@ -82,7 +82,6 @@ library LibCurveConvert {
     {
         (uint256 lp, uint256 minBeans, address pool) = convertData
             .convertWithAddress();
-
         (amountOut, amountIn) = curveRemoveLPTowardsPeg(lp, minBeans, pool);
         tokenOut = C.BEAN;
         tokenIn = pool;
@@ -103,7 +102,6 @@ library LibCurveConvert {
     {
         (uint256 beans, uint256 minLP, address pool) = convertData
             .convertWithAddress();
-
         (amountOut, amountIn) = curveAddLiquidityTowardsPeg(
             beans,
             minLP,

--- a/protocol/contracts/libraries/Convert/LibCurveConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibCurveConvert.sol
@@ -83,10 +83,6 @@ library LibCurveConvert {
         (uint256 lp, uint256 minBeans, address pool) = convertData
             .convertWithAddress();
 
-        // Only supports Bean:3Crv Metapool for now. Modify validation if `LibCurveConvert.sol`
-        // becomes used by another Curve pool.
-        require(pool == C.CURVE_BEAN_METAPOOL, "Convert: Invalid Metapool");
-
         (amountOut, amountIn) = curveRemoveLPTowardsPeg(lp, minBeans, pool);
         tokenOut = C.BEAN;
         tokenIn = pool;
@@ -107,10 +103,6 @@ library LibCurveConvert {
     {
         (uint256 beans, uint256 minLP, address pool) = convertData
             .convertWithAddress();
-
-        // Only supports Bean:3Crv Metapool for now. Modify validation if `LibCurveConvert.sol`
-        // becomes used by another Curve pool.
-        require(pool == C.CURVE_BEAN_METAPOOL, "Convert: Invalid Metapool");
 
         (amountOut, amountIn) = curveAddLiquidityTowardsPeg(
             beans,

--- a/protocol/contracts/libraries/Convert/LibCurveConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibCurveConvert.sol
@@ -82,6 +82,11 @@ library LibCurveConvert {
     {
         (uint256 lp, uint256 minBeans, address pool) = convertData
             .convertWithAddress();
+
+        // Only supports Bean:3Crv Metapool for now. Modify validation if `LibCurveConvert.sol`
+        // becomes used by another Curve pool.
+        require(pool == C.CURVE_BEAN_METAPOOL, "Convert: Invalid Metapool");
+
         (amountOut, amountIn) = curveRemoveLPTowardsPeg(lp, minBeans, pool);
         tokenOut = C.BEAN;
         tokenIn = pool;
@@ -102,6 +107,11 @@ library LibCurveConvert {
     {
         (uint256 beans, uint256 minLP, address pool) = convertData
             .convertWithAddress();
+
+        // Only supports Bean:3Crv Metapool for now. Modify validation if `LibCurveConvert.sol`
+        // becomes used by another Curve pool.
+        require(pool == C.CURVE_BEAN_METAPOOL, "Convert: Invalid Metapool");
+
         (amountOut, amountIn) = curveAddLiquidityTowardsPeg(
             beans,
             minLP,

--- a/protocol/contracts/libraries/Convert/LibWellConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibWellConvert.sol
@@ -127,6 +127,8 @@ library LibWellConvert {
     {
         (uint256 lp, uint256 minBeans, address well) = convertData.convertWithAddress();
 
+        require(LibWell.isWell(well), "Convert: Invalid Well");
+
         tokenOut = C.BEAN;
         tokenIn = well;
 
@@ -173,6 +175,8 @@ library LibWellConvert {
     {
         (uint256 beans, uint256 minLP, address well) = convertData
             .convertWithAddress();
+
+        require(LibWell.isWell(well), "Convert: Invalid Well");
     
         tokenOut = well;
         tokenIn = C.BEAN;

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -37,7 +37,7 @@ const { to6 } = require("./test/utils/helpers.js");
 const { task } = require("hardhat/config");
 const { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } = require("hardhat/builtin-tasks/task-names");
 const { bipNewSilo, mockBeanstalkAdmin } = require("./scripts/bips.js");
-const { ebip9, ebip10, ebip11 } = require("./scripts/ebips.js");
+const { ebip9, ebip10, ebip11, ebip12 } = require("./scripts/ebips.js");
 
 //////////////////////// UTILITIES ////////////////////////
 
@@ -221,6 +221,10 @@ task("migrate-bip38", async function () {
   await bipMigrateUnripeBean3CrvToBeanEth();
   await finishBeanEthMigration();
 });
+
+task("ebip12", async function () {
+  await ebip12();
+})
 
 task("ebip11", async function () {
   await ebip11();

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -37,7 +37,7 @@ const { to6 } = require("./test/utils/helpers.js");
 const { task } = require("hardhat/config");
 const { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } = require("hardhat/builtin-tasks/task-names");
 const { bipNewSilo, mockBeanstalkAdmin } = require("./scripts/bips.js");
-const { ebip9, ebip10, ebip11, ebip12 } = require("./scripts/ebips.js");
+const { ebip9, ebip10, ebip11, ebip13 } = require("./scripts/ebips.js");
 
 //////////////////////// UTILITIES ////////////////////////
 
@@ -222,8 +222,8 @@ task("migrate-bip38", async function () {
   await finishBeanEthMigration();
 });
 
-task("ebip12", async function () {
-  await ebip12();
+task("ebip13", async function () {
+  await ebip13();
 })
 
 task("ebip11", async function () {

--- a/protocol/scripts/deploy.js
+++ b/protocol/scripts/deploy.js
@@ -4,7 +4,7 @@ const diamond = require('./diamond.js')
 const { 
   impersonateBean, 
   impersonateCurve,
-  impersonateCurveMetapool, 
+  impersonateBean3CrvMetapool, 
   impersonateWeth, 
   impersonateUnripe, 
   impersonateFertilizer,
@@ -14,6 +14,7 @@ const {
   impersonateEthUsdtUniswap,
   impersonateEthUsdChainlinkAggregator
 } = require('./impersonate.js')
+
 function addCommas(nStr) {
   nStr += ''
   const x = nStr.split('.')
@@ -191,7 +192,7 @@ async function main(scriptName, verbose = true, mock = false, reset = true) {
       await impersonateEthUsdcUniswap()
       await impersonateEthUsdtUniswap()
     }
-    await impersonateCurveMetapool()
+    await impersonateBean3CrvMetapool()
     await impersonateUnripe()
     await impersonateFertilizer()
     await impersonateBlockBasefee();

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -108,7 +108,7 @@ async function ebip11(mock = true, account = undefined) {
   });
 }
 
-async function ebip12(mock = true, account = undefined) {
+async function ebip13(mock = true, account = undefined) {
   if (account == undefined) {
     account = await impersonateBeanstalkOwner();
     await mintEth(account.address);
@@ -147,4 +147,4 @@ exports.ebip8 = ebip8;
 exports.ebip9 = ebip9;
 exports.ebip10 = ebip10;
 exports.ebip11 = ebip11;
-exports.ebip12 = ebip12;
+exports.ebip13 = ebip13;

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -108,6 +108,22 @@ async function ebip11(mock = true, account = undefined) {
   });
 }
 
+async function ebip12(mock = true, account = undefined) {
+  if (account == undefined) {
+    account = await impersonateBeanstalkOwner();
+    await mintEth(account.address);
+  }
+
+  await upgradeWithNewFacets({
+    diamondAddress: BEANSTALK,
+    facetNames: ["ConvertFacet"],
+    bip: false,
+    object: !mock,
+    verbose: true,
+    account: account
+  });
+}
+
 async function bipDiamondCut(name, dc, account, mock = true) {
   beanstalk = await getBeanstalk();
   if (mock) {
@@ -130,4 +146,5 @@ exports.ebip7 = ebip7;
 exports.ebip8 = ebip8;
 exports.ebip9 = ebip9;
 exports.ebip10 = ebip10;
-exports.ebip11 = ebip11
+exports.ebip11 = ebip11;
+exports.ebip12 = ebip12;

--- a/protocol/scripts/impersonate.js
+++ b/protocol/scripts/impersonate.js
@@ -71,21 +71,24 @@ async function curve() {
 
 }
 
-async function curveMetapool() {
+async function curveMetapool(address, name) {
 
     // Deploy Bean Metapool
     let meta3CurveJson = fs.readFileSync(`./artifacts/contracts/mocks/curve/MockMeta3Curve.sol/MockMeta3Curve.json`);
     await network.provider.send("hardhat_setCode", [
-      BEAN_3_CURVE,
+      address,
       JSON.parse(meta3CurveJson).deployedBytecode,
     ]);
-    // const beanMetapool = await ethers.getContractAt('MockMeta3Curve', BEAN_3_CURVE);
 
-    const beanMetapool = await ethers.getContractAt('MockMeta3Curve', BEAN_3_CURVE);
+    const beanMetapool = await ethers.getContractAt('MockMeta3Curve', address);
     await beanMetapool.init(BEAN, THREE_CURVE, THREE_POOL);
     await beanMetapool.set_A_precise('1000');
     await beanMetapool.set_virtual_price(ethers.utils.parseEther('1'));
-    await beanMetapool.setSymbol("BEAN3CRV-f");
+    await beanMetapool.setSymbol(`${name}-f`);
+}
+
+async function bean3CrvMetapool() {
+  await curveMetapool(BEAN_3_CURVE, 'BEAN3CRV');
 }
 
 async function weth() {
@@ -295,7 +298,8 @@ async function ethUsdChainlinkAggregator() {
 exports.impersonateRouter = router
 exports.impersonateBean = bean
 exports.impersonateCurve = curve
-exports.impersonateCurveMetapool = curveMetapool 
+exports.impersonateCurveMetapool = curveMetapool
+exports.impersonateBean3CrvMetapool = bean3CrvMetapool
 exports.impersonateCurveLUSD = curveLUSD
 exports.impersonatePool = pool
 exports.impersonateWeth = weth

--- a/protocol/test/ConvertCurve.test.js
+++ b/protocol/test/ConvertCurve.test.js
@@ -109,8 +109,7 @@ describe('Curve Convert', function () {
       });
 
       it('Not whitelisted pool', async function () {
-        // await setReserves(owner, this.fakeWell, [to6('800000'), to18('1000')]);
-        const convertData = ConvertEncoder.convertBeansToCurveLP(toBean('200'), to18('190'), this.bean.address)
+        const convertData = ConvertEncoder.convertBeansToCurveLP(toBean('200'), to18('190'), this.fakeMetapool.address)
         await expect(this.convert.connect(owner).convert(
           convertData,
           [],
@@ -426,7 +425,7 @@ describe('Curve Convert', function () {
       });
 
       it('Not whitelisted pool', async function () {
-        const convertData = ConvertEncoder.convertCurveLPToBeans(to18('100'), toBean('99'), this.bean.address)
+        const convertData = ConvertEncoder.convertCurveLPToBeans(to18('100'), toBean('99'), this.fakeMetapool.address)
         await expect(this.convert.connect(owner).convert(
           convertData,
           [],

--- a/protocol/test/ConvertCurve.test.js
+++ b/protocol/test/ConvertCurve.test.js
@@ -5,12 +5,13 @@ const { BEAN, THREE_CURVE, THREE_POOL, BEAN_3_CURVE } = require('./utils/constan
 const { ConvertEncoder } = require('./utils/encoder.js')
 const { to18, toBean, toStalk, to6 } = require('./utils/helpers.js')
 const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot");
+const { impersonateCurveMetapool } = require('../scripts/impersonate.js');
 let user, user2, owner;
 let userAddress, ownerAddress, user2Address;
 
 describe('Curve Convert', function () {
   before(async function () {
-    [owner, user, user2] = await ethers.getSigners();
+    [owner, user, user2, fakeMetapoolAccount] = await ethers.getSigners();
     userAddress = user.address;
     user2Address = user2.address;
     const contracts = await deploy("Test", false, true);
@@ -25,6 +26,9 @@ describe('Curve Convert', function () {
     this.threePool = await ethers.getContractAt('Mock3Curve', THREE_POOL);
     this.threeCurve = await ethers.getContractAt('MockToken', THREE_CURVE);
     this.beanMetapool = await ethers.getContractAt('IMockCurvePool', BEAN_3_CURVE);
+
+    await impersonateCurveMetapool(fakeMetapoolAccount.address, 'FAKE');
+    this.fakeMetapool = await ethers.getContractAt('IMockCurvePool', fakeMetapoolAccount.address);
 
     await this.threeCurve.mint(userAddress, to18('100000'));
     await this.threePool.set_virtual_price(to18('1'));
@@ -103,6 +107,17 @@ describe('Curve Convert', function () {
         await expect(this.convert.connect(user).convert(ConvertEncoder.convertBeansToCurveLP(toBean('200'), to18('190'), this.beanMetapool.address), ['1'], ['1000']))
           .to.be.revertedWith('Convert: P must be >= 1.');
       });
+
+      it('Not whitelisted pool', async function () {
+        // await setReserves(owner, this.fakeWell, [to6('800000'), to18('1000')]);
+        const convertData = ConvertEncoder.convertBeansToCurveLP(toBean('200'), to18('190'), this.bean.address)
+        await expect(this.convert.connect(owner).convert(
+          convertData,
+          [],
+          []
+        )).to.be.revertedWith("Convert: Invalid Metapool")
+      })
+
 
     });
 
@@ -409,6 +424,15 @@ describe('Curve Convert', function () {
         await expect(this.convert.connect(user).convert(ConvertEncoder.convertCurveLPToBeans(to18('200'), toBean('190'), this.beanMetapool.address), [stemMetapool], ['1000']))
           .to.be.revertedWith('Convert: P must be < 1.');
       });
+
+      it('Not whitelisted pool', async function () {
+        const convertData = ConvertEncoder.convertCurveLPToBeans(to18('100'), toBean('99'), this.bean.address)
+        await expect(this.convert.connect(owner).convert(
+          convertData,
+          [],
+          []
+        )).to.be.revertedWith("Convert: Invalid Metapool")
+      })
     });
 
     describe('below max', function () {

--- a/protocol/test/ConvertCurve.test.js
+++ b/protocol/test/ConvertCurve.test.js
@@ -114,7 +114,7 @@ describe('Curve Convert', function () {
           convertData,
           [],
           []
-        )).to.be.revertedWith("Convert: Invalid Metapool")
+        )).to.be.revertedWith("Convert: Not a whitelisted Curve pool.")
       })
 
 
@@ -430,7 +430,7 @@ describe('Curve Convert', function () {
           convertData,
           [],
           []
-        )).to.be.revertedWith("Convert: Invalid Metapool")
+        )).to.be.revertedWith("Convert: Not a whitelisted Curve pool.")
       })
     });
 


### PR DESCRIPTION
# EBIP-13: Re-Add Convert

## Submitter

Beanstalk Community Multisig

## Summary

Re-add the `convert` function with a new implementation that fixes the bug from [EBIP-12](https://arweave.net/AFsSqT2HE67IHqtxafvbluoZApdyofiHmvwGmzjTUPU).

## Links

Per the process outlined in the [BCM Emergency Response Procedures](https://docs.bean.money/almanac/governance/beanstalk/bcm-process#emergency-response-procedures), the BCM can take swift action to protect Beanstalk in the event of a bug or security vulnerability.

In the case of EBIP-13, functionality that was removed in EBIP-12 is reintroduced this EBIP.

- [EBIP-13 GitHub PR](https://github.com/BeanstalkFarms/Beanstalk/pull/682)
- GitHub Commit Hash: [77996e48e1979c493c94103c7b6f4876fa80e4dc](https://github.com/BeanstalkFarms/Beanstalk/tree/77996e48e1979c493c94103c7b6f4876fa80e4dc)
- [Safe Transaction](https://app.safe.global/transactions/tx?safe=eth:0xa9bA2C40b263843C04d344727b954A545c81D043&id=multisig_0xa9bA2C40b263843C04d344727b954A545c81D043_0xe8976073276b90cd7c5f1d5b7e4cef208fc3bdd2efee929d928d3d39a442eb9e)
- [Etherscan Transaction (LINK TBD)](TBD)

## Problem

The `convert` function was removed in EBIP-12.

## Solution

Add `require` statements in `LibWellConvert` that verify that the Well being Converted in is whitelisted.

Add a `require` statement in `ConvertFacet` that verifies that the token amount being Converted from is greater than 0.

Re-add the `convert` function to Beanstalk.

All changes were reviewed by Cyfrin.

## Contract Changes

### Convert Facet

The following `ConvertFacet` is added to Beanstalk:
* [`0x7d19277B836D4787dC338251fbEd2e5841cF8c02`](https://etherscan.io/address/0x7d19277B836D4787dC338251fbEd2e5841cF8c02#code)

#### `ConvertFacet` Function Changes

| Name                         | Selector     | Action  | Type | New Functionality |
|:-----------------------------|:-------------|:--------|:-----|:------------------|
| `convert`                    | `0xb362a6e8` | Add     | Call | ✓                 |

### Event Changes

None.

## Beans Minted

None.

## Effective

Effective immediately upon commitment by the BCM, which has already happened.
