### PR TITLE
Basin UI (3) - Yield info + misc fixes

### DIFF
--- a/projects/dex-ui/codegen.ts
+++ b/projects/dex-ui/codegen.ts
@@ -2,7 +2,11 @@ import { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
   overwrite: true,
-  schema: "graphql.schema.json",
+  schema: [
+    "graphql.schema.json",
+    // beanstalk subgraph
+    "https://graph.node.bean.money/subgraphs/name/beanstalk"
+  ],
   documents: "src/**/*.graphql",
   ignoreNoDocuments: true,
   generates: {

--- a/projects/dex-ui/src/abi/MULTI_PUMP_ABI.json
+++ b/projects/dex-ui/src/abi/MULTI_PUMP_ABI.json
@@ -1,0 +1,115 @@
+[
+  {
+    "inputs": [
+      { "internalType": "bytes16", "name": "_maxPercentIncrease", "type": "bytes16" },
+      { "internalType": "bytes16", "name": "_maxPercentDecrease", "type": "bytes16" },
+      { "internalType": "uint256", "name": "_capInterval", "type": "uint256" },
+      { "internalType": "bytes16", "name": "_alpha", "type": "bytes16" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "NoTimePassed", "type": "error" },
+  { "inputs": [], "name": "NotInitialized", "type": "error" },
+  {
+    "inputs": [],
+    "name": "ALPHA",
+    "outputs": [{ "internalType": "bytes16", "name": "", "type": "bytes16" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CAP_INTERVAL",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LOG_MAX_DECREASE",
+    "outputs": [{ "internalType": "bytes16", "name": "", "type": "bytes16" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LOG_MAX_INCREASE",
+    "outputs": [{ "internalType": "bytes16", "name": "", "type": "bytes16" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "well", "type": "address" }],
+    "name": "readCappedReserves",
+    "outputs": [{ "internalType": "uint256[]", "name": "cappedReserves", "type": "uint256[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "well", "type": "address" },
+      { "internalType": "bytes", "name": "", "type": "bytes" }
+    ],
+    "name": "readCumulativeReserves",
+    "outputs": [{ "internalType": "bytes", "name": "cumulativeReserves", "type": "bytes" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "well", "type": "address" },
+      { "internalType": "bytes", "name": "", "type": "bytes" }
+    ],
+    "name": "readInstantaneousReserves",
+    "outputs": [{ "internalType": "uint256[]", "name": "emaReserves", "type": "uint256[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "well", "type": "address" }],
+    "name": "readLastCappedReserves",
+    "outputs": [{ "internalType": "uint256[]", "name": "lastCappedReserves", "type": "uint256[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "well", "type": "address" }],
+    "name": "readLastCumulativeReserves",
+    "outputs": [{ "internalType": "bytes16[]", "name": "cumulativeReserves", "type": "bytes16[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "well", "type": "address" }],
+    "name": "readLastInstantaneousReserves",
+    "outputs": [{ "internalType": "uint256[]", "name": "emaReserves", "type": "uint256[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "well", "type": "address" },
+      { "internalType": "bytes", "name": "startCumulativeReserves", "type": "bytes" },
+      { "internalType": "uint256", "name": "startTimestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "", "type": "bytes" }
+    ],
+    "name": "readTwaReserves",
+    "outputs": [
+      { "internalType": "uint256[]", "name": "twaReserves", "type": "uint256[]" },
+      { "internalType": "bytes", "name": "cumulativeReserves", "type": "bytes" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256[]", "name": "reserves", "type": "uint256[]" },
+      { "internalType": "bytes", "name": "", "type": "bytes" }
+    ],
+    "name": "update",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/projects/dex-ui/src/assets/images/start-sparkle.svg
+++ b/projects/dex-ui/src/assets/images/start-sparkle.svg
@@ -1,0 +1,13 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.44471 12.9348L9.57729 13.7451C11.1801 14.3542 12.4458 15.6198 13.0548 17.2226L13.8651 19.3552C14.0126 19.7434 14.3847 20 14.7999 20C15.2152 20 15.5872 19.7434 15.7347 19.3552L16.5451 17.2226C17.1541 15.6198 18.4198 14.3542 20.0226 13.7451L22.1551 12.9348C22.5433 12.7873 22.7999 12.4153 22.7999 12C22.7999 11.5848 22.5433 11.2127 22.1551 11.0652L20.0226 10.2549C18.4198 9.64584 17.1541 8.38017 16.5451 6.77737L15.7347 4.6448C15.5872 4.25664 15.2152 4.00002 14.7999 4.00002C14.3847 4.00002 14.0126 4.25664 13.8651 4.6448L13.0548 6.77737C12.4458 8.38017 11.1801 9.64584 9.57729 10.2549L7.44471 11.0652C7.05655 11.2127 6.79993 11.5848 6.79993 12C6.79993 12.4153 7.05655 12.7873 7.44471 12.9348Z" fill="url(#paint0_linear_4344_42164)" stroke="#46B955" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.79993 21V17" stroke="#46B955" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.79993 19H8.79993" stroke="#46B955" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.79993 7V3" stroke="#46B955" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.79993 5H7.79993" stroke="#46B955" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<linearGradient id="paint0_linear_4344_42164" x1="22.359" y1="6.00002" x2="2.96715" y2="8.81389" gradientUnits="userSpaceOnUse">
+<stop stop-color="#46B955"/>
+<stop offset="1" stop-color="#46B955" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/projects/dex-ui/src/breakpoints.ts
+++ b/projects/dex-ui/src/breakpoints.ts
@@ -9,30 +9,32 @@ const mediaSizes = {
   desktop: 1200
 };
 
-/// we add 1px to the mobile and tablet sizes so that the media queries don't overlap
+const BP_GAP = 0.05;
+
+/// we subtract 0.05px to some queries to prevent overlapping
 export const mediaQuery = {
   sm: {
     // 769px & above
     up: `@media (min-width: ${mediaSizes.mobile}px)`,
-    // 768px & below
-    only: `@media (max-width: ${mediaSizes.mobile - 1}px)`
+    // 768.95px & below
+    only: `@media (max-width: ${mediaSizes.mobile - BP_GAP}px)`
   },
   md: {
     // 1024px & above
     up: `@media (min-width: ${mediaSizes.tablet}px)`,
-    // between 769px & 1024px
-    only: `@media (min-width: ${mediaSizes.mobile}px) and (max-width: ${mediaSizes.tablet - 1}px)`,
+    // between 769px & 1023.95px
+    only: `@media (min-width: ${mediaSizes.mobile}px) and (max-width: ${mediaSizes.tablet - BP_GAP}px)`,
     // 1024px & below
-    down: `@media (max-width: ${mediaSizes.tablet}px)`
+    down: `@media (max-width: ${mediaSizes.tablet - BP_GAP}px)`
   },
   lg: {
     // 1200px & below
-    down: `@media (max-width: ${mediaSizes.desktop}px)`,
+    down: `@media (max-width: ${mediaSizes.desktop - BP_GAP}px)`,
     // 1200px & above
     only: `@media (min-width: ${mediaSizes.desktop}px)`
   },
   between: {
-    // between 769px & 1200px
-    smAndLg: `@media (min-width: ${mediaSizes.mobile}px) and (max-width: ${mediaSizes.desktop - 1}px)`
+    // between 769px & 1199.95px
+    smAndLg: `@media (min-width: ${mediaSizes.mobile}px) and (max-width: ${mediaSizes.desktop - BP_GAP}px)`
   }
 };

--- a/projects/dex-ui/src/components/Frame/ContractInfoMarquee.tsx
+++ b/projects/dex-ui/src/components/Frame/ContractInfoMarquee.tsx
@@ -7,8 +7,8 @@ type ContractMarqueeInfo = Record<string, { display: string; to?: string; url?: 
 const CarouselData: ContractMarqueeInfo = {
   ADDRESS: [
     {
-      display: "0x1584B668643617D18321a0BEc6EF3786F4b8Eb7B",
-      url: "https://etherscan.io/address/0x1584B668643617D18321a0BEc6EF3786F4b8Eb7B"
+      display: "0xBA51AAAA95aeEFc1292515b36D86C51dC7877773",
+      url: "https://etherscan.io/address/0xBA51AAAA95aeEFc1292515b36D86C51dC7877773"
     }
   ],
   AUDIT: [
@@ -19,10 +19,10 @@ const CarouselData: ContractMarqueeInfo = {
   V1: [{ display: "WHITEPAPER", url: "/basin.pdf" }]
 };
 
-const speedPerItem = 16; // approx same speed as TokenMarquee
+const speedPerItem = 16; // approx same speed as TokenMarque
 const itemGap = 24;
 const numItems = 4;
-const singleItemWidth = 1107.44;
+const singleItemWidth = 1112.06;
 
 export const ContractInfoMarquee = () => {
   const data = Object.entries(CarouselData);

--- a/projects/dex-ui/src/components/Frame/ContractInfoMarquee.tsx
+++ b/projects/dex-ui/src/components/Frame/ContractInfoMarquee.tsx
@@ -8,7 +8,7 @@ const CarouselData: ContractMarqueeInfo = {
   ADDRESS: [
     {
       display: "0x1584B668643617D18321a0BEc6EF3786F4b8Eb7B",
-      url: "https://etherscan.io/address/0xBA51AAAA95aeEFc1292515b36D86C51dC7877773"
+      url: "https://etherscan.io/address/0x1584B668643617D18321a0BEc6EF3786F4b8Eb7B"
     }
   ],
   AUDIT: [

--- a/projects/dex-ui/src/components/Liquidity/RemoveLiquidity.tsx
+++ b/projects/dex-ui/src/components/Liquidity/RemoveLiquidity.tsx
@@ -49,7 +49,7 @@ const RemoveLiquidityContent = ({ well, slippage, slippageSettingsClickHandler, 
   const { reserves: wellReserves, refetch: refetchWellReserves } = useWellReserves(well);
   const sdk = useSdk();
 
-  const lpBalance = getPositionWithWell(well)?.external;
+  const lpBalance = useMemo(() => getPositionWithWell(well)?.external, [getPositionWithWell, well]);
 
   useEffect(() => {
     const run = async () => {

--- a/projects/dex-ui/src/components/Swap/BasicInput.tsx
+++ b/projects/dex-ui/src/components/Swap/BasicInput.tsx
@@ -13,6 +13,7 @@ type Props = {
   onFocus?: FocusEventHandler<HTMLInputElement>;
   onBlur?: FocusEventHandler<HTMLInputElement>;
   canChangeValue?: boolean;
+  max?: TokenValue;
 };
 
 export const BasicInput: FC<Props> = ({
@@ -24,7 +25,8 @@ export const BasicInput: FC<Props> = ({
   onFocus,
   onBlur,
   inputRef,
-  canChangeValue = true
+  canChangeValue = true,
+  max
 }) => {
   const [id, _] = useState(_id ?? Math.random().toString(36).substring(2, 7));
   const [displayValue, setDisplayValue] = useState(value);
@@ -42,6 +44,15 @@ export const BasicInput: FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
+  const maxNum = max && parseFloat(max.toHuman());
+  const clamp = useCallback(
+    (amount: string) => {
+      if (amount === "" || amount === ".") return amount;
+      return maxNum !== undefined ? Math.min(parseFloat(amount), maxNum).toString() : amount;
+    },
+    [maxNum]
+  );
+
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       let rawValue = e.target.value;
@@ -55,10 +66,10 @@ export const BasicInput: FC<Props> = ({
         rawValue = `0${rawValue}`;
       }
 
-      setDisplayValue(rawValue);
-      onChange?.(cleanValue);
+      setDisplayValue(clamp(rawValue));
+      onChange?.(clamp(cleanValue));
     },
-    [onChange]
+    [onChange, clamp]
   );
 
   const filterKeyDown = useCallback(

--- a/projects/dex-ui/src/components/Swap/TokenInput.tsx
+++ b/projects/dex-ui/src/components/Swap/TokenInput.tsx
@@ -29,6 +29,7 @@ type TokenInput = {
   onTokenChange?: (t: Token) => void;
   canChangeValue?: boolean;
   debounceTime?: number;
+  clamp?: boolean;
 };
 
 export const TokenInput: FC<TokenInput> = ({
@@ -44,12 +45,15 @@ export const TokenInput: FC<TokenInput> = ({
   loading = false,
   allowNegative = false,
   canChangeValue = true,
-  debounceTime = 500
+  debounceTime = 500,
+  clamp = false
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { data: balance, isLoading: isBalanceLoading } = useTokenBalance(token);
   width = width ?? "100%";
+
+  // console.log("balance: ", balance?.[token.symbol].toHuman());
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const updateAmount = useCallback(
@@ -97,6 +101,7 @@ export const TokenInput: FC<TokenInput> = ({
           inputRef={inputRef}
           allowNegative={allowNegative}
           canChangeValue={!!canChangeValue}
+          max={clamp ? balance?.[token.symbol] : undefined}
         />
         <TokenPicker token={token} editable={canChangeToken} onChange={handleTokenChange} connectorFor={id} />
       </TopRow>

--- a/projects/dex-ui/src/components/Swap/TokenInput.tsx
+++ b/projects/dex-ui/src/components/Swap/TokenInput.tsx
@@ -53,8 +53,6 @@ export const TokenInput: FC<TokenInput> = ({
   const { data: balance, isLoading: isBalanceLoading } = useTokenBalance(token);
   width = width ?? "100%";
 
-  // console.log("balance: ", balance?.[token.symbol].toHuman());
-
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const updateAmount = useCallback(
     debounce((value: string) => {

--- a/projects/dex-ui/src/components/Tooltip.tsx
+++ b/projects/dex-ui/src/components/Tooltip.tsx
@@ -11,26 +11,36 @@ type Props = {
   arrowOffset: number;
   side: string;
   width?: number;
+  bgColor?: "black" | "white";
 };
 
-export const Tooltip: FC<Props> = ({ children, content, offsetX, offsetY, arrowSize, arrowOffset, side, width }) => {
+export const Tooltip: FC<Props> = ({ children, content, offsetX, offsetY, arrowSize, arrowOffset, side, width, bgColor = "black" }) => {
   return (
     <TooltipContainer>
       {children}
-      <TooltipBox offsetX={offsetX} offsetY={offsetY} arrowSize={arrowSize} arrowOffset={arrowOffset} width={width} side={side}>
+      <TooltipBox
+        offsetX={offsetX}
+        offsetY={offsetY}
+        arrowSize={arrowSize}
+        arrowOffset={arrowOffset}
+        width={width}
+        side={side}
+        bgColor={bgColor}
+      >
         {content}
       </TooltipBox>
     </TooltipContainer>
   );
 };
 
-type TooltipProps = {
+export type TooltipProps = {
   offsetX: number;
   offsetY: number;
   arrowSize: number;
   arrowOffset: number;
   side: string;
   width?: number;
+  bgColor?: "black" | "white";
 };
 
 const TooltipContainer = styled.div`
@@ -40,11 +50,12 @@ const TooltipContainer = styled.div`
 const TooltipBox = styled.div<TooltipProps>`
   padding: 8px;
   border-radius: 2px;
-  background: #000;
-  color: #fff;
+  background: ${(props) => (props.bgColor === "white" ? "#FFF" : "#000")};
+  color: ${(props) => (props.bgColor === "white" ? "#000" : "#FFF")};
   position: absolute;
   transform: translateX(${(props) => props.offsetX}%);
   width: ${(props) => (props.width ? props.width : 200)}px;
+  border: ${(props) => (props.bgColor === "white" ? "1px solid #000" : "none")};
   line-height: 18px;
   font-size: 14px;
   visibility: hidden;

--- a/projects/dex-ui/src/components/Well/Chart/Chart.tsx
+++ b/projects/dex-ui/src/components/Well/Chart/Chart.tsx
@@ -1,13 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { FC } from "src/types";
 import { ChartContainer } from "./ChartStyles";
 import { createChart } from "lightweight-charts";
 import { useRef } from "react";
 import styled from "styled-components";
+import { IChartDataItem } from "./ChartSection";
 
 type Props = {
   legend: string;
-  data: any;
+  data: IChartDataItem[];
 };
 
 function formatToUSD(value: any) {
@@ -15,13 +16,20 @@ function formatToUSD(value: any) {
   return formattedValue;
 }
 
-export const Chart: FC<Props> = ({ legend, data }) => {
+export const Chart: FC<Props> = ({ legend, data: _data }) => {
   const chartContainerRef = useRef<any>();
   const chart = useRef<any>();
   const lineSeries = useRef<any>();
   const [lastDataPoint, setLastDataPoint] = useState<any>();
   const [dataPoint, setDataPoint] = useState<any>();
   const [dataPointValue, setDataPointValue] = useState<any>();
+
+  const data = useMemo(() => {
+    return _data.map(({ time, value }) => ({
+      time,
+      value: parseFloat(value)
+    }));
+  }, [_data]);
 
   useEffect(() => {
     if (!chartContainerRef.current) return;

--- a/projects/dex-ui/src/components/Well/LearnPump.tsx
+++ b/projects/dex-ui/src/components/Well/LearnPump.tsx
@@ -10,7 +10,7 @@ function PumpDetails() {
     <TextContainer>
       <div>
         Pumps are the oracle framework of Basin. Well deployers can define the conditions under which the Well 
-        should write new reserve data to the Pump, which can be used as a price feed.
+        should write new reserve data to the Pump, which can be used as a data feed.
       </div>
       <div>
         The <StyledLink href="https://basin.exchange/multi-flow-pump.pdf" target="_blank" rel="noopener">Multi Flow Pump</StyledLink> is 
@@ -27,7 +27,7 @@ export const LearnPump: FC<Props> = () => {
         <span role="img" aria-label="glass globe emoji">
           🔮
         </span>{" "}
-        What’s a pump?
+        What is a Pump?
       </ExpandBox.Header>
       <ExpandBox.Body>
         <PumpDetails />

--- a/projects/dex-ui/src/components/Well/LearnYield.tsx
+++ b/projects/dex-ui/src/components/Well/LearnYield.tsx
@@ -18,7 +18,7 @@ function YieldDetails() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          Beanstalk UI
+          Beanstalk UI.
         </StyledLink>
       </div>
     </TextContainer>

--- a/projects/dex-ui/src/components/Well/LiquidityBox.tsx
+++ b/projects/dex-ui/src/components/Well/LiquidityBox.tsx
@@ -17,6 +17,7 @@ import { useBeanstalkSiloWhitelist } from "src/wells/useBeanstalkSiloWhitelist";
 import { LoadingItem } from "src/components/LoadingItem";
 import { Well } from "@beanstalk/sdk/Wells";
 import { Info } from "../Icons";
+import { useIsMobile } from "src/utils/ui/useIsMobile";
 
 type Props = {
   well: Well | undefined;
@@ -36,6 +37,8 @@ const displayTV = (value?: TokenValue) => (value?.gt(0) ? value.toHuman("short")
 
 export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
   const well = useMemo(() => _well, [_well]);
+
+  const isMobile = useIsMobile();
 
   const { getPositionWithWell } = useLPPositionSummary();
   const { getIsWhitelisted } = useBeanstalkSiloWhitelist();
@@ -94,8 +97,8 @@ export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
                         &nbsp;for yield.
                       </div>
                     }
-                    offsetX={0}
-                    offsetY={0}
+                    offsetX={isMobile ? -40 : -1}
+                    offsetY={350}
                     side="bottom"
                     arrowSize={4}
                     arrowOffset={50}
@@ -121,9 +124,9 @@ export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
                         Farm Balances can help reduce gas costs and efficient movement of assets within Beanstalk.
                       </div>
                     }
-                    offsetX={0}
-                    offsetY={0}
-                    arrowOffset={50}
+                    offsetX={isMobile ? -40 : -1}
+                    offsetY={630}
+                    arrowOffset={0}
                     side="bottom"
                     arrowSize={4}
                     width={270}

--- a/projects/dex-ui/src/components/Well/LiquidityBox.tsx
+++ b/projects/dex-ui/src/components/Well/LiquidityBox.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { TokenValue } from "@beanstalk/sdk";
 
 import { mediaQuery } from "src/breakpoints";
-import { BodyCaps, BodyS, LinksButtonText, TextNudge } from "src/components/Typography";
+import { BodyCaps, BodyS, BodyXS, LinksButtonText, TextNudge } from "src/components/Typography";
 import { InfoBox } from "src/components/InfoBox";
 import { TokenLogo } from "src/components/TokenLogo";
 import { Tooltip } from "src/components/Tooltip";
@@ -16,6 +16,7 @@ import { useLPPositionSummary } from "src/tokens/useLPPositionSummary";
 import { useBeanstalkSiloWhitelist } from "src/wells/useBeanstalkSiloWhitelist";
 import { LoadingItem } from "src/components/LoadingItem";
 import { Well } from "@beanstalk/sdk/Wells";
+import { Info } from "../Icons";
 
 type Props = {
   well: Well | undefined;
@@ -80,11 +81,52 @@ export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
         {!loading && isWhitelisted ? (
           <>
             <InfoBox.Row>
-              <InfoBox.Key>Deposited in the Silo</InfoBox.Key>
+              <InfoBox.Key>
+                <TooltipContainer>
+                  In the Beanstalk Silo
+                  <Tooltip
+                    content={
+                      <div className="tooltip-content">
+                        BEANETH LP token holders can Deposit their LP tokens <span className="underline">in the Beanstalk Silo</span> for
+                        yield.
+                      </div>
+                    }
+                    offsetX={0}
+                    offsetY={0}
+                    side="bottom"
+                    arrowSize={4}
+                    arrowOffset={50}
+                    width={270}
+                  >
+                    <Info color="#4b5563" />
+                  </Tooltip>
+                </TooltipContainer>
+              </InfoBox.Key>
               <InfoBox.Value>{displayTV(position?.silo)}</InfoBox.Value>
             </InfoBox.Row>
             <InfoBox.Row>
-              <InfoBox.Key>In my Farm Balance</InfoBox.Key>
+              <InfoBox.Key>
+                <TooltipContainer>
+                  In my Beanstalk Farm Balance
+                  <Tooltip
+                    content={
+                      <div className="tooltip-content">
+                        <span className="underline">Farm Balance</span> allows users of the Beanstalk protocol to hold assets without
+                        needing to withdraw to an external wallet. Using Farm Balances can help reduce gas costs and efficient movement of
+                        assets within Beanstalk.
+                      </div>
+                    }
+                    offsetX={0}
+                    offsetY={0}
+                    arrowOffset={50}
+                    side="bottom"
+                    arrowSize={4}
+                    width={270}
+                  >
+                    <Info color="#4b5563" />
+                  </Tooltip>
+                </TooltipContainer>
+              </InfoBox.Key>
               <InfoBox.Value>{displayTV(position?.internal)}</InfoBox.Value>
             </InfoBox.Row>
           </>
@@ -102,7 +144,6 @@ export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
                       {"Wallet: "}
                       <div>${externalUSD.toHuman("short")}</div>
                     </BreakdownRow>
-
                     <BreakdownRow>
                       {"Silo Deposits: "}
                       <div>${siloUSD.toHuman("short")}</div>
@@ -161,4 +202,17 @@ const BreakdownRow = styled.div`
   flex-direction: row;
   justify-content: space-between;
   gap: 4px;
+`;
+
+const TooltipContainer = styled.div`
+  display: inline-flex;
+  gap: 4px;
+
+  .tooltip-content {
+    ${BodyXS}
+  }
+
+  .underline {
+    text-decoration: underline;
+  }
 `;

--- a/projects/dex-ui/src/components/Well/LiquidityBox.tsx
+++ b/projects/dex-ui/src/components/Well/LiquidityBox.tsx
@@ -16,8 +16,7 @@ import { useLPPositionSummary } from "src/tokens/useLPPositionSummary";
 import { useBeanstalkSiloWhitelist } from "src/wells/useBeanstalkSiloWhitelist";
 import { LoadingItem } from "src/components/LoadingItem";
 import { Well } from "@beanstalk/sdk/Wells";
-import { Info } from "../Icons";
-import { useIsMobile } from "src/utils/ui/useIsMobile";
+import { Info } from "src/components/Icons";
 
 type Props = {
   well: Well | undefined;
@@ -37,8 +36,6 @@ const displayTV = (value?: TokenValue) => (value?.gt(0) ? value.toHuman("short")
 
 export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
   const well = useMemo(() => _well, [_well]);
-
-  const isMobile = useIsMobile();
 
   const { getPositionWithWell } = useLPPositionSummary();
   const { getIsWhitelisted } = useBeanstalkSiloWhitelist();
@@ -97,11 +94,11 @@ export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
                         &nbsp;for yield.
                       </div>
                     }
-                    offsetX={isMobile ? -40 : -1}
+                    offsetX={-40}
                     offsetY={350}
                     side="bottom"
-                    arrowSize={4}
-                    arrowOffset={50}
+                    arrowSize={0}
+                    arrowOffset={0}
                     width={270}
                   >
                     <Info color="#4b5563" />
@@ -120,15 +117,15 @@ export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
                         <a className="underline" href="https://app.bean.money/#/balances" target="_blank" rel="noopener noreferrer">
                           Farm Balances
                         </a>
-                        &nbsp;allow Beanstalk users to hold assets in the protocol on their behalf. Using
-                        Farm Balances can reduce gas costs and facilitate efficient movement of assets within Beanstalk.
+                        &nbsp;allow Beanstalk users to hold assets in the protocol on their behalf. Using Farm Balances can reduce gas costs
+                        and facilitate efficient movement of assets within Beanstalk.
                       </div>
                     }
-                    offsetX={isMobile ? -40 : -1}
-                    offsetY={630}
+                    offsetX={-40}
+                    offsetY={525}
                     arrowOffset={0}
                     side="bottom"
-                    arrowSize={4}
+                    arrowSize={0}
                     width={270}
                   >
                     <Info color="#4b5563" />

--- a/projects/dex-ui/src/components/Well/LiquidityBox.tsx
+++ b/projects/dex-ui/src/components/Well/LiquidityBox.tsx
@@ -87,8 +87,11 @@ export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
                   <Tooltip
                     content={
                       <div className="tooltip-content">
-                        BEANETH LP token holders can Deposit their LP tokens <span className="underline">in the Beanstalk Silo</span> for
-                        yield.
+                        BEANETH LP token holders can Deposit their LP tokens{" "}
+                        <a className="underline" href="https://app.bean.money/#/balances" target="_blank" rel="noopener noreferrer">
+                          in the Beanstalk Silo
+                        </a>
+                        &nbsp;for yield.
                       </div>
                     }
                     offsetX={0}
@@ -111,9 +114,11 @@ export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
                   <Tooltip
                     content={
                       <div className="tooltip-content">
-                        <span className="underline">Farm Balance</span> allows users of the Beanstalk protocol to hold assets without
-                        needing to withdraw to an external wallet. Using Farm Balances can help reduce gas costs and efficient movement of
-                        assets within Beanstalk.
+                        <a className="underline" href="https://app.bean.money/#/balances" target="_blank" rel="noopener noreferrer">
+                          Farm Balance
+                        </a>
+                        &nbsp;allows users of the Beanstalk protocol to hold assets without needing to withdraw to an external wallet. Using
+                        Farm Balances can help reduce gas costs and efficient movement of assets within Beanstalk.
                       </div>
                     }
                     offsetX={0}
@@ -214,5 +219,9 @@ const TooltipContainer = styled.div`
 
   .underline {
     text-decoration: underline;
+
+    &:visited {
+      color: #fff;
+    }
   }
 `;

--- a/projects/dex-ui/src/components/Well/LiquidityBox.tsx
+++ b/projects/dex-ui/src/components/Well/LiquidityBox.tsx
@@ -90,9 +90,9 @@ export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
                   <Tooltip
                     content={
                       <div className="tooltip-content">
-                        BEANETH LP token holders can Deposit their LP tokens{" "}
-                        <a className="underline" href="https://app.bean.money/#/balances" target="_blank" rel="noopener noreferrer">
-                          in the Beanstalk Silo
+                        BEANETH LP token holders can Deposit their LP tokens in the{" "}
+                        <a className="underline" href="https://app.bean.money/#/silo" target="_blank" rel="noopener noreferrer">
+                          Beanstalk Silo
                         </a>
                         &nbsp;for yield.
                       </div>
@@ -118,10 +118,10 @@ export const LiquidityBox: FC<Props> = ({ well: _well, loading }) => {
                     content={
                       <div className="tooltip-content">
                         <a className="underline" href="https://app.bean.money/#/balances" target="_blank" rel="noopener noreferrer">
-                          Farm Balance
+                          Farm Balances
                         </a>
-                        &nbsp;allows users of the Beanstalk protocol to hold assets without needing to withdraw to an external wallet. Using
-                        Farm Balances can help reduce gas costs and efficient movement of assets within Beanstalk.
+                        &nbsp;allow Beanstalk users to hold assets in the protocol on their behalf. Using
+                        Farm Balances can reduce gas costs and facilitate efficient movement of assets within Beanstalk.
                       </div>
                     }
                     offsetX={isMobile ? -40 : -1}

--- a/projects/dex-ui/src/components/Well/MultiFlowPumpTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/MultiFlowPumpTooltip.tsx
@@ -35,7 +35,7 @@ export const MultiFlowPumpTooltip: FC<{
             <div className="container-title">Multi Flow Pump</div>
             <div className="content">
               The&nbsp;
-              <a className="content-link" href="/" target="_blank" rel="noopener noreferrer">
+              <a className="content-link" href="/multi-flow-pump.pdf" target="_blank" rel="noopener noreferrer">
                 Multi Flow Pump
               </a>
               , an inter-block MEV manipulation resistant oracle, stores reserve data from this Well. In particular, Multi Flow stores

--- a/projects/dex-ui/src/components/Well/MultiFlowPumpTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/MultiFlowPumpTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react";
+import React, { FC } from "react";
 import { Info } from "src/components/Icons";
 import { Tooltip, TooltipProps } from "src/components/Tooltip";
 import { mediaQuery } from "src/breakpoints";

--- a/projects/dex-ui/src/components/Well/MultiFlowPumpTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/MultiFlowPumpTooltip.tsx
@@ -1,0 +1,167 @@
+import React, { FC, useEffect } from "react";
+import { Info } from "src/components/Icons";
+import { Tooltip, TooltipProps } from "src/components/Tooltip";
+import { mediaQuery } from "src/breakpoints";
+import styled from "styled-components";
+import { Item, Row } from "src/components/Layout";
+import { BodyS } from "src/components/Typography";
+import { Well } from "@beanstalk/sdk/Wells";
+import { TokenLogo } from "src/components/TokenLogo";
+
+export const MultiFlowPumpTooltip: FC<{
+  well: Well;
+  children?: React.ReactNode; // if no children, then the tooltip icon is rendered
+  tooltipProps?: TooltipProps;
+}> = ({ well, children, tooltipProps }) => {
+  const token1 = well.tokens?.[0];
+  const reserve1 = well.reserves?.[0];
+
+  const token2 = well.tokens?.[1];
+  const reserve2 = well.reserves?.[1];
+
+  if (!token1 || !token2 || !reserve1 || !reserve2) return null;
+
+  return (
+    <Tooltip
+      content={
+        <Container>
+          <TitleAndContentContainer column stretch>
+            <div className="container-title">Multi Flow Pump</div>
+            <div className="content">
+              The&nbsp;
+              <a className="content-link" href="/" target="_blank" rel="noopener noreferrer">
+                Multi Flow Pump
+              </a>
+              , an inter-block MEV manipulation resistant oracle, stores reserve data from this Well. In particular, Multi Flow stores
+              reserve data in two formats
+            </div>
+          </TitleAndContentContainer>
+          <ReservesInfo column stretch>
+            <ReserveData column stretch>
+              <div className="reserve-type">Instantaneous reserves</div>
+              <StyledItem stretch>
+                <StyledRow>
+                  <div className="reserve-token-container">
+                    <TokenLogo token={token1} size={16} />
+                    {token1.symbol}
+                  </div>
+                  {reserve1.toHuman("short")}
+                </StyledRow>
+              </StyledItem>
+              <StyledItem stretch>
+                <StyledRow>
+                  <div className="reserve-token-container">
+                    <TokenLogo token={token2} size={16} />
+                    {token2.symbol}
+                  </div>
+                  {reserve2.toHuman("short")}
+                </StyledRow>
+              </StyledItem>
+            </ReserveData>
+            <ReserveData column stretch>
+              <div className="reserve-type">Time-weighted average reserves</div>
+              <StyledItem stretch>
+                <StyledRow>
+                  <div className="reserve-token-container">
+                    <TokenLogo token={token1} size={16} />
+                    {token1.symbol}
+                  </div>
+                  {reserve1.toHuman("short")}
+                </StyledRow>
+              </StyledItem>
+              <StyledItem stretch>
+                <StyledRow>
+                  <div className="reserve-token-container">
+                    <TokenLogo token={token2} size={16} />
+                    {token2.symbol}
+                  </div>
+                  {reserve2.toHuman("short")}
+                </StyledRow>
+              </StyledItem>
+            </ReserveData>
+          </ReservesInfo>
+        </Container>
+      }
+      offsetX={0}
+      offsetY={0}
+      arrowSize={0}
+      arrowOffset={0}
+      side="top"
+      bgColor="white"
+      width={370}
+      {...tooltipProps}
+    >
+      {children ? children : <Info color="#9CA3AF" width={14} height={14} />}
+    </Tooltip>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  padding: 12px;
+  box-sizing: border-box;
+
+  ${mediaQuery.sm.only} {
+    gap: 16px;
+  }
+`;
+
+const TitleAndContentContainer = styled(Item)`
+  width: 100%;
+
+  gap: 8px;
+  ${BodyS}
+
+  .container-title {
+    font-weight: 600;
+  }
+
+  .content {
+    color: #4B556;
+
+    .content-link {
+      color: #46b955;
+      cursor: pointer;
+      text-decoration: none;
+
+      :focus {
+        text-decoration: none;
+      }
+    }
+  }
+`;
+
+const ReservesInfo = styled(Item)`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const ReserveData = styled(Item)`
+  font-weight: 600;
+  gap: 4px;
+
+  .reserve-type {
+    ${BodyS}
+    font-weight: 400;
+    color: #4B556;
+  }
+
+  .reserve-token-container {
+    display: flex;
+    flex-direction: row;
+    gap: 4px;
+  }
+`;
+
+const StyledItem = styled(Item)`
+  gap: 4px;
+`;
+
+const StyledRow = styled(Row)`
+  width: 100%;
+  justify-content: space-between;
+`;

--- a/projects/dex-ui/src/components/Well/MultiFlowPumpTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/MultiFlowPumpTooltip.tsx
@@ -39,7 +39,7 @@ export const MultiFlowPumpTooltip: FC<{
                 Multi Flow Pump
               </a>
               , an inter-block MEV manipulation resistant oracle, stores reserve data from this Well. In particular, Multi Flow stores
-              reserve data in two formats
+              reserve data in two formats:
             </div>
           </TitleAndContentContainer>
           <ReservesInfo column stretch>

--- a/projects/dex-ui/src/components/Well/MultiFlowPumpTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/MultiFlowPumpTooltip.tsx
@@ -7,17 +7,23 @@ import { Item, Row } from "src/components/Layout";
 import { BodyS } from "src/components/Typography";
 import { Well } from "@beanstalk/sdk/Wells";
 import { TokenLogo } from "src/components/TokenLogo";
+import { TokenValue } from "@beanstalk/sdk";
+import { formatNum } from "src/utils/format";
 
 export const MultiFlowPumpTooltip: FC<{
   well: Well;
+  twaReserves: TokenValue[] | undefined;
   children?: React.ReactNode; // if no children, then the tooltip icon is rendered
   tooltipProps?: TooltipProps;
-}> = ({ well, children, tooltipProps }) => {
+}> = ({ well, children, tooltipProps, twaReserves }) => {
   const token1 = well.tokens?.[0];
   const reserve1 = well.reserves?.[0];
 
   const token2 = well.tokens?.[1];
   const reserve2 = well.reserves?.[1];
+
+  const twaReserves1 = twaReserves?.[0];
+  const twaReserves2 = twaReserves?.[1];
 
   if (!token1 || !token2 || !reserve1 || !reserve2) return null;
 
@@ -45,7 +51,7 @@ export const MultiFlowPumpTooltip: FC<{
                     <TokenLogo token={token1} size={16} />
                     {token1.symbol}
                   </div>
-                  {reserve1.toHuman("short")}
+                  {formatNum(reserve1, { minDecimals: 2 })}
                 </StyledRow>
               </StyledItem>
               <StyledItem stretch>
@@ -54,31 +60,33 @@ export const MultiFlowPumpTooltip: FC<{
                     <TokenLogo token={token2} size={16} />
                     {token2.symbol}
                   </div>
-                  {reserve2.toHuman("short")}
+                  {formatNum(reserve2, { minDecimals: 2 })}
                 </StyledRow>
               </StyledItem>
             </ReserveData>
-            <ReserveData column stretch>
-              <div className="reserve-type">Time-weighted average reserves</div>
-              <StyledItem stretch>
-                <StyledRow>
-                  <div className="reserve-token-container">
-                    <TokenLogo token={token1} size={16} />
-                    {token1.symbol}
-                  </div>
-                  {reserve1.toHuman("short")}
-                </StyledRow>
-              </StyledItem>
-              <StyledItem stretch>
-                <StyledRow>
-                  <div className="reserve-token-container">
-                    <TokenLogo token={token2} size={16} />
-                    {token2.symbol}
-                  </div>
-                  {reserve2.toHuman("short")}
-                </StyledRow>
-              </StyledItem>
-            </ReserveData>
+            {twaReserves1 && twaReserves2 && (
+              <ReserveData column stretch>
+                <div className="reserve-type">Time-weighted average reserves</div>
+                <StyledItem stretch>
+                  <StyledRow>
+                    <div className="reserve-token-container">
+                      <TokenLogo token={token1} size={16} />
+                      {token1.symbol}
+                    </div>
+                    {formatNum(twaReserves1, { minDecimals: 2 })}
+                  </StyledRow>
+                </StyledItem>
+                <StyledItem stretch>
+                  <StyledRow>
+                    <div className="reserve-token-container">
+                      <TokenLogo token={token2} size={16} />
+                      {token2.symbol}
+                    </div>
+                    {formatNum(twaReserves2, { minDecimals: 2 })}
+                  </StyledRow>
+                </StyledItem>
+              </ReserveData>
+            )}
           </ReservesInfo>
         </Container>
       }

--- a/projects/dex-ui/src/components/Well/Reserves.tsx
+++ b/projects/dex-ui/src/components/Well/Reserves.tsx
@@ -10,6 +10,9 @@ import { formatNum, formatPercent } from "src/utils/format";
 
 import { MultiFlowPumpTooltip } from "./MultiFlowPumpTooltip";
 import { Well } from "@beanstalk/sdk/Wells";
+import { useBeanstalkSiloWhitelist } from "src/wells/useBeanstalkSiloWhitelist";
+import { TooltipProps } from "../Tooltip";
+import { useIsMobile } from "src/utils/ui/useIsMobile";
 
 export type ReservesProps = {
   well: Well | undefined;
@@ -19,18 +22,24 @@ export type ReservesProps = {
     dollarAmount: TokenValue | null;
     percentage: TokenValue | null;
   }[];
+  twaReserves: TokenValue[] | undefined;
 };
 
-export const Reserves: FC<ReservesProps> = ({ reserves, well }) => {
+export const Reserves: FC<ReservesProps> = ({ reserves, well, twaReserves }) => {
+  const { getIsMultiPumpWell } = useBeanstalkSiloWhitelist();
+  const isMobile = useIsMobile();
+
   if (!well) return null;
 
   const rows = (reserves ?? []).map((r, i) => (
     <Item key={i} column>
       <Symbol>
         {r.token?.symbol}
-        <div className="info-icon">
-          <MultiFlowPumpTooltip well={well} />
-        </div>
+        {getIsMultiPumpWell(well) && (
+          <div className="info-icon">
+            <MultiFlowPumpTooltip well={well} twaReserves={twaReserves} tooltipProps={getTooltipProps(isMobile, i)} />
+          </div>
+        )}
       </Symbol>
       <Wrapper>
         <TokenLogo token={r.token} size={16} mobileSize={16} />
@@ -89,3 +98,17 @@ const Percent = styled.div`
     ${BodyS}
   }
 `;
+
+const baseTooltipProps = { offsetX: 0, offsetY: 0, arrowSize: 0, arrowOffset: 0, side: "top" } as TooltipProps;
+
+const getTooltipProps = (isMobile: boolean, index: number) => {
+  const copy = { ...baseTooltipProps };
+  if (!isMobile) return copy;
+
+  copy.width = 300;
+
+  if (index === 0) copy.offsetX = -15;
+  else copy.offsetX = -70;
+
+  return copy;
+};

--- a/projects/dex-ui/src/components/Well/Reserves.tsx
+++ b/projects/dex-ui/src/components/Well/Reserves.tsx
@@ -6,8 +6,13 @@ import { Token, TokenValue } from "@beanstalk/sdk";
 import { TokenLogo } from "../TokenLogo";
 import { Item, Row } from "../Layout";
 import { size } from "src/breakpoints";
+import { formatNum, formatPercent } from "src/utils/format";
 
-type Props = {
+import { MultiFlowPumpTooltip } from "./MultiFlowPumpTooltip";
+import { Well } from "@beanstalk/sdk/Wells";
+
+export type ReservesProps = {
+  well: Well | undefined;
   reserves: {
     token: Token;
     amount: TokenValue;
@@ -15,17 +20,25 @@ type Props = {
     percentage: TokenValue | null;
   }[];
 };
-export const Reserves: FC<Props> = ({ reserves }) => {
+
+export const Reserves: FC<ReservesProps> = ({ reserves, well }) => {
+  if (!well) return null;
+
   const rows = (reserves ?? []).map((r, i) => (
     <Item key={i} column>
-      <Symbol>{r.token?.symbol}</Symbol>
+      <Symbol>
+        {r.token?.symbol}
+        <div className="info-icon">
+          <MultiFlowPumpTooltip well={well} />
+        </div>
+      </Symbol>
       <Wrapper>
         <TokenLogo token={r.token} size={16} mobileSize={16} />
         <TextNudge amount={2}>
-          <Amount>{r.amount.toHuman("short")}</Amount>
+          <Amount>{formatNum(r.amount, { minDecimals: 2 })}</Amount>
         </TextNudge>
         <TextNudge amount={2}>
-          <Percent>{`(${r.percentage?.mul(100).toHuman("short")}%)`}</Percent>
+          <Percent>{formatPercent(r.percentage)}</Percent>
         </TextNudge>
       </Wrapper>
     </Item>
@@ -35,12 +48,20 @@ export const Reserves: FC<Props> = ({ reserves }) => {
 };
 
 const Symbol = styled.div`
+  display: inline-flex;
+  flex-direction: row;
+
   ${BodyL}
   color: #4B5563;
   @media (max-width: ${size.mobile}) {
     ${BodyS}
   }
+
+  .info-icon {
+    margin-left: 6px;
+  }
 `;
+
 const Wrapper = styled.div`
   display: flex;
   flex-direction: row;

--- a/projects/dex-ui/src/components/Well/Table/WellDetailRow.tsx
+++ b/projects/dex-ui/src/components/Well/Table/WellDetailRow.tsx
@@ -8,6 +8,8 @@ import { mediaQuery, size } from "src/breakpoints";
 import { formatNum } from "src/utils/format";
 import { Well } from "@beanstalk/sdk/Wells";
 import { Skeleton } from "src/components/Skeleton";
+import { WellYieldWithTooltip } from "../WellYieldWithTooltip";
+import { Item } from "src/components/Layout";
 
 /// format value with 2 decimals, if value is less than 1M, otherwise use short format
 const formatMayDecimals = (tv: TokenValue | undefined) => {
@@ -51,7 +53,9 @@ export const WellDetailRow: FC<{
         <WellPricing>{functionName || "Price Function"}</WellPricing>
       </DesktopContainer>
       <DesktopContainer align="right">
-        <TradingFee>0.00%</TradingFee>
+        <Item column right>
+          <WellYieldWithTooltip well={well} />
+        </Item>
       </DesktopContainer>
       <DesktopContainer align="right">
         <Amount>${liquidity ? liquidity.toHuman("short") : "-.--"}</Amount>
@@ -91,7 +95,7 @@ export const WellDetailLoadingRow: FC<{}> = () => {
         <Skeleton height={24} width={125} />
       </DesktopContainer>
       <DesktopContainer align="right">
-        <Skeleton height={24} width={75} />
+        <Skeleton height={32} width={75} />
       </DesktopContainer>
       <DesktopContainer align="right">
         <Skeleton height={24} width={90} />
@@ -209,4 +213,8 @@ const WellPricing = styled.div`
 
 const TokenLogoWrapper = styled.div`
   margin-bottom: 2px;
+`;
+
+const TooltipContainer = styled.div`
+  display: flex;
 `;

--- a/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 import { BodyL, BodyS } from "../Typography";
 import { TokenLogo } from "../TokenLogo";
@@ -9,24 +9,36 @@ import { TokenValue } from "@beanstalk/sdk";
 import StartSparkle from "src/assets/images/start-sparkle.svg";
 import { useIsMobile } from "src/utils/ui/useIsMobile";
 import { Well } from "@beanstalk/sdk/Wells";
+import useBeanstalkSiloAPYs from "src/wells/useBeanstalkSiloAPYs";
+import { mediaQuery } from "src/breakpoints";
 
 type Props = {
-  well?: Well;
+  well: Well | undefined;
   apy?: TokenValue;
+  loading?: boolean;
   tooltipProps?: Partial<Pick<TooltipProps, "offsetX" | "offsetY" | "side">>;
 };
 
-export const WellYieldWithTooltip: React.FC<Props> = ({ tooltipProps }) => {
+export const WellYieldWithTooltip: React.FC<Props> = ({ tooltipProps, well }) => {
   const sdk = useSdk();
 
   const bean = sdk.tokens.BEAN;
   const isMobile = useIsMobile();
 
-  const apy = TokenValue.fromHuman("0.0458", 4);
+  const { getSiloAPYWithWell } = useBeanstalkSiloAPYs();
 
-  const displayAPY = `${apy.mul(100).toHuman("short")}%`;
+  const apy = useMemo(() => {
+    const data = getSiloAPYWithWell(well);
+
+    if (!data) return undefined;
+    return `${data.mul(100).toHuman("short")}%`;
+  }, [well, getSiloAPYWithWell]);
 
   const tooltipWidth = isMobile ? 250 : 360;
+
+  if (!apy) {
+    return null;
+  }
 
   return (
     <TooltipContainer>
@@ -42,7 +54,7 @@ export const WellYieldWithTooltip: React.FC<Props> = ({ tooltipProps }) => {
                   </div>
                   Bean vAPY
                 </div>
-                {displayAPY}
+                {apy}
               </div>
             </TitleContainer>
             <ContentContainer>
@@ -63,7 +75,7 @@ export const WellYieldWithTooltip: React.FC<Props> = ({ tooltipProps }) => {
       >
         <ChildContainer>
           <StyledImg src={StartSparkle} alt="basin-bean-vAPY" />
-          <div>{displayAPY} vAPY</div>
+          <div>{apy} vAPY</div>
         </ChildContainer>
       </Tooltip>
     </TooltipContainer>
@@ -80,6 +92,10 @@ const Container = styled.div`
 
   .underlined {
     text-decoration: underline;
+  }
+
+  ${mediaQuery.sm.only} {
+    gap: 16px;
   }
 `;
 
@@ -129,6 +145,11 @@ const StyledImg = styled.img`
   justify-content: center;
   align-items: center;
   box-sizing: border-box;
+
+  ${mediaQuery.sm.only} {
+    height: 20px;
+    width: 20px;
+  }
 `;
 
 const ChildContainer = styled.div`
@@ -144,6 +165,10 @@ const ChildContainer = styled.div`
 
   ${BodyL}
   font-weight: 600;
+
+  ${mediaQuery.sm.only} {
+    ${BodyS}
+  }
 `;
 
 const TooltipContainer = styled.div`

--- a/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
@@ -37,7 +37,7 @@ export const WellYieldWithTooltip: React.FC<Props> = ({ tooltipProps, well }) =>
   const tooltipWidth = isMobile ? 250 : 360;
 
   if (!apy) {
-    return null;
+    return <>{"-"}</>;
   }
 
   return (

--- a/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import styled from "styled-components";
+import { BodyL, BodyS } from "../Typography";
+import { TokenLogo } from "../TokenLogo";
+import useSdk from "src/utils/sdk/useSdk";
+import { Tooltip, TooltipProps } from "../Tooltip";
+import { TokenValue } from "@beanstalk/sdk";
+
+import StartSparkle from "src/assets/images/start-sparkle.svg";
+import { useIsMobile } from "src/utils/ui/useIsMobile";
+import { Well } from "@beanstalk/sdk/Wells";
+
+type Props = {
+  well?: Well;
+  apy?: TokenValue;
+  tooltipProps?: Partial<Pick<TooltipProps, "offsetX" | "offsetY" | "side">>;
+};
+
+export const WellYieldWithTooltip: React.FC<Props> = ({ tooltipProps }) => {
+  const sdk = useSdk();
+
+  const bean = sdk.tokens.BEAN;
+  const isMobile = useIsMobile();
+
+  const apy = TokenValue.fromHuman("0.0458", 4);
+
+  const displayAPY = `${apy.mul(100).toHuman("short")}%`;
+
+  const tooltipWidth = isMobile ? 250 : 360;
+
+  return (
+    <TooltipContainer>
+      <Tooltip
+        content={
+          <Container>
+            <TitleContainer>
+              <div className="title">Well Yield</div>
+              <div className="label-value">
+                <div className="label">
+                  <div className="logo-wrapper">
+                    <TokenLogo token={bean} size={16} />
+                  </div>
+                  Bean vAPY
+                </div>
+                {displayAPY}
+              </div>
+            </TitleContainer>
+            <ContentContainer>
+              <div>
+                The Variable Bean APY (vAPY) uses historical data of Beans earned by <span className="underlined">Silo Depositors</span> to
+                estimate future returns
+              </div>
+            </ContentContainer>
+          </Container>
+        }
+        offsetY={tooltipProps?.offsetY || 0}
+        offsetX={tooltipProps?.offsetX || 0}
+        arrowOffset={0}
+        arrowSize={0}
+        side={tooltipProps?.side || "top"}
+        bgColor="white"
+        width={tooltipWidth}
+      >
+        <ChildContainer>
+          <StyledImg src={StartSparkle} alt="basin-bean-vAPY" />
+          <div>{displayAPY} vAPY</div>
+        </ChildContainer>
+      </Tooltip>
+    </TooltipContainer>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+  padding: 4px;
+  box-sizing: border-box;
+
+  .underlined {
+    text-decoration: underline;
+  }
+`;
+
+const TitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  .title {
+    ${BodyS}
+    font-weight: 600;
+  }
+
+  .label-value {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    ${BodyS}
+    color: #46b955;
+    font-weight: 600;
+
+    .logo-wrapper {
+      position: relative;
+      margin-top: 2px;
+    }
+
+    .label {
+      display: flex;
+      flex-direction: row;
+      gap: 4px;
+    }
+  }
+`;
+
+const ContentContainer = styled.div`
+  display: flex;
+  width: 100%;
+  ${BodyS}
+`;
+
+const StyledImg = styled.img`
+  display: flex;
+  width: 24px;
+  height: 24px;
+  padding: 3px 2px 3px 3px;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+`;
+
+const ChildContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  background: #edf8ee;
+  padding: 4px;
+  color: #46b955;
+  width: max-content;
+  border-radius: 4px;
+
+  ${BodyL}
+  font-weight: 600;
+`;
+
+const TooltipContainer = styled.div`
+  width: max-content;
+`;

--- a/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
@@ -59,8 +59,16 @@ export const WellYieldWithTooltip: React.FC<Props> = ({ tooltipProps, well }) =>
             </TitleContainer>
             <ContentContainer>
               <div>
-                The Variable Bean APY (vAPY) uses historical data of Beans earned by <span className="underlined">Silo Depositors</span> to
-                estimate future returns
+                The Variable Bean APY (vAPY) uses historical data of Beans earned by{" "}
+                <a
+                  href="https://docs.bean.money/almanac/guides/silo/understand-vapy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underlined"
+                >
+                  Silo Depositors
+                </a>
+                &nbsp;to estimate future returns
               </div>
             </ContentContainer>
           </Container>
@@ -92,6 +100,10 @@ const Container = styled.div`
 
   .underlined {
     text-decoration: underline;
+
+    &:visited {
+      color: #000;
+    }
   }
 
   ${mediaQuery.sm.only} {
@@ -102,6 +114,8 @@ const Container = styled.div`
 const TitleContainer = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
   gap: 8px;
 
   .title {
@@ -112,6 +126,7 @@ const TitleContainer = styled.div`
   .label-value {
     display: flex;
     flex-direction: row;
+    width: 100%;
     justify-content: space-between;
     align-items: center;
     ${BodyS}
@@ -135,6 +150,7 @@ const ContentContainer = styled.div`
   display: flex;
   width: 100%;
   ${BodyS}
+  text-align: left;
 `;
 
 const StyledImg = styled.img`

--- a/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
@@ -68,7 +68,7 @@ export const WellYieldWithTooltip: React.FC<Props> = ({ tooltipProps, well }) =>
                 >
                   Silo Depositors
                 </a>
-                &nbsp;to estimate future returns
+                &nbsp;to estimate future returns.
               </div>
             </ContentContainer>
           </Container>

--- a/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
+++ b/projects/dex-ui/src/components/Well/WellYieldWithTooltip.tsx
@@ -9,7 +9,7 @@ import { TokenValue } from "@beanstalk/sdk";
 import StartSparkle from "src/assets/images/start-sparkle.svg";
 import { useIsMobile } from "src/utils/ui/useIsMobile";
 import { Well } from "@beanstalk/sdk/Wells";
-import useBeanstalkSiloAPYs from "src/wells/useBeanstalkSiloAPYs";
+import { useBeanstalkSiloAPYs } from "src/wells/useBeanstalkSiloAPYs";
 import { mediaQuery } from "src/breakpoints";
 
 type Props = {

--- a/projects/dex-ui/src/pages/Home.tsx
+++ b/projects/dex-ui/src/pages/Home.tsx
@@ -16,7 +16,7 @@ const copy = {
 const links = {
   multiFlowPump: "/multi-flow-pump.pdf",
   whitepaper: "/basin.pdf",
-  docs: "https://docs.basin.exchange/",
+  docs: "https://docs.basin.exchange/implementations/overview",
   wells: "/#/wells",
   swap: "/#/swap"
 };

--- a/projects/dex-ui/src/pages/Home.tsx
+++ b/projects/dex-ui/src/pages/Home.tsx
@@ -8,9 +8,9 @@ import { BodyL } from "src/components/Typography";
 import { ContractInfoMarquee } from "src/components/Frame/ContractInfoMarquee";
 
 const copy = {
-  build: "Use components written, audited and deployed by other developers for your custom liquidity pool.",
-  deploy: "Liquidity pools with unique pricing functions for more granular market making.",
-  fees: "Trade assets using liquidity pools that don’t impose trading fees."
+  build: "Use DEX components written, audited and deployed by other developers for your custom liquidity pool.",
+  deploy: "Deploy liquidity in pools with unique pricing functions for more granular market making.",
+  fees: "Exchange assets in liquidity pools that don't impose trading fees."
 };
 
 const links = {
@@ -29,10 +29,9 @@ export const Home = () => {
           <MevBanner>
             <MevBannerBG>
               <MevInfo>
-                <MevTitle>Multi-Flow Pump is here!</MevTitle>
+                <MevTitle>Multi Flow Pump is here!</MevTitle>
                 <div>
-                  Explore the <span style={{ fontWeight: 600 }}>multi-block MEV manipulation resistant Oracle </span>framework, with easy
-                  integration for everyone.
+                  Explore the <span style={{ fontWeight: 600 }}>inter-block MEV manipulation resistant oracle implementation</span> used by the BEAN:WETH Well.
                 </div>
               </MevInfo>
               <GetStartedContainer href={links.multiFlowPump} target="_blank" rel="noopener noreferrer">
@@ -42,7 +41,7 @@ export const Home = () => {
           </MevBanner>
           <InfoContainer>
             <TitleSubtitleContainer>
-              <Title>A Composable EVM-native DEX </Title>
+              <Title>A Composable EVM-Native DEX </Title>
               <SubTitle>
                 Customizable liquidity pools with shared components.&nbsp;
                 <WhitepaperLink href={links.whitepaper} target="_blank">

--- a/projects/dex-ui/src/pages/Home.tsx
+++ b/projects/dex-ui/src/pages/Home.tsx
@@ -31,7 +31,8 @@ export const Home = () => {
               <MevInfo>
                 <MevTitle>Multi Flow Pump is here!</MevTitle>
                 <div>
-                  Explore the <span style={{ fontWeight: 600 }}>inter-block MEV manipulation resistant oracle implementation</span> used by the BEAN:WETH Well.
+                  Explore the <span style={{ fontWeight: 600 }}>inter-block MEV manipulation resistant oracle implementation</span> used by
+                  the BEAN:WETH Well.
                 </div>
               </MevInfo>
               <GetStartedContainer href={links.multiFlowPump} target="_blank" rel="noopener noreferrer">
@@ -171,6 +172,8 @@ const MevTitle = styled.div`
 `;
 
 const GetStartedContainer = styled.a`
+  text-decoration: none;
+
   :focus {
     text-decoration: none;
   }

--- a/projects/dex-ui/src/pages/Well.tsx
+++ b/projects/dex-ui/src/pages/Well.tsx
@@ -35,7 +35,6 @@ import { useMultiFlowPumpTWAReserves } from "src/wells/useMultiFlowPumpTWAReserv
 export const Well = () => {
   const { well, loading: dataLoading, error } = useWellWithParams();
   const { isLoading: apysLoading } = useBeanstalkSiloAPYs();
-
   const { isLoading: twaLoading, getTWAReservesWithWell } = useMultiFlowPumpTWAReserves();
 
   const loading = useLagLoading(dataLoading || apysLoading || twaLoading);

--- a/projects/dex-ui/src/pages/Well.tsx
+++ b/projects/dex-ui/src/pages/Well.tsx
@@ -52,8 +52,6 @@ export const Well = () => {
     setTab(i);
   }, []);
 
-  console.log("aquifer address: ", well?.aquifer?.address);
-
   const [open, setOpen] = useState(false);
   const toggle = useCallback(() => {
     setOpen(!open);

--- a/projects/dex-ui/src/pages/Well.tsx
+++ b/projects/dex-ui/src/pages/Well.tsx
@@ -26,14 +26,19 @@ import { Error } from "src/components/Error";
 import { useWellWithParams } from "src/wells/useWellWithParams";
 import { LoadingItem } from "src/components/LoadingItem";
 import { LoadingTemplate } from "src/components/LoadingTemplate";
+import { WellYieldWithTooltip } from "src/components/Well/WellYieldWithTooltip";
+import { useIsMobile } from "src/utils/ui/useIsMobile";
+import { useLagLoading } from "src/utils/ui/useLagLoading";
 
 export const Well = () => {
-  const { well, loading: loading, error } = useWellWithParams();
+  const { well, loading: dataLoading, error } = useWellWithParams();
+  const loading = useLagLoading(dataLoading);
 
   const sdk = useSdk();
   const navigate = useNavigate();
   const [prices, setPrices] = useState<(TokenValue | null)[]>([]);
   const [wellFunctionName, setWellFunctionName] = useState<string | undefined>("-");
+  const isMobile = useIsMobile();
 
   const [tab, setTab] = useState(0);
   const showTab = useCallback((e: React.MouseEvent<HTMLButtonElement, MouseEvent>, i: number) => {
@@ -140,6 +145,16 @@ export const Well = () => {
                 <TextNudge amount={10} mobileAmount={-2}>
                   {title}
                 </TextNudge>
+                <div className="silo-yield-section">
+                  <WellYieldWithTooltip
+                    well={well}
+                    tooltipProps={{
+                      offsetX: isMobile ? -35 : 0,
+                      offsetY: 0,
+                      side: "top"
+                    }}
+                  />
+                </div>
               </Header>
             </Item>
             <StyledItem column stretch>
@@ -281,7 +296,7 @@ const ContentWrapper = styled.div`
   width: 100%;
 
   ${mediaQuery.lg.only} {
-    height: 1400px;
+    height: 1500px;
   }
 
   ${mediaQuery.between.smAndLg} {
@@ -305,6 +320,10 @@ const Header = styled.div`
   ${mediaQuery.lg.down} {
     font-size: 24px;
     gap: 8px;
+  }
+
+  .silo-yield-section {
+    align-self: center;
   }
 `;
 

--- a/projects/dex-ui/src/pages/Well.tsx
+++ b/projects/dex-ui/src/pages/Well.tsx
@@ -29,10 +29,16 @@ import { LoadingTemplate } from "src/components/LoadingTemplate";
 import { WellYieldWithTooltip } from "src/components/Well/WellYieldWithTooltip";
 import { useIsMobile } from "src/utils/ui/useIsMobile";
 import { useLagLoading } from "src/utils/ui/useLagLoading";
+import { useBeanstalkSiloAPYs } from "src/wells/useBeanstalkSiloAPYs";
+import { useMultiFlowPumpTWAReserves } from "src/wells/useMultiFlowPumpTWAReserves";
 
 export const Well = () => {
   const { well, loading: dataLoading, error } = useWellWithParams();
-  const loading = useLagLoading(dataLoading);
+  const { isLoading: apysLoading } = useBeanstalkSiloAPYs();
+
+  useMultiFlowPumpTWAReserves();
+
+  const loading = useLagLoading(dataLoading || apysLoading);
 
   const sdk = useSdk();
   const navigate = useNavigate();
@@ -169,7 +175,7 @@ export const Well = () => {
          */}
         <ReservesContainer>
           <LoadingItem loading={loading} onLoading={<SkeletonReserves />}>
-            <Reserves reserves={reserves} />
+            <Reserves reserves={reserves} well={well} />
           </LoadingItem>
         </ReservesContainer>
 

--- a/projects/dex-ui/src/pages/Well.tsx
+++ b/projects/dex-ui/src/pages/Well.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getPrice } from "src/utils/price/usePrice";
 import useSdk from "src/utils/sdk/useSdk";
@@ -36,9 +36,9 @@ export const Well = () => {
   const { well, loading: dataLoading, error } = useWellWithParams();
   const { isLoading: apysLoading } = useBeanstalkSiloAPYs();
 
-  useMultiFlowPumpTWAReserves();
+  const { isLoading: twaLoading, getTWAReservesWithWell } = useMultiFlowPumpTWAReserves();
 
-  const loading = useLagLoading(dataLoading || apysLoading);
+  const loading = useLagLoading(dataLoading || apysLoading || twaLoading);
 
   const sdk = useSdk();
   const navigate = useNavigate();
@@ -94,6 +94,8 @@ export const Well = () => {
   reserves.forEach((reserve) => {
     reserve.percentage = reserve.dollarAmount && totalUSD.gt(TokenValue.ZERO) ? reserve.dollarAmount.div(totalUSD) : TokenValue.ZERO;
   });
+
+  const twaReserves = useMemo(() => getTWAReservesWithWell(well), [well, getTWAReservesWithWell]);
 
   const goLiquidity = () => navigate(`./liquidity`);
 
@@ -175,7 +177,7 @@ export const Well = () => {
          */}
         <ReservesContainer>
           <LoadingItem loading={loading} onLoading={<SkeletonReserves />}>
-            <Reserves reserves={reserves} well={well} />
+            <Reserves reserves={reserves} well={well} twaReserves={twaReserves} />
           </LoadingItem>
         </ReservesContainer>
 

--- a/projects/dex-ui/src/pages/Well.tsx
+++ b/projects/dex-ui/src/pages/Well.tsx
@@ -304,7 +304,7 @@ const ContentWrapper = styled.div`
   width: 100%;
 
   ${mediaQuery.lg.only} {
-    height: 1500px;
+    height: 1600px;
   }
 
   ${mediaQuery.between.smAndLg} {

--- a/projects/dex-ui/src/pages/Well.tsx
+++ b/projects/dex-ui/src/pages/Well.tsx
@@ -52,6 +52,8 @@ export const Well = () => {
     setTab(i);
   }, []);
 
+  console.log("aquifer address: ", well?.aquifer?.address);
+
   const [open, setOpen] = useState(false);
   const toggle = useCallback(() => {
     setOpen(!open);

--- a/projects/dex-ui/src/pages/Wells.tsx
+++ b/projects/dex-ui/src/pages/Wells.tsx
@@ -17,6 +17,8 @@ import { useLPPositionSummary } from "src/tokens/useLPPositionSummary";
 
 import { WellDetailLoadingRow, WellDetailRow } from "src/components/Well/Table/WellDetailRow";
 import { MyWellPositionLoadingRow, MyWellPositionRow } from "src/components/Well/Table/MyWellPositionRow";
+import { useBeanstalkSiloAPYs } from "src/wells/useBeanstalkSiloAPYs";
+import { useLagLoading } from "src/utils/ui/useLagLoading";
 
 export const Wells = () => {
   const { data: wells, isLoading, error } = useWells();
@@ -27,8 +29,10 @@ export const Wells = () => {
   const [tab, showTab] = useState<number>(0);
 
   const { data: lpTokenPrices } = useWellLPTokenPrice(wells);
+  const { hasPositions, getPositionWithWell, isLoading: positionsLoading } = useLPPositionSummary();
+  const { isLoading: apysLoading } = useBeanstalkSiloAPYs();
 
-  const { hasPositions, getPositionWithWell } = useLPPositionSummary();
+  const loading = useLagLoading(isLoading || apysLoading || positionsLoading);
 
   useMemo(() => {
     const run = async () => {
@@ -101,7 +105,7 @@ export const Wells = () => {
           </THead>
         )}
         <TBody>
-          {isLoading ? (
+          {loading ? (
             <>
               {Array(5)
                 .fill(null)

--- a/projects/dex-ui/src/pages/Wells.tsx
+++ b/projects/dex-ui/src/pages/Wells.tsx
@@ -81,7 +81,7 @@ export const Wells = () => {
           </TabButton>
         </Item>
       </StyledRow>
-      <Table>
+      <StyledTable>
         {tab === 0 ? (
           <THead>
             <TableRow>
@@ -150,10 +150,14 @@ export const Wells = () => {
             </>
           )}
         </TBody>
-      </Table>
+      </StyledTable>
     </Page>
   );
 };
+
+const StyledTable = styled(Table)`
+  overflow: auto;
+`;
 
 const TableRow = styled(Row)`
   @media (max-width: ${size.mobile}) {

--- a/projects/dex-ui/src/queries/GetSiloAPY.graphql
+++ b/projects/dex-ui/src/queries/GetSiloAPY.graphql
@@ -1,0 +1,13 @@
+query BeanstalkSiloLatestAPY {
+  siloYields(first: 1, orderBy: season, orderDirection: desc) {
+    id
+    season
+    zeroSeedBeanAPY
+    twoSeedBeanAPY
+    fourSeedBeanAPY
+    threeSeedBeanAPY
+    threePointTwoFiveSeedBeanAPY
+    fourPointFiveSeedBeanAPY
+    beansPerSeasonEMA
+  }
+}

--- a/projects/dex-ui/src/settings/development.ts
+++ b/projects/dex-ui/src/settings/development.ts
@@ -5,6 +5,7 @@ export const DevSettings: DexSettings = {
   AQUIFER_ADDRESS: import.meta.env.VITE_AQUIFER_ADDRESS,
   SUBGRAPH_URL: "https://graph.node.bean.money/subgraphs/name/basin",
   // SUBGRAPH_URL: "http://127.0.0.1:8000/subgraphs/name/beanstalk-wells",
+  BEANSTALK_SUBGRAPH_URL: "https://graph.node.bean.money/subgraphs/name/beanstalk",
   WELLS_ORIGIN_BLOCK: parseInt(import.meta.env.VITE_WELLS_ORIGIN_BLOCK) || 17977922,
   LOAD_HISTORY_FROM_GRAPH: !!parseInt(import.meta.env.VITE_LOAD_HISTORY_FROM_GRAPH) || false
 };

--- a/projects/dex-ui/src/settings/index.ts
+++ b/projects/dex-ui/src/settings/index.ts
@@ -11,6 +11,7 @@ export type DexSettings = {
   PRODUCTION: boolean;
   AQUIFER_ADDRESS: Address;
   SUBGRAPH_URL: string;
+  BEANSTALK_SUBGRAPH_URL: string;
   WELLS_ORIGIN_BLOCK: number;
   LOAD_HISTORY_FROM_GRAPH: boolean;
   NETLIFY_CONTEXT?: string;

--- a/projects/dex-ui/src/settings/production.ts
+++ b/projects/dex-ui/src/settings/production.ts
@@ -4,6 +4,7 @@ export const ProdSettings: DexSettings = {
   PRODUCTION: true,
   AQUIFER_ADDRESS: import.meta.env.VITE_AQUIFER_ADDRESS,
   SUBGRAPH_URL: "https://graph.node.bean.money/subgraphs/name/basin",
+  BEANSTALK_SUBGRAPH_URL: "https://graph.node.bean.money/subgraphs/name/beanstalk",
   WELLS_ORIGIN_BLOCK: 17977922,
   LOAD_HISTORY_FROM_GRAPH: true
 };

--- a/projects/dex-ui/src/utils/addresses.ts
+++ b/projects/dex-ui/src/utils/addresses.ts
@@ -1,0 +1,7 @@
+/// All addresses are in lowercase for consistency
+
+/// Well LP Tokens
+export const BEANETH_ADDRESS = "0xbea0e11282e2bb5893bece110cf199501e872bad";
+
+/// Pump Addresses
+export const BEANETH_MULTIPUMP_ADDRESS = "0xba510f10e3095b83a0f33aa9ad2544e22570a87c";

--- a/projects/dex-ui/src/utils/addresses.tsx
+++ b/projects/dex-ui/src/utils/addresses.tsx
@@ -1,1 +1,0 @@
-export const BEANETH_ADDRESS = "0xbea0e11282e2bb5893bece110cf199501e872bad";

--- a/projects/dex-ui/src/utils/addresses.tsx
+++ b/projects/dex-ui/src/utils/addresses.tsx
@@ -1,0 +1,1 @@
+export const BEANETH_ADDRESS = "0xbea0e11282e2bb5893bece110cf199501e872bad";

--- a/projects/dex-ui/src/utils/format.ts
+++ b/projects/dex-ui/src/utils/format.ts
@@ -1,6 +1,6 @@
 import { Token, TokenValue } from "@beanstalk/sdk";
 
-type NumberPrimitive = string | number | TokenValue | undefined;
+type NumberPrimitive = string | number | TokenValue | undefined | null;
 
 /**
  * We can for the most part use TokenValue.toHuman("short"),
@@ -15,13 +15,13 @@ export const formatNum = (
     maxDecimals?: number;
   }
 ) => {
-  if (val === undefined) return options?.defaultValue || "-.--";
+  if (val === undefined || val === null) return options?.defaultValue || "-.--";
 
   const normalised = val instanceof TokenValue ? val.toHuman() : val.toString();
 
   return Number(normalised).toLocaleString("en-US", {
-    minimumFractionDigits: 0 || options?.minDecimals,
-    maximumFractionDigits: 2 || options?.maxDecimals
+    minimumFractionDigits: options?.minDecimals || 0,
+    maximumFractionDigits: options?.maxDecimals || 2
   });
 };
 
@@ -32,6 +32,28 @@ export const formatUSD = (
   }
 ) => {
   return `$${formatNum(val || TokenValue.ZERO, { minDecimals: 2, maxDecimals: 2, ...options })}`;
+};
+
+const normaliseAsTokenValue = (val: NumberPrimitive) => {
+  if (val instanceof TokenValue) return val;
+  const num = val ? (typeof val === "string" ? Number(val) : val) : 0;
+  return TokenValue.ZERO.add(num);
+};
+
+/**
+ * Formats a number as a percentage.
+ * - If value to format is 0.01, it will be formatted as 1.00%.
+ * - If value is undefined, it will be formatted as "--%" or options.defaultValue.
+ * - If value is < (0.0001) (0.01%), it will be formatted as "<0.01%"
+ */
+export const formatPercent = (val: NumberPrimitive, options?: { defaultValue: string }) => {
+  if (!val) return `${options?.defaultValue || "--"}%`;
+
+  const pct = normaliseAsTokenValue(val).mul(100);
+
+  if (pct.lt(0.01)) return "<0.01%";
+
+  return `${formatNum(pct, { minDecimals: 2, maxDecimals: 2, ...options })}%`;
 };
 
 const TokenSymbolMap = {

--- a/projects/dex-ui/src/utils/ui/useLagLoading.ts
+++ b/projects/dex-ui/src/utils/ui/useLagLoading.ts
@@ -4,15 +4,14 @@ import { useEffect, useRef, useState } from "react";
  * Purpose of this hook is to prevent loading indicators
  * from flashing due to fast load times
  */
-
 export const useLagLoading = (_loading: boolean, _lagTime?: number) => {
   const mountTime = useRef(Date.now());
-  const [loading, setDataLoading] = useState(true);
-
-  const lagTime = _lagTime || 300;
+  const [loading, setDataLoading] = useState(_loading);
+  
+  const lagTime = _lagTime || 500;
 
   useEffect(() => {
-    if (_loading || !loading) return;
+    if (!_loading) return;
 
     const now = Date.now();
     const diff = Math.abs(mountTime.current - now);

--- a/projects/dex-ui/src/utils/ui/useLagLoading.ts
+++ b/projects/dex-ui/src/utils/ui/useLagLoading.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from "react";
+
+export const useLagLoading = (_loading: boolean, _lagTime?: number) => {
+  const mountTime = useRef(Date.now());
+  const [loading, setDataLoading] = useState(true);
+
+  const lagTime = _lagTime || 300;
+
+  useEffect(() => {
+    if (_loading || !loading) return;
+
+    const now = Date.now();
+    const diff = Math.abs(mountTime.current - now);
+
+    const run = async () => {
+      if (diff > lagTime) {
+        setDataLoading(false);
+      } else {
+        const remaining = lagTime - diff;
+        setTimeout(() => {
+          setDataLoading(false);
+        }, remaining);
+      }
+    };
+
+    run();
+  }, [loading, _loading, mountTime, lagTime]);
+
+  return loading;
+};

--- a/projects/dex-ui/src/utils/ui/useLagLoading.ts
+++ b/projects/dex-ui/src/utils/ui/useLagLoading.ts
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 
+/**
+ * Purpose of this hook is to prevent loading indicators
+ * from flashing due to fast load times
+ */
+
 export const useLagLoading = (_loading: boolean, _lagTime?: number) => {
   const mountTime = useRef(Date.now());
   const [loading, setDataLoading] = useState(true);

--- a/projects/dex-ui/src/wells/apyFetcher.ts
+++ b/projects/dex-ui/src/wells/apyFetcher.ts
@@ -1,0 +1,72 @@
+import { TokenValue } from "@beanstalk/sdk";
+import { Log } from "src/utils/logger";
+import { BeanstalkSiloLatestApyDocument } from "src/generated/graph/graphql";
+import { fetchFromSubgraphRequest } from "./subgraphFetch";
+
+export type SiloAPYResult = {
+  id: string;
+  season: number;
+  zeroSeedBeanAPY: TokenValue;
+  twoSeedBeanAPY: TokenValue;
+  threeSeedBeanAPY: TokenValue;
+  threePointTwoFiveSeedBeanAPY: TokenValue;
+  fourSeedBeanAPY: TokenValue;
+  fourPointFiveSeedBeanAPY: TokenValue;
+  beansPerSeasonEMA: TokenValue;
+};
+
+const defaultResult: SiloAPYResult = {
+  id: "",
+  season: 0,
+  zeroSeedBeanAPY: TokenValue.ZERO,
+  twoSeedBeanAPY: TokenValue.ZERO,
+  fourSeedBeanAPY: TokenValue.ZERO,
+  threeSeedBeanAPY: TokenValue.ZERO,
+  threePointTwoFiveSeedBeanAPY: TokenValue.ZERO,
+  fourPointFiveSeedBeanAPY: TokenValue.ZERO,
+  beansPerSeasonEMA: TokenValue.ZERO
+};
+
+const normalise = (data: string | number) => {
+  return TokenValue.ZERO.add(parseFloat(typeof data === "string" ? data : data.toString()));
+};
+
+const fetchAPYFromSubgraph = async () => {
+  Log.module("SiloAPYData").debug("Loading APY data from Graph");
+  const fetch = await fetchFromSubgraphRequest(BeanstalkSiloLatestApyDocument, undefined, { useBeanstalkSubgraph: true });
+
+  const result = await fetch()
+    .then((response) => {
+      if (!response.siloYields.length) return { ...defaultResult };
+
+      return response.siloYields.reduce<SiloAPYResult>(
+        (_, datum) => {
+          return {
+            id: datum.id,
+            season: datum.season,
+            zeroSeedBeanAPY: normalise(datum.zeroSeedBeanAPY),
+            twoSeedBeanAPY: normalise(datum.twoSeedBeanAPY),
+            fourSeedBeanAPY: normalise(datum.fourSeedBeanAPY),
+            threeSeedBeanAPY: normalise(datum.threeSeedBeanAPY),
+            threePointTwoFiveSeedBeanAPY: normalise(datum.threePointTwoFiveSeedBeanAPY),
+            fourPointFiveSeedBeanAPY: normalise(datum.fourPointFiveSeedBeanAPY),
+            beansPerSeasonEMA: normalise(datum.beansPerSeasonEMA)
+          };
+        },
+        { ...defaultResult }
+      );
+    })
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    .catch((e) => {
+      // console.error("FAILED TO FETCH SILO APYS: ", e);
+      return { ...defaultResult };
+    });
+
+  Log.module("SiloAPYData").debug("result: ", result);
+
+  return result;
+};
+
+export const loadSiloAPYData = async () => {
+  return fetchAPYFromSubgraph();
+};

--- a/projects/dex-ui/src/wells/chartDataLoader.ts
+++ b/projects/dex-ui/src/wells/chartDataLoader.ts
@@ -1,10 +1,12 @@
 import { BeanstalkSDK } from "@beanstalk/sdk";
 import { fetchFromSubgraphRequest } from "./subgraphFetch";
 import { Well } from "@beanstalk/sdk/Wells";
-import { GetWellChartDataDocument } from "src/generated/graph/graphql";
+import { GetWellChartDataDocument, GetWellChartDataQuery } from "src/generated/graph/graphql";
 import { Log } from "src/utils/logger";
 
-const loadFromGraph = async (sdk: BeanstalkSDK, well: Well, timePeriod: string) => {
+export type IWellHourlySnapshot = NonNullable<GetWellChartDataQuery["well"]>["hourlySnapshots"][number];
+
+const loadFromGraph = async (sdk: BeanstalkSDK, well: Well, timePeriod: string): Promise<IWellHourlySnapshot[]> => {
   if (!well) return [];
 
   Log.module("wellChartData").debug("Loading chart data from Graph");
@@ -13,7 +15,7 @@ const loadFromGraph = async (sdk: BeanstalkSDK, well: Well, timePeriod: string) 
   const HISTORY_DAYS_AGO_BLOCK_TIMESTAMP =
     HISTORY_DAYS === 0 ? 0 : Math.floor(new Date(Date.now() - HISTORY_DAYS * 24 * 60 * 60 * 1000).getTime() / 1000);
 
-  let results: any[] = [];
+  let results: IWellHourlySnapshot[] = [];
   let goToNextPage: boolean = false;
   let nextPage: number = 0;
   let skipAmount: number = 0;
@@ -39,8 +41,7 @@ const loadFromGraph = async (sdk: BeanstalkSDK, well: Well, timePeriod: string) 
     } else {
       goToNextPage = false;
     }
-  }
-
+  } 
   while (goToNextPage === true);
 
   return results;

--- a/projects/dex-ui/src/wells/subgraphFetch.ts
+++ b/projects/dex-ui/src/wells/subgraphFetch.ts
@@ -2,9 +2,19 @@ import request from "graphql-request";
 import { type TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { Settings } from "src/settings";
 
+type AdditionalSubgraphFetchOptions = {
+  useBeanstalkSubgraph?: boolean;
+};
+
 export function fetchFromSubgraphRequest<TResult, TVariables>(
   document: TypedDocumentNode<TResult, TVariables>,
-  variables: TVariables extends Record<string, never> ? undefined : TVariables
+  variables: TVariables extends Record<string, never> ? undefined : TVariables,
+  options?: AdditionalSubgraphFetchOptions
 ): () => Promise<TResult> {
-  return async () => request(Settings.SUBGRAPH_URL, document, variables ? variables : undefined);
+  return async () =>
+    request(
+      options?.useBeanstalkSubgraph ? Settings.BEANSTALK_SUBGRAPH_URL : Settings.SUBGRAPH_URL,
+      document,
+      variables ? variables : undefined
+    );
 }

--- a/projects/dex-ui/src/wells/useBeanstalkSiloAPYs.tsx
+++ b/projects/dex-ui/src/wells/useBeanstalkSiloAPYs.tsx
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import { loadSiloAPYData } from "./apyFetcher";
+import { Well } from "@beanstalk/sdk/Wells";
+import { useCallback } from "react";
+import { useBeanstalkSiloWhitelist } from "./useBeanstalkSiloWhitelist";
+
+const useBeanstalkSiloAPYs = () => {
+  const { getSeedsWithWell } = useBeanstalkSiloWhitelist();
+
+  const query = useQuery(
+    ["wells", "APYs"],
+    async () => {
+      const data = await loadSiloAPYData();
+      return data;
+    },
+    {
+      staleTime: 1000 * 60,
+      refetchOnWindowFocus: false
+    }
+  );
+
+  const getSiloAPYWithWell = useCallback(
+    (well: Well | undefined) => {
+      const seeds = getSeedsWithWell(well);
+      if (!query.data || !seeds) return undefined;
+
+      const d = query.data;
+
+      switch (seeds) {
+        case 0:
+          return d.zeroSeedBeanAPY;
+        case 2:
+          return d.twoSeedBeanAPY;
+        case 3:
+          return d.threeSeedBeanAPY;
+        case 3.5:
+          return d.threePointTwoFiveSeedBeanAPY;
+        case 4:
+          return d.fourSeedBeanAPY;
+        case 4.5:
+          return d.fourPointFiveSeedBeanAPY;
+        default:
+          return undefined;
+      }
+    },
+    [getSeedsWithWell, query.data]
+  );
+
+  return {
+    ...query,
+    getSiloAPYWithWell
+  };
+};
+
+export default useBeanstalkSiloAPYs;

--- a/projects/dex-ui/src/wells/useBeanstalkSiloAPYs.tsx
+++ b/projects/dex-ui/src/wells/useBeanstalkSiloAPYs.tsx
@@ -4,7 +4,7 @@ import { Well } from "@beanstalk/sdk/Wells";
 import { useCallback } from "react";
 import { useBeanstalkSiloWhitelist } from "./useBeanstalkSiloWhitelist";
 
-const useBeanstalkSiloAPYs = () => {
+export const useBeanstalkSiloAPYs = () => {
   const { getSeedsWithWell } = useBeanstalkSiloWhitelist();
 
   const query = useQuery(
@@ -51,5 +51,3 @@ const useBeanstalkSiloAPYs = () => {
     getSiloAPYWithWell
   };
 };
-
-export default useBeanstalkSiloAPYs;

--- a/projects/dex-ui/src/wells/useBeanstalkSiloAPYs.tsx
+++ b/projects/dex-ui/src/wells/useBeanstalkSiloAPYs.tsx
@@ -4,6 +4,7 @@ import { Well } from "@beanstalk/sdk/Wells";
 import { useCallback } from "react";
 import { useBeanstalkSiloWhitelist } from "./useBeanstalkSiloWhitelist";
 
+// TODO: BIP39 will change the APYs we get from the subgraph
 export const useBeanstalkSiloAPYs = () => {
   const { getSeedsWithWell } = useBeanstalkSiloWhitelist();
 
@@ -24,20 +25,21 @@ export const useBeanstalkSiloAPYs = () => {
       const seeds = getSeedsWithWell(well);
       if (!query.data || !seeds) return undefined;
 
+      const seedsStr = parseFloat(seeds.toHuman()).toString();
       const d = query.data;
 
-      switch (seeds) {
-        case 0:
+      switch (seedsStr) {
+        case "0":
           return d.zeroSeedBeanAPY;
-        case 2:
+        case "2":
           return d.twoSeedBeanAPY;
-        case 3:
+        case "3":
           return d.threeSeedBeanAPY;
-        case 3.5:
+        case "3.5":
           return d.threePointTwoFiveSeedBeanAPY;
-        case 4:
+        case "4":
           return d.fourSeedBeanAPY;
-        case 4.5:
+        case "4.5":
           return d.fourPointFiveSeedBeanAPY;
         default:
           return undefined;

--- a/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
+++ b/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
@@ -1,11 +1,13 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { Well } from "@beanstalk/sdk/Wells";
 
 const WHITELIST_MAP = {
   /// BEANWETHCP2w (BEANETH LP)
   "0xbea0e11282e2bb5893bece110cf199501e872bad": {
     address: "0xBEA0e11282e2bB5893bEcE110cF199501e872bAd",
-    lpTokenAddress: "0xbea0e11282e2bb5893bece110cf199501e872bad"
+    lpTokenAddress: "0xbea0e11282e2bb5893bece110cf199501e872bad",
+    /// Can we make this mapping dynamic?
+    seeds: 4.5
   }
 };
 
@@ -13,12 +15,18 @@ const WHITELIST_MAP = {
 export const useBeanstalkSiloWhitelist = () => {
   const whitelistedAddresses = useMemo(() => Object.keys(WHITELIST_MAP), []);
 
-  const getIsWhitelisted = (well: Well | undefined) => {
+  const getIsWhitelisted = useCallback((well: Well | undefined) => {
     if (!well) return false;
     const wellAddress = well.address.toLowerCase();
 
     return wellAddress in WHITELIST_MAP;
-  };
+  }, []);
 
-  return { whitelist: whitelistedAddresses, getIsWhitelisted } as const;
+  const getSeedsWithWell = useCallback((well: Well | undefined) => {
+    const wellAddress = well?.address.toLowerCase();
+    const key = wellAddress as keyof typeof WHITELIST_MAP;
+    return WHITELIST_MAP?.[key]?.seeds || undefined;
+  }, []);
+
+  return { whitelist: whitelistedAddresses, getIsWhitelisted, getSeedsWithWell } as const;
 };

--- a/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
+++ b/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
@@ -14,31 +14,37 @@ const WHITELIST_MAP = {
   }
 };
 
-const functions = {
-  getIsWhitelisted: (well: Well | undefined) => {
-    if (!well) return false;
-    const wellAddress = well.address.toLowerCase();
 
-    return wellAddress in WHITELIST_MAP;
-  },
-  getSeedsWithWell: (well: Well | undefined) => {
-    const wellAddress = well?.address.toLowerCase();
-    const key = wellAddress as keyof typeof WHITELIST_MAP;
-    return WHITELIST_MAP?.[key]?.seeds || undefined;
-  },
-  getIsMultiPumpWell: (well: Well | undefined) => {
-    if (well) {
-      const wellAddress = well.address.toLowerCase();
-      const key = wellAddress as keyof typeof WHITELIST_MAP;
-      return WHITELIST_MAP?.[key]?.isMultiFlowPump || false;
-    }
-    return false;
-  }
+const getIsWhitelisted = (well: Well | undefined) => {
+  if (!well) return false;
+  const wellAddress = well.address.toLowerCase();
+
+  return wellAddress in WHITELIST_MAP;
 };
+
+const getSeedsWithWell = (well: Well | undefined) => {
+  const wellAddress = well?.address.toLowerCase();
+  const key = wellAddress as keyof typeof WHITELIST_MAP;
+  return WHITELIST_MAP?.[key]?.seeds || undefined;
+};
+
+const getIsMultiPumpWell = (well: Well | undefined) => {
+  if (well) {
+    const wellAddress = well.address.toLowerCase();
+    const key = wellAddress as keyof typeof WHITELIST_MAP;
+    return WHITELIST_MAP?.[key]?.isMultiFlowPump || false;
+  }
+  return false;
+}
 
 /// set of wells that are whitelisted for the Beanstalk silo
 export const useBeanstalkSiloWhitelist = () => {
   const whitelistedAddresses = useMemo(() => Object.keys(WHITELIST_MAP), []);
 
-  return { whitelist: whitelistedAddresses, ...functions } as const;
+  return { 
+    whitelist: whitelistedAddresses, 
+    getIsWhitelisted, 
+    getSeedsWithWell, 
+    getIsMultiPumpWell
+  } as const;
 };

--- a/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
+++ b/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
@@ -15,13 +15,13 @@ const WHITELIST_MAP = {
 };
 
 const functions = {
-  isWhitelisted: (well: Well | undefined) => {
+  getIsWhitelisted: (well: Well | undefined) => {
     if (!well) return false;
     const wellAddress = well.address.toLowerCase();
 
     return wellAddress in WHITELIST_MAP;
   },
-  seedsWithWell: (well: Well | undefined) => {
+  getSeedsWithWell: (well: Well | undefined) => {
     const wellAddress = well?.address.toLowerCase();
     const key = wellAddress as keyof typeof WHITELIST_MAP;
     return WHITELIST_MAP?.[key]?.seeds || undefined;

--- a/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
+++ b/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
@@ -1,11 +1,10 @@
 import { useMemo } from "react";
 import { Well } from "@beanstalk/sdk/Wells";
-
-const BEANETH = "0xbea0e11282e2bb5893bece110cf199501e872bad";
+import { BEANETH_ADDRESS } from "src/utils/addresses";
 
 const WHITELIST_MAP = {
   /// BEANWETHCP2w (BEANETH LP)
-  [`${BEANETH}`]: {
+  [`${BEANETH_ADDRESS}`]: {
     address: "0xBEA0e11282e2bB5893bEcE110cF199501e872bAd",
     /// better way to do this?
     isMultiFlowPump: true,
@@ -13,7 +12,6 @@ const WHITELIST_MAP = {
     seeds: 4.5
   }
 };
-
 
 const getIsWhitelisted = (well: Well | undefined) => {
   if (!well) return false;
@@ -35,16 +33,16 @@ const getIsMultiPumpWell = (well: Well | undefined) => {
     return WHITELIST_MAP?.[key]?.isMultiFlowPump || false;
   }
   return false;
-}
+};
 
 /// set of wells that are whitelisted for the Beanstalk silo
 export const useBeanstalkSiloWhitelist = () => {
   const whitelistedAddresses = useMemo(() => Object.keys(WHITELIST_MAP), []);
 
-  return { 
-    whitelist: whitelistedAddresses, 
-    getIsWhitelisted, 
-    getSeedsWithWell, 
+  return {
+    whitelist: whitelistedAddresses,
+    getIsWhitelisted,
+    getSeedsWithWell,
     getIsMultiPumpWell
   } as const;
 };

--- a/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
+++ b/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 import { Well } from "@beanstalk/sdk/Wells";
 import { BEANETH_MULTIPUMP_ADDRESS } from "src/utils/addresses";
 import useSdk from "src/utils/sdk/useSdk";
-import { TokenValue } from "@beanstalk/sdk";
 
 export const useBeanstalkSiloWhitelist = () => {
   const sdk = useSdk();
@@ -11,7 +10,7 @@ export const useBeanstalkSiloWhitelist = () => {
     (well: Well | undefined) => {
       if (!well?.lpToken) return false;
       const token = sdk.tokens.findByAddress(well.lpToken.address);
-      return token && sdk.tokens.siloWhitelist.has(token);
+      return Boolean(token && sdk.tokens.siloWhitelist.has(token));
     },
     [sdk.tokens]
   );

--- a/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
+++ b/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
@@ -1,13 +1,38 @@
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import { Well } from "@beanstalk/sdk/Wells";
+
+const BEANETH = "0xbea0e11282e2bb5893bece110cf199501e872bad";
 
 const WHITELIST_MAP = {
   /// BEANWETHCP2w (BEANETH LP)
-  "0xbea0e11282e2bb5893bece110cf199501e872bad": {
+  [`${BEANETH}`]: {
     address: "0xBEA0e11282e2bB5893bEcE110cF199501e872bAd",
-    lpTokenAddress: "0xbea0e11282e2bb5893bece110cf199501e872bad",
+    /// better way to do this?
+    isMultiFlowPump: true,
     /// Can we make this mapping dynamic?
     seeds: 4.5
+  }
+};
+
+const functions = {
+  isWhitelisted: (well: Well | undefined) => {
+    if (!well) return false;
+    const wellAddress = well.address.toLowerCase();
+
+    return wellAddress in WHITELIST_MAP;
+  },
+  seedsWithWell: (well: Well | undefined) => {
+    const wellAddress = well?.address.toLowerCase();
+    const key = wellAddress as keyof typeof WHITELIST_MAP;
+    return WHITELIST_MAP?.[key]?.seeds || undefined;
+  },
+  getIsMultiPumpWell: (well: Well | undefined) => {
+    if (well) {
+      const wellAddress = well.address.toLowerCase();
+      const key = wellAddress as keyof typeof WHITELIST_MAP;
+      return WHITELIST_MAP?.[key]?.isMultiFlowPump || false;
+    }
+    return false;
   }
 };
 
@@ -15,18 +40,5 @@ const WHITELIST_MAP = {
 export const useBeanstalkSiloWhitelist = () => {
   const whitelistedAddresses = useMemo(() => Object.keys(WHITELIST_MAP), []);
 
-  const getIsWhitelisted = useCallback((well: Well | undefined) => {
-    if (!well) return false;
-    const wellAddress = well.address.toLowerCase();
-
-    return wellAddress in WHITELIST_MAP;
-  }, []);
-
-  const getSeedsWithWell = useCallback((well: Well | undefined) => {
-    const wellAddress = well?.address.toLowerCase();
-    const key = wellAddress as keyof typeof WHITELIST_MAP;
-    return WHITELIST_MAP?.[key]?.seeds || undefined;
-  }, []);
-
-  return { whitelist: whitelistedAddresses, getIsWhitelisted, getSeedsWithWell } as const;
+  return { whitelist: whitelistedAddresses, ...functions } as const;
 };

--- a/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
+++ b/projects/dex-ui/src/wells/useBeanstalkSiloWhitelist.ts
@@ -4,12 +4,6 @@ import { BEANETH_MULTIPUMP_ADDRESS } from "src/utils/addresses";
 import useSdk from "src/utils/sdk/useSdk";
 import { TokenValue } from "@beanstalk/sdk";
 
-export type BeanstalkSiloWhitelistConfig = {
-  address: string;
-  isMultiFlowPump: boolean;
-  seeds: TokenValue;
-};
-
 export const useBeanstalkSiloWhitelist = () => {
   const sdk = useSdk();
 

--- a/projects/dex-ui/src/wells/useMultiFlowPumpTWAReserves.tsx
+++ b/projects/dex-ui/src/wells/useMultiFlowPumpTWAReserves.tsx
@@ -1,0 +1,73 @@
+import useSdk from "src/utils/sdk/useSdk";
+import { useWells } from "./useWells";
+import { useBeanstalkSiloWhitelist } from "./useBeanstalkSiloWhitelist";
+
+import { multicall } from "@wagmi/core";
+import MULTI_PUMP_ABI from "src/abi/MULTI_PUMP_ABI.json";
+import { TokenValue } from "@beanstalk/sdk";
+import { useQuery } from "@tanstack/react-query";
+
+export const useMultiFlowPumpTWAReserves = () => {
+  const { data: wells } = useWells();
+  const { getIsMultiPumpWell } = useBeanstalkSiloWhitelist();
+  const sdk = useSdk();
+
+  const query = useQuery(
+    ["wells", "multiFlowPumpTWAReserves"],
+    async () => {
+      const whitelistedWells = (wells || []).filter((well) => getIsMultiPumpWell(well));
+
+      const [{ timestamp: seasonTimestamp }, ...wellOracleSnapshots] = await Promise.all([
+        sdk.contracts.beanstalk.time(),
+        ...whitelistedWells.map((well) => sdk.contracts.beanstalk.wellOracleSnapshot(well.address))
+      ]);
+
+      const calls: any[] = whitelistedWells.reduce<any[]>((prev, well, idx) => {
+        well.pumps?.forEach((pump) => {
+          prev.push({
+            address: pump.address as `0x{string}`,
+            abi: MULTI_PUMP_ABI,
+            functionName: "readTwaReserves",
+            args: [well.address, wellOracleSnapshots[idx], seasonTimestamp.toString(), "0x"]
+          });
+        });
+
+        return prev;
+      }, []);
+
+      const twaReservesResult: any[] = await multicall({ contracts: calls });
+
+      const mapping: Record<string, any[]> = {};
+      let index = 0;
+
+      whitelistedWells.forEach((well) => {
+        const twa = [TokenValue.ZERO, TokenValue.ZERO];
+        const numPumps = well.pumps?.length || 1;
+
+        well.pumps?.forEach((_pump) => {
+          const twaResult = twaReservesResult[index];
+          const token1 = well.tokens?.[0];
+          const token2 = well.tokens?.[1];
+
+          const reserves = twaResult["twaReserves"];
+
+          if (token1 && token2 && reserves.length === 2) {
+            twa[0] = twa[0].add(TokenValue.fromBlockchain(reserves[0], token1.decimals));
+            twa[1] = twa[1].add(TokenValue.fromBlockchain(reserves[1], token2.decimals));
+          }
+          index += 1;
+        });
+
+        mapping[well.address] = [twa[0].div(numPumps), twa[1].div(numPumps)];
+      });
+      return mapping;
+    },
+    {
+      staleTime: 1000 * 60,
+      enabled: !!wells?.length,
+      refetchOnMount: true
+    }
+  );
+
+  return query;
+};

--- a/projects/dex-ui/src/wells/useMultiFlowPumpTWAReserves.tsx
+++ b/projects/dex-ui/src/wells/useMultiFlowPumpTWAReserves.tsx
@@ -6,6 +6,8 @@ import { multicall } from "@wagmi/core";
 import MULTI_PUMP_ABI from "src/abi/MULTI_PUMP_ABI.json";
 import { TokenValue } from "@beanstalk/sdk";
 import { useQuery } from "@tanstack/react-query";
+import { Well } from "@beanstalk/sdk/Wells";
+import { useCallback } from "react";
 
 export const useMultiFlowPumpTWAReserves = () => {
   const { data: wells } = useWells();
@@ -37,7 +39,7 @@ export const useMultiFlowPumpTWAReserves = () => {
 
       const twaReservesResult: any[] = await multicall({ contracts: calls });
 
-      const mapping: Record<string, any[]> = {};
+      const mapping: Record<string, TokenValue[]> = {};
       let index = 0;
 
       whitelistedWells.forEach((well) => {
@@ -58,6 +60,7 @@ export const useMultiFlowPumpTWAReserves = () => {
           index += 1;
         });
 
+        /// In case there is more than one pump, divide the reserves by the number of pumps
         mapping[well.address] = [twa[0].div(numPumps), twa[1].div(numPumps)];
       });
       return mapping;
@@ -69,5 +72,14 @@ export const useMultiFlowPumpTWAReserves = () => {
     }
   );
 
-  return query;
+  const getTWAReservesWithWell = useCallback(
+    (well: Well | undefined) => {
+      if (!well || !query.data) return undefined;
+
+      return query.data[well.address];
+    },
+    [query.data]
+  );
+
+  return { ...query, getTWAReservesWithWell };
 };

--- a/projects/dex-ui/src/wells/useMultiFlowPumpTWAReserves.tsx
+++ b/projects/dex-ui/src/wells/useMultiFlowPumpTWAReserves.tsx
@@ -61,7 +61,8 @@ export const useMultiFlowPumpTWAReserves = () => {
         });
 
         /// In case there is more than one pump, divide the reserves by the number of pumps
-        mapping[well.address] = [twa[0].div(numPumps), twa[1].div(numPumps)];
+        /// Is this how to handle the case where there is more than one pump?
+        mapping[well.address.toLowerCase()] = [twa[0].div(numPumps), twa[1].div(numPumps)];
       });
       return mapping;
     },
@@ -76,7 +77,7 @@ export const useMultiFlowPumpTWAReserves = () => {
     (well: Well | undefined) => {
       if (!well || !query.data) return undefined;
 
-      return query.data[well.address];
+      return query.data[well.address.toLowerCase()];
     },
     [query.data]
   );

--- a/projects/dex-ui/src/wells/useWellChartData.tsx
+++ b/projects/dex-ui/src/wells/useWellChartData.tsx
@@ -1,13 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 
 import useSdk from "src/utils/sdk/useSdk";
-import { loadChartData } from "./chartDataLoader";
+import { IWellHourlySnapshot, loadChartData } from "./chartDataLoader";
 import { Well } from "@beanstalk/sdk/Wells";
 
 const useWellChartData = (well: Well, timePeriod: string) => {
   const sdk = useSdk();
 
-  return useQuery(
+  return useQuery<IWellHourlySnapshot[]>(
     ["wells", "wellChartData", well.address],
     async () => {
       const data = await loadChartData(sdk, well, timePeriod);

--- a/projects/examples/src/wells/deployNewWell.ts
+++ b/projects/examples/src/wells/deployNewWell.ts
@@ -1,0 +1,29 @@
+import { provider, signer } from "../setup";
+import { WellsSDK, Well, Aquifer, WellFunction } from "@beanstalk/sdk-wells";
+
+const ACCOUNTS = [
+  ["0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"],
+  ["0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d", "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"]
+];
+
+const DEPLOYED_AQUIFER_ADDRESS = "0xBA51AAAA95aeEFc1292515b36D86C51dC7877773";
+
+main().catch((e) => {
+  console.log("[ERROR]:", e);
+});
+
+async function main() {
+  const wellsSDK = new WellsSDK({ provider, signer });
+
+  const wellTokens = [wellsSDK.tokens.BEAN, wellsSDK.tokens.WETH];
+
+  const aquifer = new Aquifer(wellsSDK, DEPLOYED_AQUIFER_ADDRESS);
+
+  console.log("Building Well w/ Constant Product Well Function...");
+  const wellFunction = await WellFunction.BuildConstantProduct(wellsSDK);
+
+  console.log("Deploying Well with Aquifer: ", aquifer.address);
+  const well = await Well.DeployViaAquifer(wellsSDK, aquifer, wellTokens, wellFunction, []);
+
+  console.log("[DEPLOYED WELL/address]", well.address);
+}

--- a/projects/examples/src/wells/deployNewWell.ts
+++ b/projects/examples/src/wells/deployNewWell.ts
@@ -1,11 +1,6 @@
 import { provider, signer } from "../setup";
 import { WellsSDK, Well, Aquifer, WellFunction } from "@beanstalk/sdk-wells";
 
-const ACCOUNTS = [
-  ["0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"],
-  ["0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d", "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"]
-];
-
 const DEPLOYED_AQUIFER_ADDRESS = "0xBA51AAAA95aeEFc1292515b36D86C51dC7877773";
 
 main().catch((e) => {


### PR DESCRIPTION
In This PR:

- Replaced Well Trading Fees column for Yield & added tooltip on hover
- Updated tooltips throughout the app
- modified Reserves component formatting
- added well reserve tooltip displaying well reserves & TWAReserves if the well has MultiFlowPump
- Disallow user from inputting an amount greater than their balance in 'Remove Liquidity'
- Fixed a bug where duplicated data would cause the chart to display nothing
- other minor housekeeping / formatting / typing along the way
- Fix charts Y data points overflowing chart heights

To deploy an empty well for testing, you can run npx ts-node projects/examples/src/wells/deployNewWell.ts from the project root folder