### PR TITLE
Bean subgraph: Correct pool cross handler

### DIFF
--- a/projects/subgraph-bean/src/utils/Bean.ts
+++ b/projects/subgraph-bean/src/utils/Bean.ts
@@ -159,16 +159,22 @@ export function getBeanTokenAddress(blockNumber: BigInt): string {
 export function updateBeanSupplyPegPercent(blockNumber: BigInt): void {
   if (blockNumber < BigInt.fromString("15278082")) {
     let bean = loadBean(BEAN_ERC20_V1.toHexString());
+    let lpSupply = ZERO_BD;
 
-    let pool = loadOrCreatePool(BEAN_WETH_V1.toHexString(), blockNumber);
+    let pool = Pool.load(BEAN_WETH_V1.toHexString());
+    if (pool != null) {
+      lpSupply = lpSupply.plus(toDecimal(pool.reserves[1]));
+    }
 
-    let lpSupply = toDecimal(pool.reserves[1]);
+    pool = Pool.load(BEAN_3CRV_V1.toHexString());
+    if (pool != null) {
+      lpSupply = lpSupply.plus(toDecimal(pool.reserves[0]));
+    }
 
-    pool = loadOrCreatePool(BEAN_3CRV_V1.toHexString(), blockNumber);
-    lpSupply = lpSupply.plus(toDecimal(pool.reserves[0]));
-
-    pool = loadOrCreatePool(BEAN_LUSD_V1.toHexString(), blockNumber);
-    lpSupply = lpSupply.plus(toDecimal(pool.reserves[0]));
+    pool = Pool.load(BEAN_LUSD_V1.toHexString());
+    if (pool != null) {
+      lpSupply = lpSupply.plus(toDecimal(pool.reserves[0]));
+    }
 
     bean.supplyInPegLP = lpSupply.div(toDecimal(bean.supply));
     bean.save();

--- a/projects/subgraph-bean/src/utils/Cross.ts
+++ b/projects/subgraph-bean/src/utils/Cross.ts
@@ -47,8 +47,8 @@ export function checkPoolCross(pool: string, timestamp: BigInt, blockNumber: Big
   let poolInfo = loadOrCreatePool(pool, blockNumber);
   let token = poolInfo.bean;
   let bean = loadBean(token);
-  let poolHourly = loadOrCreatePoolHourlySnapshot(token, timestamp, BigInt.fromI32(bean.lastSeason));
-  let poolDaily = loadOrCreatePoolDailySnapshot(token, timestamp, blockNumber);
+  let poolHourly = loadOrCreatePoolHourlySnapshot(pool, timestamp, BigInt.fromI32(bean.lastSeason));
+  let poolDaily = loadOrCreatePoolDailySnapshot(pool, timestamp, blockNumber);
 
   if (oldPrice >= ONE_BD && newPrice < ONE_BD) {
     let cross = loadOrCreatePoolCross(poolInfo.crosses, pool, timestamp);


### PR DESCRIPTION
When checking for a pool cross, the wrong value was being passed in to load the snapshots. Pass the pool address instead of the bean address to correct.