### PR TITLE
Include v1 BEAN3CRV and BEANLUSD in liquidity to supply calc

### DIFF
--- a/projects/ui/src/components/Analytics/Bean/LiquiditySupplyRatio.tsx
+++ b/projects/ui/src/components/Analytics/Bean/LiquiditySupplyRatio.tsx
@@ -17,7 +17,7 @@ const formatValue = (value: number) =>
 const statProps = {
   title: 'Liquidity to Supply Ratio',
   titleTooltip:
-    `The ratio of Beans in liquidity pools on the Oracle Whitelist per Bean, displayed as a percentage, at the beginning of every Season. The Liquidity to Supply Ratio is a useful indicator of Beanstalk's health.`,
+    `The ratio of Beans in liquidity pools on the Oracle Whitelist per Bean, displayed as a percentage, at the beginning of every Season. The Liquidity to Supply Ratio is a useful indicator of Beanstalk's health. Pre-exploit values include liquidity in pools on the Deposit Whitelist.`,
   gap: 0.25,
 };
 const queryConfig = {


### PR DESCRIPTION
Include all of the Beans held within the pools to the liquidity to supply ratio prior to replant.