### PR TITLE
BIP-X: BDV Decrease

### DIFF
--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -83,6 +83,12 @@ contract ConvertFacet is ReentrancyGuard {
         * and decreaseBDV is true */
         (toToken, fromToken, toAmount, fromAmount, account, decreaseBDV) = LibConvert.convert(convertData);
 
+        console.log("Inside ConvertFacet");
+        console.log("Convert decoded");
+        console.log("toToken: %s", toToken);
+        console.log("fromToken: %s", fromToken);
+        console.log("toAmount: %s", toAmount);
+        console.log("fromAmount: %s", fromAmount);
         console.log("decreaseBDV: %s", decreaseBDV);
         console.log("account convert is called on: %s", account);
         
@@ -108,8 +114,6 @@ contract ConvertFacet is ReentrancyGuard {
         // calculate the bdv of the new deposit
         uint256 newBdv = LibTokenSilo.beanDenominatedValue(toToken, toAmount);
 
-        console.log("fromBdv: %s", fromBdv);
-
         // if we have used the anti-lambda-lamda convert, 
         // we need to decrease the bdv of the new deposit
         if(decreaseBDV) {
@@ -119,6 +123,8 @@ contract ConvertFacet is ReentrancyGuard {
 	        toBdv = newBdv > fromBdv ? newBdv : fromBdv;
         }
 
+        console.log("withdrawTokensCompleted. Results:");
+        console.log("fromBdv: %s", fromBdv);
         console.log("toBdv Final: %s", toBdv);
 
         toStem = _depositTokensForConvert(toToken, toAmount, toBdv, grownStalk, account);
@@ -137,8 +143,7 @@ contract ConvertFacet is ReentrancyGuard {
             stems.length == amounts.length,
             "Convert: stems, amounts are diff lengths."
         );
-        console.log("Inside _withdrawTokens");
-        console.log("BDV not yet updated");
+        console.log("Inside ConvertFacet _withdrawTokens");
         LibSilo.AssetsRemoved memory a;
         uint256 depositBDV;
         uint256 i = 0;
@@ -240,7 +245,7 @@ contract ConvertFacet is ReentrancyGuard {
         require(bdv > 0 && amount > 0, "Convert: BDV or amount is 0.");
        
         console.log("Inside ConverFacet: _depositTokensForConvert");
-        console.log("Account to deposit: %s", account);
+        console.log("Account to deposit to: %s", account);
         console.log("bdv to re add: %s", bdv);
         console.log("amount of tokens to re add: %s", amount);
 
@@ -255,8 +260,6 @@ contract ConvertFacet is ReentrancyGuard {
         // grownStalk = uint256(LibTokenSilo.calculateStalkFromStemAndBdv(IERC20(token), _stemTip, bdv));
 
         (grownStalk, stem) = LibTokenSilo.calculateGrownStalkAndStem(token, grownStalk, bdv);
-
-        console.log("grownStalk: %s", grownStalk);
 
         LibSilo.mintStalk(account, bdv.mul(LibTokenSilo.stalkIssuedPerBdv(token)).add(grownStalk));
 

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -74,14 +74,20 @@ contract ConvertFacet is ReentrancyGuard {
         nonReentrant
         returns (int96 toStem, uint256 fromAmount, uint256 toAmount, uint256 fromBdv, uint256 toBdv)
     {
-        address toToken; address fromToken; uint256 grownStalk; address account;
+        address toToken; address fromToken; uint256 grownStalk; address account; bool decreaseBDV;
 
-        (toToken, fromToken, toAmount, fromAmount) = LibConvert.convert(convertData);
+        /** @dev account and decreaseBDV are initialized at the start of LibConvert.convert()
+        * as address(0) and false respectively and remain that way if a convert is not anti-lambda-lambda
+        * If it is anti-lambda, account is the address of the account to update the deposit
+        * and decreaseBDV is true */
+        (toToken, fromToken, toAmount, fromAmount, account, decreaseBDV) = LibConvert.convert(convertData);
         
         require(fromAmount > 0, "Convert: From amount is 0.");
 
-        LibSilo._mow(msg.sender, fromToken);
-        LibSilo._mow(msg.sender, toToken);
+        if(account == address(0)) account = msg.sender;
+
+        LibSilo._mow(account, fromToken);
+        LibSilo._mow(account, toToken);
 
         (grownStalk, fromBdv) = _withdrawTokens(
             fromToken,
@@ -93,11 +99,17 @@ contract ConvertFacet is ReentrancyGuard {
         // calculate the bdv of the new deposit
         uint256 newBdv = LibTokenSilo.beanDenominatedValue(toToken, toAmount);
 
-        toBdv = newBdv > fromBdv ? newBdv : fromBdv;
+        // if we have used the anti-lambda-lamda convert, 
+        // we need to decrease the bdv of the new deposit
+        if(decreaseBDV) {
+	        toBdv = newBdv;
+        } else {
+	        toBdv = newBdv > fromBdv ? newBdv : fromBdv;
+        }
 
         toStem = _depositTokensForConvert(toToken, toAmount, toBdv, grownStalk);
 
-        emit Convert(msg.sender, fromToken, toToken, fromAmount, toAmount);
+        emit Convert(account, fromToken, toToken, fromAmount, toAmount);
     }
 
     function _withdrawTokens(

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -84,10 +84,10 @@ contract ConvertFacet is ReentrancyGuard {
         if(account == address(0)) account = msg.sender;
 
         LibSilo._mow(account, fromToken);
-        // if the fromToken and toToken are different, mow the toToken as well
+        // If the fromToken and toToken are different, mow the toToken as well.
         if (fromToken != toToken) LibSilo._mow(account, toToken);
 
-        // withdraw the tokens from the deposit 
+        // Withdraw the tokens from the deposit.
         (grownStalk, fromBdv) = _withdrawTokens(
             fromToken,
             stems,
@@ -96,10 +96,10 @@ contract ConvertFacet is ReentrancyGuard {
             account
         );
 
-        // calculate the bdv of the new deposit
+        // Calculate the bdv of the new deposit.
         uint256 newBdv = LibTokenSilo.beanDenominatedValue(toToken, toAmount);
 
-        // if `decreaseBDV` flag is not enabled, set toBDV to the max of the two bdvs
+        // If `decreaseBDV` flag is not enabled, set toBDV to the max of the two bdvs.
         toBdv = (newBdv > fromBdv || decreaseBDV)  ? newBdv : fromBdv;
 
         toStem = _depositTokensForConvert(toToken, toAmount, toBdv, grownStalk, account);

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -417,9 +417,6 @@ contract TokenSilo is Silo {
      * @notice Get the total amount of `token` currently Deposited in the Silo across all users.
      */
     function getTotalDeposited(address token) external view returns (uint256) {
-        console.log("getTotalDeposited");
-        console.log(token);
-        console.log(s.siloBalances[token].deposited);
         return s.siloBalances[token].deposited;
     }
 
@@ -427,9 +424,6 @@ contract TokenSilo is Silo {
      * @notice Get the total bdv of `token` currently Deposited in the Silo across all users.
      */
     function getTotalDepositedBdv(address token) external view returns (uint256) {
-        console.log("getTotalDepositedBdv");
-        console.log(token);
-        console.log(s.siloBalances[token].depositedBdv);
         return s.siloBalances[token].depositedBdv;
     }
 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -417,6 +417,9 @@ contract TokenSilo is Silo {
      * @notice Get the total amount of `token` currently Deposited in the Silo across all users.
      */
     function getTotalDeposited(address token) external view returns (uint256) {
+        console.log("getTotalDeposited");
+        console.log(token);
+        console.log(s.siloBalances[token].deposited);
         return s.siloBalances[token].deposited;
     }
 
@@ -424,6 +427,9 @@ contract TokenSilo is Silo {
      * @notice Get the total bdv of `token` currently Deposited in the Silo across all users.
      */
     function getTotalDepositedBdv(address token) external view returns (uint256) {
+        console.log("getTotalDepositedBdv");
+        console.log(token);
+        console.log(s.siloBalances[token].depositedBdv);
         return s.siloBalances[token].depositedBdv;
     }
 

--- a/protocol/contracts/libraries/Convert/LibConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibConvert.sol
@@ -33,10 +33,16 @@ library LibConvert {
             address tokenOut,
             address tokenIn,
             uint256 amountOut,
-            uint256 amountIn
+            uint256 amountIn,
+            address account,
+            bool decreaseBDV
         )
     {
         LibConvertData.ConvertKind kind = convertData.convertKind();
+
+        // added return values initialization
+        bool decreaseBDV = false;
+        address account = address(0);
 
         if (kind == LibConvertData.ConvertKind.BEANS_TO_CURVE_LP) {
             (tokenOut, tokenIn, amountOut, amountIn) = LibCurveConvert
@@ -62,6 +68,11 @@ library LibConvert {
         } else if (kind == LibConvertData.ConvertKind.UNRIPE_TO_RIPE) {
             (tokenOut, tokenIn, amountOut, amountIn) = LibChopConvert
                 .convertUnripeToRipe(convertData);
+        // Anti-Lambda -> Lambda
+        } else if (kind == LibConvertData.ConvertKind.ANTI_LAMBDA_LAMBDA) {
+	        (tokenOut, tokenIn, amountOut, amountIn, account) = LibLambdaConvert
+                .antiConvert(convertData);
+	        decreaseBDV = true;
         } else {
             revert("Convert: Invalid payload");
         }
@@ -81,6 +92,7 @@ library LibConvert {
             return LibCurveConvert.beansToPeg(C.CURVE_BEAN_METAPOOL);
         
         // Lambda -> Lambda
+        // Anti-Lambda -> Lambda
         if (tokenIn == tokenOut) 
             return type(uint256).max;
 
@@ -137,6 +149,7 @@ library LibConvert {
             return LibUnripeConvert.getLPAmountOut(amountIn);
         
         // Lambda -> Lambda
+        // Anti-Lambda -> Lambda
         if (tokenIn == tokenOut)
             return amountIn;
 

--- a/protocol/contracts/libraries/Convert/LibConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibConvert.sol
@@ -12,6 +12,7 @@ import {LibWellConvert} from "./LibWellConvert.sol";
 import {LibChopConvert} from "./LibChopConvert.sol";
 import {LibWell} from "contracts/libraries/Well/LibWell.sol";
 import {C} from "contracts/C.sol";
+import "hardhat/console.sol";
 
 /**
  * @title LibConvert
@@ -41,8 +42,10 @@ library LibConvert {
         LibConvertData.ConvertKind kind = convertData.convertKind();
 
         // added return values initialization
-        bool decreaseBDV = false;
-        address account = address(0);
+        // may not be necessary and cause compiler to 'lock' them to false and 0
+        // decleared in return params 
+        // bool decreaseBDV = false;
+        // address account = address(0);
 
         if (kind == LibConvertData.ConvertKind.BEANS_TO_CURVE_LP) {
             (tokenOut, tokenIn, amountOut, amountIn) = LibCurveConvert
@@ -70,6 +73,7 @@ library LibConvert {
                 .convertUnripeToRipe(convertData);
         // Anti-Lambda -> Lambda
         } else if (kind == LibConvertData.ConvertKind.ANTI_LAMBDA_LAMBDA) {
+            console.log("Anti-Lambda -> Lambda Triggered");
 	        (tokenOut, tokenIn, amountOut, amountIn, account) = LibLambdaConvert
                 .antiConvert(convertData);
 	        decreaseBDV = true;

--- a/protocol/contracts/libraries/Convert/LibConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibConvert.sol
@@ -12,11 +12,10 @@ import {LibWellConvert} from "./LibWellConvert.sol";
 import {LibChopConvert} from "./LibChopConvert.sol";
 import {LibWell} from "contracts/libraries/Well/LibWell.sol";
 import {C} from "contracts/C.sol";
-import "hardhat/console.sol";
 
 /**
  * @title LibConvert
- * @author Publius
+ * @author Publius, deadmanwalking
  */
 library LibConvert {
     using SafeMath for uint256;
@@ -65,9 +64,7 @@ library LibConvert {
         } else if (kind == LibConvertData.ConvertKind.UNRIPE_TO_RIPE) {
             (tokenOut, tokenIn, amountOut, amountIn) = LibChopConvert
                 .convertUnripeToRipe(convertData);
-        // Anti-Lambda -> Lambda
         } else if (kind == LibConvertData.ConvertKind.ANTI_LAMBDA_LAMBDA) {
-            console.log("Anti-Lambda -> Lambda Triggered In LibConvert");
 	        (tokenOut, tokenIn, amountOut, amountIn, account) = LibLambdaConvert
                 .antiConvert(convertData);
 	        decreaseBDV = true;
@@ -89,7 +86,7 @@ library LibConvert {
         if (tokenIn == C.BEAN && tokenOut == C.CURVE_BEAN_METAPOOL)
             return LibCurveConvert.beansToPeg(C.CURVE_BEAN_METAPOOL);
         
-        // Lambda -> Lambda
+        // Lambda -> Lambda &
         // Anti-Lambda -> Lambda
         if (tokenIn == tokenOut) 
             return type(uint256).max;
@@ -146,7 +143,7 @@ library LibConvert {
         if (tokenIn == C.UNRIPE_BEAN && tokenOut == C.UNRIPE_LP)
             return LibUnripeConvert.getLPAmountOut(amountIn);
         
-        // Lambda -> Lambda
+        // Lambda -> Lambda &
         // Anti-Lambda -> Lambda
         if (tokenIn == tokenOut)
             return amountIn;

--- a/protocol/contracts/libraries/Convert/LibConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibConvert.sol
@@ -41,12 +41,6 @@ library LibConvert {
     {
         LibConvertData.ConvertKind kind = convertData.convertKind();
 
-        // added return values initialization
-        // may not be necessary and cause compiler to 'lock' them to false and 0
-        // decleared in return params 
-        // bool decreaseBDV = false;
-        // address account = address(0);
-
         if (kind == LibConvertData.ConvertKind.BEANS_TO_CURVE_LP) {
             (tokenOut, tokenIn, amountOut, amountIn) = LibCurveConvert
                 .convertBeansToLP(convertData);
@@ -73,7 +67,7 @@ library LibConvert {
                 .convertUnripeToRipe(convertData);
         // Anti-Lambda -> Lambda
         } else if (kind == LibConvertData.ConvertKind.ANTI_LAMBDA_LAMBDA) {
-            console.log("Anti-Lambda -> Lambda Triggered");
+            console.log("Anti-Lambda -> Lambda Triggered In LibConvert");
 	        (tokenOut, tokenIn, amountOut, amountIn, account) = LibLambdaConvert
                 .antiConvert(convertData);
 	        decreaseBDV = true;

--- a/protocol/contracts/libraries/Convert/LibConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibConvert.sol
@@ -26,6 +26,10 @@ library LibConvert {
      * @notice Takes in bytes object that has convert input data encoded into it for a particular convert for
      * a specified pool and returns the in and out convert amounts and token addresses and bdv
      * @param convertData Contains convert input parameters for a specified convert
+     * note account and decreaseBDV variables are initialized at the start
+     * as address(0) and false respectively and remain that way if a convert is not anti-lambda-lambda
+     * If it is anti-lambda, account is the address of the account to update the deposit
+     * and decreaseBDV is true
      */
     function convert(bytes calldata convertData)
         external
@@ -65,9 +69,8 @@ library LibConvert {
             (tokenOut, tokenIn, amountOut, amountIn) = LibChopConvert
                 .convertUnripeToRipe(convertData);
         } else if (kind == LibConvertData.ConvertKind.ANTI_LAMBDA_LAMBDA) {
-	        (tokenOut, tokenIn, amountOut, amountIn, account) = LibLambdaConvert
+	        (tokenOut, tokenIn, amountOut, amountIn, account, decreaseBDV) = LibLambdaConvert
                 .antiConvert(convertData);
-	        decreaseBDV = true;
         } else {
             revert("Convert: Invalid payload");
         }

--- a/protocol/contracts/libraries/Convert/LibConvertData.sol
+++ b/protocol/contracts/libraries/Convert/LibConvertData.sol
@@ -68,6 +68,7 @@ library LibConvertData {
     }
 
     /// @notice Decoder for the antiLambdaConvert
+    /// @dev contains an additional address parameter for the account to update the deposit
     function antiLambdaConvert(bytes memory self)
         internal
         pure

--- a/protocol/contracts/libraries/Convert/LibConvertData.sol
+++ b/protocol/contracts/libraries/Convert/LibConvertData.sol
@@ -17,7 +17,8 @@ library LibConvertData {
         LAMBDA_LAMBDA,
         BEANS_TO_WELL_LP,
         WELL_LP_TO_BEANS,
-        UNRIPE_TO_RIPE
+        UNRIPE_TO_RIPE,
+        ANTI_LAMBDA_LAMBDA
     }
 
     /// @notice Decoder for the Convert Enum
@@ -65,4 +66,15 @@ library LibConvertData {
     {
         (, amount, token) = abi.decode(self, (ConvertKind, uint256, address));
     }
+
+    /// @notice Decoder for the antiLambdaConvert
+    function antiLambdaConvert(bytes memory self)
+        internal
+        pure
+        returns (uint256 amount, address token , address account)
+    {
+        (, amount, token , account) = abi.decode(self, (ConvertKind, uint256, address , address));
+    }
+
+
 }

--- a/protocol/contracts/libraries/Convert/LibConvertData.sol
+++ b/protocol/contracts/libraries/Convert/LibConvertData.sol
@@ -69,12 +69,14 @@ library LibConvertData {
 
     /// @notice Decoder for the antiLambdaConvert
     /// @dev contains an additional address parameter for the account to update the deposit
+    /// and a bool to indicate whether to decrease the bdv
     function antiLambdaConvert(bytes memory self)
         internal
         pure
-        returns (uint256 amount, address token , address account)
+        returns (uint256 amount, address token , address account, bool decreaseBDV)
     {
         (, amount, token , account) = abi.decode(self, (ConvertKind, uint256, address , address));
+        decreaseBDV = true;
     }
 
 

--- a/protocol/contracts/libraries/Convert/LibLambdaConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibLambdaConvert.sol
@@ -7,11 +7,15 @@ import {LibConvertData} from "./LibConvertData.sol";
 
 /**
  * @title LibLambdaConvert
- * @author Publius
+ * @author Publius, deadmanwalking
  */
 library LibLambdaConvert {
     using LibConvertData for bytes;
-    
+
+    /**
+     * @notice This function returns the full input for use in lambda convert
+     * In lambda convert, the account converts from and to the same token.
+     */
     function convert(bytes memory convertData)
         internal
         pure
@@ -27,6 +31,12 @@ library LibLambdaConvert {
         amountOut = amountIn;
     }
 
+    /** 
+     * @notice This function returns the full input for use in anti-lamda convert
+     * In anti lamda convert, any user can convert on behalf of an account 
+     * to update a dedposit's bdv.
+     * This is why the additional account parameter is returned.
+     */
     function antiConvert(bytes memory convertData)
         internal
         pure

--- a/protocol/contracts/libraries/Convert/LibLambdaConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibLambdaConvert.sol
@@ -26,4 +26,20 @@ library LibLambdaConvert {
         tokenOut = tokenIn;
         amountOut = amountIn;
     }
+
+    function antiConvert(bytes memory convertData)
+        internal
+        pure
+        returns (
+            address tokenOut,
+            address tokenIn,
+            uint256 amountOut,
+            uint256 amountIn,
+            address account
+        )
+    {
+        (amountIn, tokenIn , account) = convertData.antiLambdaConvert();
+        tokenOut = tokenIn;
+        amountOut = amountIn;
+    }
 }

--- a/protocol/contracts/libraries/Convert/LibLambdaConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibLambdaConvert.sol
@@ -34,8 +34,8 @@ library LibLambdaConvert {
     /** 
      * @notice This function returns the full input for use in anti-lamda convert
      * In anti lamda convert, any user can convert on behalf of an account 
-     * to update a dedposit's bdv.
-     * This is why the additional account parameter is returned.
+     * to update a deposit's bdv.
+     * This is why the additional 'account' parameter is returned.
      */
     function antiConvert(bytes memory convertData)
         internal
@@ -45,10 +45,11 @@ library LibLambdaConvert {
             address tokenIn,
             uint256 amountOut,
             uint256 amountIn,
-            address account
+            address account,
+            bool decreaseBDV
         )
     {
-        (amountIn, tokenIn , account) = convertData.antiLambdaConvert();
+        (amountIn, tokenIn, account, decreaseBDV) = convertData.antiLambdaConvert();
         tokenOut = tokenIn;
         amountOut = amountIn;
     }

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -258,8 +258,7 @@ library LibTokenSilo {
             );
             return removedBDV;
         }
-        // Full remove
-        // deletes the deposit from storage
+        // Full remove, deletes the deposit from storage
         if (crateAmount > 0) delete s.a[account].deposits[depositId];
         // SafeMath unnecessary b/c crateBDV <= type(uint128).max
         s.a[account].mowStatuses[token].bdv = s.a[account].mowStatuses[token].bdv.sub(

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -90,7 +90,6 @@ library LibTokenSilo {
         console.log("Inside LibTokenSilo: incrementTotalDeposited");
         console.log("total token balance in silo: %s", s.siloBalances[token].deposited);
         console.log("total bdv balance in silo of token: %s", s.siloBalances[token].depositedBdv);
-
     }
 
     /**
@@ -186,7 +185,7 @@ library LibTokenSilo {
         uint256 bdv,
         Transfer transferType
     ) internal {
-        console.log("Inside LibTokenSilo: addDepositToAccount last step");
+        console.log("Inside LibTokenSilo: addDepositToAccount");
         console.log("account: %s", account);
         console.log("token: %s", token);
         console.log("amount: %s", amount);
@@ -203,9 +202,9 @@ library LibTokenSilo {
         s.a[account].deposits[depositId].bdv = 
             s.a[account].deposits[depositId].bdv.add(bdv.toUint128());
 
-        console.log("Inside LibTokenSilo: addDepositToAccount DEPOSIT ID FINAL VALUES");
-        console.log("amount: %s", s.a[account].deposits[depositId].amount);
-        console.log("bdv: %s", s.a[account].deposits[depositId].bdv);
+        console.log("Inside LibTokenSilo: addDepositToAccount DEPOSIT ID FINAL VALUES FROM STORAGE");
+        console.log("new deposit amount: %s", s.a[account].deposits[depositId].amount);
+        console.log("new depsosit bdv: %s", s.a[account].deposits[depositId].bdv);
         
         // update the mow status (note: mow status is per token, not per depositId)
         // SafeMath not necessary as the bdv is already checked to be <= type(uint128).max
@@ -285,7 +284,6 @@ library LibTokenSilo {
         // deletes the deposit from storage
         if (crateAmount > 0) delete s.a[account].deposits[depositId];
         console.log("LibTokenSilo: Deposit Removed fully");
-
         // SafeMath unnecessary b/c crateBDV <= type(uint128).max
         s.a[account].mowStatuses[token].bdv = s.a[account].mowStatuses[token].bdv.sub(
             uint128(crateBDV)

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -14,7 +14,6 @@ import "contracts/libraries/LibSafeMath128.sol";
 import "contracts/libraries/LibSafeMathSigned128.sol";
 import "contracts/libraries/LibSafeMathSigned96.sol";
 import "contracts/libraries/LibBytes.sol";
-import "hardhat/console.sol";
 
 
 /**
@@ -76,10 +75,6 @@ library LibTokenSilo {
      * @dev Increment the total amount and bdv of `token` deposited in the Silo.
      */
     function incrementTotalDeposited(address token, uint256 amount, uint256 bdv) internal {
-        console.log("Inside LibTokenSilo: incrementTotalDeposited");
-        console.log("to add token: %s", token);
-        console.log("to add amount: %s", amount);
-        console.log("to add bdv: %s", bdv);
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.siloBalances[token].deposited = s.siloBalances[token].deposited.add(
             amount.toUint128()
@@ -87,9 +82,6 @@ library LibTokenSilo {
         s.siloBalances[token].depositedBdv = s.siloBalances[token].depositedBdv.add(
             bdv.toUint128()
         );
-        console.log("Inside LibTokenSilo: incrementTotalDeposited");
-        console.log("total token balance in silo: %s", s.siloBalances[token].deposited);
-        console.log("total bdv balance in silo of token: %s", s.siloBalances[token].depositedBdv);
     }
 
     /**
@@ -103,9 +95,6 @@ library LibTokenSilo {
         s.siloBalances[token].depositedBdv = s.siloBalances[token].depositedBdv.sub(
             bdv.toUint128()
         );
-        console.log("Inside LibTokenSilo: decrementTotalDeposited");
-        console.log("total token balance in silo: %s", s.siloBalances[token].deposited);
-        console.log("total bdv balance in silo of token: %s", s.siloBalances[token].depositedBdv);
     }
 
     /**
@@ -185,11 +174,6 @@ library LibTokenSilo {
         uint256 bdv,
         Transfer transferType
     ) internal {
-        console.log("Inside LibTokenSilo: addDepositToAccount");
-        console.log("account: %s", account);
-        console.log("token: %s", token);
-        console.log("amount: %s", amount);
-        console.log("bdv: %s", bdv);
         AppStorage storage s = LibAppStorage.diamondStorage();
         uint256 depositId = LibBytes.packAddressAndStem(
             token,
@@ -201,10 +185,6 @@ library LibTokenSilo {
             s.a[account].deposits[depositId].amount.add(amount.toUint128());
         s.a[account].deposits[depositId].bdv = 
             s.a[account].deposits[depositId].bdv.add(bdv.toUint128());
-
-        console.log("Inside LibTokenSilo: addDepositToAccount DEPOSIT ID FINAL VALUES FROM STORAGE");
-        console.log("new deposit amount: %s", s.a[account].deposits[depositId].amount);
-        console.log("new depsosit bdv: %s", s.a[account].deposits[depositId].bdv);
         
         // update the mow status (note: mow status is per token, not per depositId)
         // SafeMath not necessary as the bdv is already checked to be <= type(uint128).max
@@ -276,14 +256,11 @@ library LibTokenSilo {
             s.a[account].mowStatuses[token].bdv = s.a[account].mowStatuses[token].bdv.sub(
                 removedBDV.toUint128()
             );
-            console.log("LibTokenSilo: Deposit Removed Partially");
-            console.log("LibTokenSilo: removedBDV: %s", removedBDV);
             return removedBDV;
         }
         // Full remove
         // deletes the deposit from storage
         if (crateAmount > 0) delete s.a[account].deposits[depositId];
-        console.log("LibTokenSilo: Deposit Removed fully");
         // SafeMath unnecessary b/c crateBDV <= type(uint128).max
         s.a[account].mowStatuses[token].bdv = s.a[account].mowStatuses[token].bdv.sub(
             uint128(crateBDV)

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -14,6 +14,7 @@ import "contracts/libraries/LibSafeMath128.sol";
 import "contracts/libraries/LibSafeMathSigned128.sol";
 import "contracts/libraries/LibSafeMathSigned96.sol";
 import "contracts/libraries/LibBytes.sol";
+import "hardhat/console.sol";
 
 
 /**
@@ -75,6 +76,10 @@ library LibTokenSilo {
      * @dev Increment the total amount and bdv of `token` deposited in the Silo.
      */
     function incrementTotalDeposited(address token, uint256 amount, uint256 bdv) internal {
+        console.log("Inside LibTokenSilo: incrementTotalDeposited");
+        console.log("to add token: %s", token);
+        console.log("to add amount: %s", amount);
+        console.log("to add bdv: %s", bdv);
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.siloBalances[token].deposited = s.siloBalances[token].deposited.add(
             amount.toUint128()
@@ -82,6 +87,10 @@ library LibTokenSilo {
         s.siloBalances[token].depositedBdv = s.siloBalances[token].depositedBdv.add(
             bdv.toUint128()
         );
+        console.log("Inside LibTokenSilo: incrementTotalDeposited");
+        console.log("total token balance in silo: %s", s.siloBalances[token].deposited);
+        console.log("total bdv balance in silo of token: %s", s.siloBalances[token].depositedBdv);
+
     }
 
     /**
@@ -95,6 +104,9 @@ library LibTokenSilo {
         s.siloBalances[token].depositedBdv = s.siloBalances[token].depositedBdv.sub(
             bdv.toUint128()
         );
+        console.log("Inside LibTokenSilo: decrementTotalDeposited");
+        console.log("total token balance in silo: %s", s.siloBalances[token].deposited);
+        console.log("total bdv balance in silo of token: %s", s.siloBalances[token].depositedBdv);
     }
 
     /**
@@ -174,6 +186,11 @@ library LibTokenSilo {
         uint256 bdv,
         Transfer transferType
     ) internal {
+        console.log("Inside LibTokenSilo: addDepositToAccount last step");
+        console.log("account: %s", account);
+        console.log("token: %s", token);
+        console.log("amount: %s", amount);
+        console.log("bdv: %s", bdv);
         AppStorage storage s = LibAppStorage.diamondStorage();
         uint256 depositId = LibBytes.packAddressAndStem(
             token,
@@ -185,6 +202,10 @@ library LibTokenSilo {
             s.a[account].deposits[depositId].amount.add(amount.toUint128());
         s.a[account].deposits[depositId].bdv = 
             s.a[account].deposits[depositId].bdv.add(bdv.toUint128());
+
+        console.log("Inside LibTokenSilo: addDepositToAccount DEPOSIT ID FINAL VALUES");
+        console.log("amount: %s", s.a[account].deposits[depositId].amount);
+        console.log("bdv: %s", s.a[account].deposits[depositId].bdv);
         
         // update the mow status (note: mow status is per token, not per depositId)
         // SafeMath not necessary as the bdv is already checked to be <= type(uint128).max
@@ -256,11 +277,14 @@ library LibTokenSilo {
             s.a[account].mowStatuses[token].bdv = s.a[account].mowStatuses[token].bdv.sub(
                 removedBDV.toUint128()
             );
+            console.log("LibTokenSilo: Deposit Removed Partially");
+            console.log("LibTokenSilo: removedBDV: %s", removedBDV);
             return removedBDV;
         }
         // Full remove
+        // deletes the deposit from storage
         if (crateAmount > 0) delete s.a[account].deposits[depositId];
-
+        console.log("LibTokenSilo: Deposit Removed fully");
 
         // SafeMath unnecessary b/c crateBDV <= type(uint128).max
         s.a[account].mowStatuses[token].bdv = s.a[account].mowStatuses[token].bdv.sub(

--- a/protocol/contracts/mocks/mockFacets/MockConvertFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockConvertFacet.sol
@@ -24,9 +24,11 @@ contract MockConvertFacet is ConvertFacet {
         address token,
         int96[] memory stems,
         uint256[] memory amounts,
-        uint256 maxTokens
+        uint256 maxTokens,
+        address account
     ) external {
-        (uint256 stalkRemoved, uint256 bdvRemoved) = _withdrawTokens(token, stems, amounts, maxTokens);
+        if (account == address(0)) account = msg.sender;
+        (uint256 stalkRemoved, uint256 bdvRemoved) = _withdrawTokens(token, stems, amounts, maxTokens, account);
         
         
         emit MockConvert(stalkRemoved, bdvRemoved);
@@ -36,9 +38,11 @@ contract MockConvertFacet is ConvertFacet {
         address token, 
         uint256 amount, 
         uint256 bdv, 
-        uint256 grownStalk
+        uint256 grownStalk,
+        address account
     ) external {
-        _depositTokensForConvert(token, amount, bdv, grownStalk);
+        if (account == address(0)) account = msg.sender;
+        _depositTokensForConvert(token, amount, bdv, grownStalk, account);
     }
 
     function convertInternalE(

--- a/protocol/contracts/mocks/mockFacets/MockConvertFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockConvertFacet.sol
@@ -49,10 +49,12 @@ contract MockConvertFacet is ConvertFacet {
         address toToken,
         address fromToken,
         uint256 toAmount,
-        uint256 fromAmount
+        uint256 fromAmount,
+        address account,
+        bool decreaseBDV
     ) {
         IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
-        (toToken, fromToken, toAmount, fromAmount) = LibConvert.convert(
+        (toToken, fromToken, toAmount, fromAmount , account , decreaseBDV) = LibConvert.convert(
             convertData
         );
         IERC20(toToken).safeTransfer(msg.sender, toAmount);

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -42,10 +42,12 @@ contract MockSiloFacet is SiloFacet {
         return amount - 10;
     }
 
+    /// @dev Mocks a constant BDV of 1e6
     function newMockBDV() external pure returns (uint256) {
         return 1e6;
     }
 
+    /// @dev Mocks a decrease in constant BDV of 
     function newMockBDVDecrease() external pure returns (uint256) {
         return 0.9e6;
     }

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -47,11 +47,12 @@ contract MockSiloFacet is SiloFacet {
         return 1e6;
     }
 
-    /// @dev Mocks a decrease in constant BDV of 
+    /// @dev Mocks a decrease in constant BDV
     function newMockBDVDecrease() external pure returns (uint256) {
         return 0.9e6;
     }
 
+    /// @dev Mocks an increase in constant BDV
     function newMockBDVIncrease() external pure returns (uint256) {
         return 1.1e6;
     }

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -52,6 +52,10 @@ contract MockSiloFacet is SiloFacet {
         return 0.9e6;
     }
 
+    function newMockBDVIncrease() external pure returns (uint256) {
+        return 1.1e6;
+    }
+
     /// @dev changes bdv selector of token
     function mockChangeBDVSelector(address token, bytes4 selector) external {
         AppStorage storage s = LibAppStorage.diamondStorage();

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -42,6 +42,14 @@ contract MockSiloFacet is SiloFacet {
         return amount - 10;
     }
 
+    function newMockBDV() external pure returns (uint256) {
+        return 1e6;
+    }
+
+    function newMockBDVDecrease() external pure returns (uint256) {
+        return 0.9e6;
+    }
+
     /// @dev changes bdv selector of token
     function mockChangeBDVSelector(address token, bytes4 selector) external {
         AppStorage storage s = LibAppStorage.diamondStorage();

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -36,6 +36,17 @@ contract MockSiloFacet is SiloFacet {
     function mockBDVIncrease(uint256 amount) external pure returns (uint256) {
         return amount.mul(3).div(2);
     }
+    
+    /// @dev Mocks a BDV decrease of 10
+    function mockBDVDecrease(uint256 amount) external pure returns (uint256) {
+        return amount - 10;
+    }
+
+    /// @dev changes bdv selector of token
+    function mockChangeBDVSelector(address token, bytes4 selector) external {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        s.ss[token].selector = selector;
+    }
 
     function mockUnripeLPDeposit(uint256 t, uint32 _s, uint256 amount, uint256 bdv) external {
         _mowLegacy(msg.sender);
@@ -381,4 +392,5 @@ contract MockSiloFacet is SiloFacet {
             amount.toUint128()
         );
     }
+
 }

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -96,313 +96,313 @@ describe('Convert', function () {
     await revertToSnapshot(snapshotId);
   });
   //  -------------------------------- OLD TESTS --------------------------------
-  // describe('Withdraw For Convert', async function () {
-  //   describe("Revert", async function () {
-  //     it('diff lengths', async function () {
-  //       await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100'], '100')).to.be.revertedWith('Convert: stems, amounts are diff lengths.')
-  //     });
+  describe('Withdraw For Convert', async function () {
+    describe("Revert", async function () {
+      it('diff lengths', async function () {
+        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100'], '100' , userAddress)).to.be.revertedWith('Convert: stems, amounts are diff lengths.')
+      });
 
-  //     it('crate balance too low', async function () {
-  //       //params are token, stem, amounts, maxtokens
-  //       // await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.') //before moving to constants for the original 4 whitelisted tokens (post replant), this test would revert with 'Silo: Crate balance too low.', but now it reverts with 'Must line up with season' because there's no constant seeds amount hardcoded in for this test token
-  //       await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.')
-  //     });
+      it('crate balance too low', async function () {
+        //params are token, stem, amounts, maxtokens
+        // await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.') //before moving to constants for the original 4 whitelisted tokens (post replant), this test would revert with 'Silo: Crate balance too low.', but now it reverts with 'Must line up with season' because there's no constant seeds amount hardcoded in for this test token
+        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150', userAddress)).to.be.revertedWith('Silo: Crate balance too low.')
+      });
 
-  //     it('not enough removed', async function () {
-  //       await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['100'], '150')).to.be.revertedWith('Convert: Not enough tokens removed.')
-  //     });
-  //   })
+      it('not enough removed', async function () {
+        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['100'], '150', userAddress)).to.be.revertedWith('Convert: Not enough tokens removed.')
+      });
+    })
 
-  //   //this test withdraws from stem index of 2, verifies they are removed correctly and stalk balances updated
-  //   describe("Withdraw 1 Crate", async function () {
-  //     beforeEach(async function () {
-  //       this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['100'], '100');
-  //     })
+    //this test withdraws from stem index of 2, verifies they are removed correctly and stalk balances updated
+    describe("Withdraw 1 Crate", async function () {
+      beforeEach(async function () {
+        this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['100'], '100', userAddress);
+      })
 
-  //     it('Emits event', async function () {
-  //       await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2], ['100'], '100', ['100']);
-  //       await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
-  //     })
+      it('Emits event', async function () {
+        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2], ['100'], '100', ['100']);
+        await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
+      })
 
-  //     it('Decrements totals', async function () {
-  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('100');
-  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('100');
-  //       expect(await this.silo.totalStalk()).to.equal('1000100');
-  //       //expect(await this.silo.totalSeeds()).to.equal('100');
-  //     })
+      it('Decrements totals', async function () {
+        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('100');
+        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('100');
+        expect(await this.silo.totalStalk()).to.equal('1000100');
+        //expect(await this.silo.totalSeeds()).to.equal('100');
+      })
 
-  //     it('Decrements balances', async function () {
-  //       expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
-  //       //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
-  //     })
+      it('Decrements balances', async function () {
+        expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
+      })
 
-  //     it('properly removes the crate', async function () {
-  //       let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+      it('properly removes the crate', async function () {
+        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
 
-  //       expect(deposit[0]).to.eq('100');
-  //       expect(deposit[1]).to.eq('100');
-  //       deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+        expect(deposit[0]).to.eq('100');
+        expect(deposit[1]).to.eq('100');
+        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
 
-  //       expect(deposit[0]).to.eq('0');
-  //       expect(deposit[1]).to.eq('0');
-  //     })
-  //   })
+        expect(deposit[0]).to.eq('0');
+        expect(deposit[1]).to.eq('0');
+      })
+    })
 
-  //   //this test withdraws from stem indexes of 2 and 1
-  //   describe("Withdraw 1 Crate 2 input", async function () {
-  //     beforeEach(async function () {
-  //       this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2', '1'], ['100', '100'], '100');
-  //     })
+    //this test withdraws from stem indexes of 2 and 1
+    describe("Withdraw 1 Crate 2 input", async function () {
+      beforeEach(async function () {
+        this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2', '1'], ['100', '100'], '100', userAddress);
+      })
 
-  //     it('Emits event', async function () {
-  //       await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2, 1], ['100', '0'], '100',['100', '0'] );
-  //       await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
-  //     })
+      it('Emits event', async function () {
+        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2, 1], ['100', '0'], '100',['100', '0'] );
+        await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
+      })
 
-  //     it('Decrements totals', async function () {
-  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('100');
-  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('100');
-  //       expect(await this.silo.totalStalk()).to.equal('1000100');
-  //       //expect(await this.silo.totalSeeds()).to.equal('100');
-  //     })
+      it('Decrements totals', async function () {
+        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('100');
+        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('100');
+        expect(await this.silo.totalStalk()).to.equal('1000100');
+        //expect(await this.silo.totalSeeds()).to.equal('100');
+      })
 
-  //     it('Decrements balances', async function () {
-  //       expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
-  //       //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
-  //     })
+      it('Decrements balances', async function () {
+        expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
+      })
 
-  //     it('properly removes the crate', async function () {
-  //       let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
-  //       expect(deposit[0]).to.eq('100');
-  //       expect(deposit[1]).to.eq('100');
-  //       deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
-  //       expect(deposit[0]).to.eq('0');
-  //       expect(deposit[1]).to.eq('0');
-  //     })
-  //   })
+      it('properly removes the crate', async function () {
+        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+        expect(deposit[0]).to.eq('100');
+        expect(deposit[1]).to.eq('100');
+        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+        expect(deposit[0]).to.eq('0');
+        expect(deposit[1]).to.eq('0');
+      })
+    })
 
-  //   //withdraws less than the full deposited amount from stem indexes of 2 and 1
-  //   describe("Withdraw 2 Crates exact", async function () {
-  //     beforeEach(async function () {
-  //       this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100', '50'], '150');
-  //     })
+    //withdraws less than the full deposited amount from stem indexes of 2 and 1
+    describe("Withdraw 2 Crates exact", async function () {
+      beforeEach(async function () {
+        this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100', '50'], '150', userAddress);
+      })
 
-  //     it('Emits event', async function () { 
-  //       await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '50'], '150', ['100', '50']);
+      it('Emits event', async function () { 
+        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '50'], '150', ['100', '50']);
 
-  //       await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('100', '150');
-  //     })
+        await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('100', '150');
+      })
 
-  //     it('Decrements totals', async function () {
-  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('50');
-  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('50');
-  //       expect(await this.silo.totalStalk()).to.equal('500000');
-  //       //expect(await this.silo.totalSeeds()).to.equal('50');
-  //     })
+      it('Decrements totals', async function () {
+        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('50');
+        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('50');
+        expect(await this.silo.totalStalk()).to.equal('500000');
+        //expect(await this.silo.totalSeeds()).to.equal('50');
+      })
 
-  //     it('Decrements balances', async function () {
-  //       expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
-  //       //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
-  //     })
+      it('Decrements balances', async function () {
+        expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
+      })
 
-  //     it('properly removes the crate', async function () {
-  //       let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
-  //       expect(deposit[0]).to.eq('0');
-  //       expect(deposit[1]).to.eq('0');
-  //       deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
-  //       expect(deposit[0]).to.eq('50');
-  //       expect(deposit[1]).to.eq('50');
-  //     })
-  //   })
+      it('properly removes the crate', async function () {
+        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+        expect(deposit[0]).to.eq('0');
+        expect(deposit[1]).to.eq('0');
+        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+        expect(deposit[0]).to.eq('50');
+        expect(deposit[1]).to.eq('50');
+      })
+    })
 
-  //   describe("Withdraw 2 Crates under", async function () {
-  //     beforeEach(async function () {
-  //       this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100', '100'], '150');
-  //     })
+    describe("Withdraw 2 Crates under", async function () {
+      beforeEach(async function () {
+        this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100', '100'], '150', userAddress);
+      })
 
-  //     it('Emits event', async function () { 
-  //       await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100','50'], '150', ['100','50']);
-  //       await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('100', '150');
-  //     })
+      it('Emits event', async function () { 
+        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100','50'], '150', ['100','50']);
+        await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('100', '150');
+      })
 
-  //     it('Decrements totals', async function () {
-  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('50');
-  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('50');
-  //       expect(await this.silo.totalStalk()).to.equal('500000');
-  //       //expect(await this.silo.totalSeeds()).to.equal('50');
-  //     })
+      it('Decrements totals', async function () {
+        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('50');
+        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('50');
+        expect(await this.silo.totalStalk()).to.equal('500000');
+        //expect(await this.silo.totalSeeds()).to.equal('50');
+      })
 
-  //     it('Decrements balances', async function () {
-  //       expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
-  //       //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
-  //     })
+      it('Decrements balances', async function () {
+        expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
+        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
+      })
 
-  //     it('properly removes the crate', async function () {
-  //       let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
-  //       expect(deposit[0]).to.eq('0');
-  //       expect(deposit[1]).to.eq('0');
-  //       deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
-  //       expect(deposit[0]).to.eq('50');
-  //       expect(deposit[1]).to.eq('50');
-  //     })
-  //   })
-  // })
+      it('properly removes the crate', async function () {
+        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+        expect(deposit[0]).to.eq('0');
+        expect(deposit[1]).to.eq('0');
+        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+        expect(deposit[0]).to.eq('50');
+        expect(deposit[1]).to.eq('50');
+      })
+    })
+  })
   
-  // describe('Deposit For Convert', async function () {
-  //   describe("Revert", async function () {
-  //     it("Reverts if BDV is 0", async function () {
-  //       await expect(this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '0', '100')).to.be.revertedWith("Convert: BDV or amount is 0.")
-  //     })
+  describe('Deposit For Convert', async function () {
+    describe("Revert", async function () {
+      it("Reverts if BDV is 0", async function () {
+        await expect(this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '0', '100', user2Address)).to.be.revertedWith("Convert: BDV or amount is 0.")
+      })
 
-  //     it("Reverts if amount is 0", async function () {
-  //       await expect(this.convert.connect(user2).depositForConvertE(this.siloToken.address, '0', '100', '100')).to.be.revertedWith("Convert: BDV or amount is 0.")
-  //     })
-  //   })
+      it("Reverts if amount is 0", async function () {
+        await expect(this.convert.connect(user2).depositForConvertE(this.siloToken.address, '0', '100', '100', user2Address)).to.be.revertedWith("Convert: BDV or amount is 0.")
+      })
+    })
 
-  //   describe('Deposit Tokens No Grown', async function () {
-  //     beforeEach(async function () {
-  //       this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '0');
-  //     });
+    describe('Deposit Tokens No Grown', async function () {
+      beforeEach(async function () {
+        this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '0', user2Address);
+      });
 
-  //     it('Emits event', async function () {
-  //       await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 2, '100', '100');
-  //     })
+      it('Emits event', async function () {
+        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 2, '100', '100');
+      })
 
-  //     it('Decrements totals', async function () {
-  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
-  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
-  //       expect(await this.silo.totalStalk()).to.equal('3000100');
-  //       //expect(await this.silo.totalSeeds()).to.equal('300');
-  //     })
+      it('Decrements totals', async function () {
+        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
+        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
+        expect(await this.silo.totalStalk()).to.equal('3000100');
+        //expect(await this.silo.totalSeeds()).to.equal('300');
+      })
 
-  //     it('Decrements balances', async function () {
-  //       expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000000');
-  //       //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
-  //     })
+      it('Decrements balances', async function () {
+        expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000000');
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+      })
 
-  //     it('properly removes the crate', async function () {
-  //       const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 2);
-  //       expect(deposit[0]).to.eq('100');
-  //       expect(deposit[1]).to.eq('100');
-  //     })
-  //   })
+      it('properly removes the crate', async function () {
+        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 2);
+        expect(deposit[0]).to.eq('100');
+        expect(deposit[1]).to.eq('100');
+      })
+    })
 
-  //   describe('Deposit Tokens some grown', async function () {
-  //     beforeEach(async function () {
-  //       this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '100');
-  //     });
+    describe('Deposit Tokens some grown', async function () {
+      beforeEach(async function () {
+        this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '100', user2Address);
+      });
 
-  //     it('Emits event', async function () {
-  //       //seasons start at 1 and the current season is 3
-  //       //a deposit with 100 grown stalk, when the "seeds" count is 1, means that 1 season has passed since this deposit
-  //       //and the current grown stalk index should be 2, since a total of 2 seasons have passed (1->2, 2->3)
-  //       //so "1 grown stalk season ago" would be season 1
-  //       await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 1, '100', '100');
-  //     })
+      it('Emits event', async function () {
+        //seasons start at 1 and the current season is 3
+        //a deposit with 100 grown stalk, when the "seeds" count is 1, means that 1 season has passed since this deposit
+        //and the current grown stalk index should be 2, since a total of 2 seasons have passed (1->2, 2->3)
+        //so "1 grown stalk season ago" would be season 1
+        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 1, '100', '100');
+      })
 
-  //     it('Decrements totals', async function () {
-  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
-  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
-  //       expect(await this.silo.totalStalk()).to.equal('3000200');
-  //       //expect(await this.silo.totalSeeds()).to.equal('300');
-  //     })
+      it('Decrements totals', async function () {
+        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
+        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
+        expect(await this.silo.totalStalk()).to.equal('3000200');
+        //expect(await this.silo.totalSeeds()).to.equal('300');
+      })
 
-  //     it('Decrements balances', async function () {
-  //       expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000100');
-  //       //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
-  //     })
+      it('Decrements balances', async function () {
+        expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000100');
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+      })
 
-  //     it('properly removes the crate', async function () {
-  //       const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 1);
-  //       expect(deposit[0]).to.eq('100');
-  //       expect(deposit[1]).to.eq('100');
-  //     })
-  //   })
+      it('properly removes the crate', async function () {
+        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 1);
+        expect(deposit[0]).to.eq('100');
+        expect(deposit[1]).to.eq('100');
+      })
+    })
 
-  //   describe('Deposit Tokens more grown', async function () {
-  //     beforeEach(async function () {
-  //       this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '250');
-  //     });
+    describe('Deposit Tokens more grown', async function () {
+      beforeEach(async function () {
+        this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '250', user2Address);
+      });
 
-  //     it('Emits event', async function () {
-  //       //at 250 grown stalk, this would need to have been deposited 2.5 seasons ago, or at grown stalk index of 2.5
-  //       //But guess what, we don't have decimals for 2.5, only 2, so you'll lose 0.5 seasons of grown stalk (30 mins)
-  //       //so with the current grown stalk index at 2, 2 seasons ago would be 0
-  //       await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 0, '100', '100');
-  //     })
+      it('Emits event', async function () {
+        //at 250 grown stalk, this would need to have been deposited 2.5 seasons ago, or at grown stalk index of 2.5
+        //But guess what, we don't have decimals for 2.5, only 2, so you'll lose 0.5 seasons of grown stalk (30 mins)
+        //so with the current grown stalk index at 2, 2 seasons ago would be 0
+        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 0, '100', '100');
+      })
 
-  //     it('Decrements totals', async function () {
-  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
-  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
-  //       expect(await this.silo.totalStalk()).to.equal('3000300');
-  //       //expect(await this.silo.totalSeeds()).to.equal('300');
-  //     })
+      it('Decrements totals', async function () {
+        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
+        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
+        expect(await this.silo.totalStalk()).to.equal('3000300');
+        //expect(await this.silo.totalSeeds()).to.equal('300');
+      })
 
-  //     it('Decrements balances', async function () {
-  //       expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000200');
-  //       //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
-  //     })
+      it('Decrements balances', async function () {
+        expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000200');
+        //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+      })
 
-  //     it('properly removes the crate', async function () {
-  //       const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 0);
-  //       expect(deposit[0]).to.eq('100');
-  //       expect(deposit[1]).to.eq('100');
-  //     })
-  //   })
-  // });
+      it('properly removes the crate', async function () {
+        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 0);
+        expect(deposit[0]).to.eq('100');
+        expect(deposit[1]).to.eq('100');
+      })
+    })
+  });
 
-  // describe("lambda convert", async function () {
-  //   it('returns correct value', async function () {
-  //     this.result = await this.convert.connect(user).callStatic.convert(
-  //       ConvertEncoder.convertLambdaToLambda(
-  //         '100',
-  //         this.siloToken.address
-  //       ),
-  //       ['2'],
-  //       ['100']
-  //     )
-  //     expect(this.result.toStem).to.be.equal(2)
-  //     expect(this.result.toAmount).to.be.equal('100')
-  //   })
+  describe("lambda convert", async function () {
+    it('returns correct value', async function () {
+      this.result = await this.convert.connect(user).callStatic.convert(
+        ConvertEncoder.convertLambdaToLambda(
+          '100',
+          this.siloToken.address
+        ),
+        ['2'],
+        ['100']
+      )
+      expect(this.result.toStem).to.be.equal(2)
+      expect(this.result.toAmount).to.be.equal('100')
+    })
 
-  //   beforeEach(async function () {
-  //     this.result = await this.convert.connect(user).convert(
-  //       ConvertEncoder.convertLambdaToLambda(
-  //         '200',
-  //         this.siloToken.address
-  //       ),
-  //       ['1', '2'],
-  //       ['100', '100']
-  //     )
-  //   })
+    beforeEach(async function () {
+      this.result = await this.convert.connect(user).convert(
+        ConvertEncoder.convertLambdaToLambda(
+          '200',
+          this.siloToken.address
+        ),
+        ['1', '2'],
+        ['100', '100']
+      )
+    })
 
-  //   it('removes and adds deposit', async function () {
-  //     let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
-  //     expect(deposit[0]).to.eq('0');
-  //     expect(deposit[1]).to.eq('0');
+    it('removes and adds deposit', async function () {
+      let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+      expect(deposit[0]).to.eq('0');
+      expect(deposit[1]).to.eq('0');
 
-  //     deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
-  //     expect(deposit[0]).to.eq('200');
-  //     expect(deposit[1]).to.eq('200');
-  //   })
+      deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+      expect(deposit[0]).to.eq('200');
+      expect(deposit[1]).to.eq('200');
+    })
 
-  //   it('Decrements balances', async function () {
-  //     expect(await this.silo.balanceOfStalk(userAddress)).to.equal('2000000');
-  //     //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('200');
-  //   })
+    it('Decrements balances', async function () {
+      expect(await this.silo.balanceOfStalk(userAddress)).to.equal('2000000');
+      //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('200');
+    })
 
-  //   it('Decrements totals', async function () {
-  //     expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('200');
-  //     expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('200');
-  //     expect(await this.silo.totalStalk()).to.equal('2000000');
-  //     //expect(await this.silo.totalSeeds()).to.equal('200');
-  //   })
+    it('Decrements totals', async function () {
+      expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('200');
+      expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('200');
+      expect(await this.silo.totalStalk()).to.equal('2000000');
+      //expect(await this.silo.totalSeeds()).to.equal('200');
+    })
 
-  //   it('Emits events', async function () {
-  //     await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '100'], '200', ['100', '100']);
-  //     await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, this.siloToken.address, 2, '200', '200');
-  //   })
-  // })
+    it('Emits events', async function () {
+      await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '100'], '200', ['100', '100']);
+      await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, this.siloToken.address, 2, '200', '200');
+    })
+  })
 
 //  ------------------------------ ANTI LAMBDA CONVERT ----------------------------------
 // FOR BDV OF INDIVIDUAL DEPOSIT? (SiloExit.sol)
@@ -450,66 +450,61 @@ describe('Convert', function () {
     //     uint256[] memory amounts
     // )
 
-  describe("anti lambda convert", async function () {
-    // Implement a new Convert type that allows any user to decrease a Deposit’s BDV if the Recorded BDV 
-    // (the BDV stored on-chain with the Deposit) (storage.depositID.bdv) is greater than the Current BDV 
-    // (the number of tokens in the Deposit * the current BDV of that token).
+  // describe("anti lambda convert", async function () {
+  //   // Implement a new Convert type that allows any user to decrease a Deposit’s BDV if the Recorded BDV 
+  //   // (the BDV stored on-chain with the Deposit) (storage.depositID.bdv) is greater than the Current BDV 
+  //   // (the number of tokens in the Deposit * the current BDV of that token).
     
-    beforeEach(async function () {
-      // --------------------- USER2 DEPOSIT ----------------------
-      console.log("-------------------------- START DEPOSIT PRINTS --------------------------")
-      // also mint some silo tokens for user2
-      await this.siloToken.mint(user2Address, '10000');
-      // approve the silo to spend the silo token for user2 as well
-      await this.siloToken.connect(user2).approve(this.silo.address, '100000000000');
-      // user2 should also make a deposit of 100 at stem 2
-      await this.silo.connect(user2).deposit(this.siloToken.address, '100', EXTERNAL);
-      console.log("-------------------------- END DEPOSIT PRINTS --------------------------")
-      // ------------------ USER2 DEPOSIT INFO ---------------------
-      let user2deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 2)
-      const amount = user2deposit[0]
-      const recordedBdv = user2deposit[1]
-      console.log("------------------------USER2 DEPOSIT BEFORE CONVERT WITH ORIGINAL SELECTOR----------------------------")
-      console.log("Recorded BDV: " + recordedBdv + " Amount: " + amount)
-      // SIMULATE DEPOSIT BDV DECREASE FOR USER2 BY CHANGING BDV SELECTOR TO MOCKBDVDECREASE
-      this.silo.mockChangeBDVSelector(this.siloToken.address, this.silo.interface.getSighash("mockBDVDecrease(uint256 amount)"))
-      console.log("Selector changed")
-      currentBdv = await this.silo.mockBDVDecrease(amount)
-      console.log("Current BDV: " + currentBdv)
-      // ----------------------- CONVERT ------------------------
-      console.log("User calls anti lambda convert on user2 to decrease user2's deposit bdv to current bdv")
-      console.log("User2 address: " + user2Address)
-      console.log("Silo token address: " + this.siloToken.address)
-      console.log("-------------------------- END TEST PRINTS --------------------------")
-      // MockConvertFacet.sol
-      this.result = await this.convert.connect(user).callStatic.convert(
-        // CALLDATA                              // amount, token ,account
-        ConvertEncoder.convertAntiLambdaToLambda('100', this.siloToken.address , user2Address),
-        // STEMS []
-        ['2', '3'],
-        // AMOUNTS []
-        ['100', '100']
-      )
-      // Result returns (int96 toStem, uint256 fromAmount, uint256 toAmount, uint256 fromBdv, uint256 toBdv)
-      console.log("Result: " + this.result)
-      expect(this.result.toStem).to.be.equal(2)
-      expect(this.result.toAmount).to.be.equal('100')
-      expect(this.result.fromAmount).to.be.equal('100')
-      expect(this.result.fromBdv).to.be.equal('100')
-      expect(this.result.toBdv).to.be.equal('90')
-    })
+  //   beforeEach(async function () {
+  //     // --------------------- USER2 DEPOSIT ----------------------
+  //     console.log("-------------------------- START DEPOSIT PRINTS --------------------------")
+  //     // also mint some silo tokens for user2
+  //     await this.siloToken.mint(user2Address, '10000');
+  //     // approve the silo to spend the silo token for user2 as well
+  //     await this.siloToken.connect(user2).approve(this.silo.address, '100000000000');
+  //     // user2 should also make a deposit of 100 at stem 2
+  //     await this.silo.connect(user2).deposit(this.siloToken.address, '100', EXTERNAL);
+  //     console.log("-------------------------- END DEPOSIT PRINTS --------------------------")
+  //     // ------------------ USER2 DEPOSIT INFO ---------------------
+  //     let user2deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 2)
+  //     const amount = user2deposit[0]
+  //     const recordedBdv = user2deposit[1]
+  //     console.log("------------------------USER2 DEPOSIT BEFORE CONVERT WITH ORIGINAL SELECTOR----------------------------")
+  //     console.log("Recorded BDV: " + recordedBdv + " Amount: " + amount)
+  //     // SIMULATE DEPOSIT BDV DECREASE FOR USER2 BY CHANGING BDV SELECTOR TO MOCKBDVDECREASE
+  //     this.silo.mockChangeBDVSelector(this.siloToken.address, this.silo.interface.getSighash("mockBDVDecrease(uint256 amount)"))
+  //     console.log("Selector changed")
+  //     currentBdv = await this.silo.mockBDVDecrease(amount)
+  //     console.log("Current BDV: " + currentBdv)
+  //     // ----------------------- CONVERT ------------------------
+  //     console.log("User calls anti lambda convert on user2 to decrease user2's deposit bdv to current bdv")
+  //     console.log("User2 address: " + user2Address)
+  //     console.log("Silo token address: " + this.siloToken.address)
+  //     console.log("-------------------------- END TEST PRINTS --------------------------")
+  //     // MockConvertFacet.sol
+  //     this.result = await this.convert.connect(user).callStatic.convert(
+  //       // CALLDATA                              // amount, token ,account
+  //       ConvertEncoder.convertAntiLambdaToLambda('100', this.siloToken.address , user2Address),
+  //       // STEMS []
+  //       ['2'],
+  //       // AMOUNTS []
+  //       ['100']
+  //     )
+  //     // Result returns (int96 toStem, uint256 fromAmount, uint256 toAmount, uint256 fromBdv, uint256 toBdv)
+  //     console.log("Result: toStem: " + this.result.toStem + " fromAmount: " + this.result.fromAmount + " toAmount: " + this.result.toAmount + " fromBdv: " + this.result.fromBdv + " toBdv: " + this.result.toBdv)
+  //   })
 
-    it('correctly updates deposit stats', async function () {
-                                        // account ,    token,      stem
-      let deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 3);
-      expect(deposit[0]).to.eq('100'); // deposit[0] = amount of tokens
-      expect(deposit[1]).to.eq('90');  // deposit[1] = bdv
-    })
+  //   it('correctly updates deposit stats', async function () {
+  //                                       // account ,    token,      stem
+  //     let deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 3);
+  //     expect(deposit[0]).to.eq('100'); // deposit[0] = amount of tokens
+  //     expect(deposit[1]).to.eq('90');  // deposit[1] = bdv
+  //   })
 
-    it('correctly updates totals', async function () {
-      expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
-      expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('290');
-    })
+  //   it('correctly updates totals', async function () {
+  //     expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
+  //     expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('290');
+  //   })
   
-  })
+  // })
 });

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -29,7 +29,7 @@ describe('Convert', function () {
 
 
 
-    //test setup includes making 2 deposits, one at stem of 1, and another deposit at 2
+    // test setup includes making 2 deposits, one at stem of 1, and another deposit at 2
 
     await this.bean.mint(userAddress, '1000000000');
     await this.bean.mint(user2Address, '1000000000');

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -4,6 +4,7 @@ const { EXTERNAL, INTERNAL, INTERNAL_EXTERNAL, INTERNAL_TOLERANT } = require('./
 const { ConvertEncoder } = require('./utils/encoder.js')
 const { BEAN } = require('./utils/constants')
 const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot");
+const { re } = require('mathjs');
 
 let user,user2,owner;
 let userAddress, ownerAddress, user2Address;
@@ -22,11 +23,9 @@ describe('Convert', function () {
     this.bean = await ethers.getContractAt('MockToken', BEAN);
 
     
-
     this.siloToken = await ethers.getContractFactory("MockToken");
     this.siloToken = await this.siloToken.deploy("Silo", "SILO")
     await this.siloToken.deployed()
-
 
 
     // test setup includes making 2 deposits, one at stem of 1, and another deposit at 2
@@ -40,16 +39,53 @@ describe('Convert', function () {
     await this.season.teleportSunrise(10);
 
     this.season.deployStemsUpgrade();
+
+    /**
+     * @notice Describes the settings for each Token that is Whitelisted in the Silo.
+     * @param selector The encoded BDV function selector for the token that pertains to 
+     * an external view Beanstalk function with the following signature:
+     * ```
+     * function tokenToBdv(uint256 amount) external view returns (uint256);
+     * --> CAN BE FOUND AT THE BDV FACET FOR SEVERAL WHITELISTED TOKENS IE CURVE, ETH...
+     * ```
+     * It is called by `LibTokenSilo` through the use of `delegatecall`
+     * to calculate a token's BDV at the time of Deposit.
+     * @param stalkIssuedPerBdv The Stalk Per BDV that the Silo grants in exchange for Depositing this Token.
+     * previously called stalk.
+    */
+
     await this.silo.mockWhitelistToken(
-      this.siloToken.address, 
-      this.silo.interface.getSighash("mockBDV(uint256 amount)"), 
-      '10000', 
-      1e6 //aka "1 seed"
+      this.siloToken.address, // token                         
+      this.silo.interface.getSighash("mockBDV(uint256 amount)"), // selector --> how you will calculate the bdv. see LibTokenSilo.sol beandenominatedvalue function
+      // SINCE THE EXTERNAL FUNCTION USED TO CALC THE BDV OF THE SILO TOKEN IS THE MOCKBDV THAT JUST RETURNS THE AMOUNT
+      // THE BDV IS JUST THE INPUT AMOUNT SO 1 SILO TOKEN = 1 BDV
+      '10000', // stalkIssuedPerBdv
+      1e6 //aka "1 seed" // stalkEarnedPerSeason
     );
+    // user1 deposits 2 times at stem 1 and 2 100 silo tokens , so 100 bdv for each deposit
     await this.season.siloSunrise(0);
     await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL);
     await this.season.siloSunrise(0);
     await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL); //something about this deposit adds extra stalk
+    
+    // ------------------------------ NEW CHANGES ------------------------------
+
+    this.newSiloToken = await ethers.getContractFactory("MockToken");
+    this.newSiloToken = await this.newSiloToken.deploy("Silo2", "SILO2")
+    await this.newSiloToken.deployed()
+
+    await this.silo.mockWhitelistToken(
+      this.newSiloToken.address, // token                        
+      this.silo.interface.getSighash("newMockBDV()"), // selector
+      '10000', // stalkIssuedPerBdv
+      1e6 //aka "1 seed" // stalkEarnedPerSeason
+    );
+    
+    // // user deposits 100 new silo token at stem 2
+    // await this.newSiloToken.mint(userAddress, '100000000000000');
+    // await this.newSiloToken.connect(user).approve(this.silo.address, '1000000000');
+    // await this.silo.connect(user).deposit(this.newSiloToken.address, '100', EXTERNAL);
+
   });
 
   beforeEach(async function () {
@@ -59,312 +95,421 @@ describe('Convert', function () {
   afterEach(async function () {
     await revertToSnapshot(snapshotId);
   });
+  //  -------------------------------- OLD TESTS --------------------------------
+  // describe('Withdraw For Convert', async function () {
+  //   describe("Revert", async function () {
+  //     it('diff lengths', async function () {
+  //       await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100'], '100')).to.be.revertedWith('Convert: stems, amounts are diff lengths.')
+  //     });
 
-  describe('Withdraw For Convert', async function () {
-    describe("Revert", async function () {
-      it('diff lengths', async function () {
-        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100'], '100')).to.be.revertedWith('Convert: stems, amounts are diff lengths.')
-      });
+  //     it('crate balance too low', async function () {
+  //       //params are token, stem, amounts, maxtokens
+  //       // await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.') //before moving to constants for the original 4 whitelisted tokens (post replant), this test would revert with 'Silo: Crate balance too low.', but now it reverts with 'Must line up with season' because there's no constant seeds amount hardcoded in for this test token
+  //       await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.')
+  //     });
 
-      it('crate balance too low', async function () {
-        //params are token, stem, amounts, maxtokens
-        // await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.') //before moving to constants for the original 4 whitelisted tokens (post replant), this test would revert with 'Silo: Crate balance too low.', but now it reverts with 'Must line up with season' because there's no constant seeds amount hardcoded in for this test token
-        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['0'], ['150'], '150')).to.be.revertedWith('Silo: Crate balance too low.')
-      });
+  //     it('not enough removed', async function () {
+  //       await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['100'], '150')).to.be.revertedWith('Convert: Not enough tokens removed.')
+  //     });
+  //   })
 
-      it('not enough removed', async function () {
-        await expect(this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['100'], '150')).to.be.revertedWith('Convert: Not enough tokens removed.')
-      });
-    })
+  //   //this test withdraws from stem index of 2, verifies they are removed correctly and stalk balances updated
+  //   describe("Withdraw 1 Crate", async function () {
+  //     beforeEach(async function () {
+  //       this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['100'], '100');
+  //     })
 
-    //this test withdraws from stem index of 2, verifies they are removed correctly and stalk balances updated
-    describe("Withdraw 1 Crate", async function () {
-      beforeEach(async function () {
-        this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2'], ['100'], '100');
-      })
+  //     it('Emits event', async function () {
+  //       await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2], ['100'], '100', ['100']);
+  //       await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
+  //     })
 
-      it('Emits event', async function () {
-        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2], ['100'], '100', ['100']);
-        await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
-      })
+  //     it('Decrements totals', async function () {
+  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('100');
+  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('100');
+  //       expect(await this.silo.totalStalk()).to.equal('1000100');
+  //       //expect(await this.silo.totalSeeds()).to.equal('100');
+  //     })
 
-      it('Decrements totals', async function () {
-        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('100');
-        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('100');
-        expect(await this.silo.totalStalk()).to.equal('1000100');
-        //expect(await this.silo.totalSeeds()).to.equal('100');
-      })
+  //     it('Decrements balances', async function () {
+  //       expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
+  //       //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
+  //     })
 
-      it('Decrements balances', async function () {
-        expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
-        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
-      })
+  //     it('properly removes the crate', async function () {
+  //       let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
 
-      it('properly removes the crate', async function () {
-        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+  //       expect(deposit[0]).to.eq('100');
+  //       expect(deposit[1]).to.eq('100');
+  //       deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
 
-        expect(deposit[0]).to.eq('100');
-        expect(deposit[1]).to.eq('100');
-        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+  //       expect(deposit[0]).to.eq('0');
+  //       expect(deposit[1]).to.eq('0');
+  //     })
+  //   })
 
-        expect(deposit[0]).to.eq('0');
-        expect(deposit[1]).to.eq('0');
-      })
-    })
+  //   //this test withdraws from stem indexes of 2 and 1
+  //   describe("Withdraw 1 Crate 2 input", async function () {
+  //     beforeEach(async function () {
+  //       this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2', '1'], ['100', '100'], '100');
+  //     })
 
-    //this test withdraws from stem indexes of 2 and 1
-    describe("Withdraw 1 Crate 2 input", async function () {
-      beforeEach(async function () {
-        this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['2', '1'], ['100', '100'], '100');
-      })
+  //     it('Emits event', async function () {
+  //       await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2, 1], ['100', '0'], '100',['100', '0'] );
+  //       await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
+  //     })
 
-      it('Emits event', async function () {
-        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [2, 1], ['100', '0'], '100',['100', '0'] );
-        await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('0', '100');
-      })
+  //     it('Decrements totals', async function () {
+  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('100');
+  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('100');
+  //       expect(await this.silo.totalStalk()).to.equal('1000100');
+  //       //expect(await this.silo.totalSeeds()).to.equal('100');
+  //     })
 
-      it('Decrements totals', async function () {
-        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('100');
-        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('100');
-        expect(await this.silo.totalStalk()).to.equal('1000100');
-        //expect(await this.silo.totalSeeds()).to.equal('100');
-      })
+  //     it('Decrements balances', async function () {
+  //       expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
+  //       //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
+  //     })
 
-      it('Decrements balances', async function () {
-        expect(await this.silo.balanceOfStalk(userAddress)).to.equal('1000100');
-        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('100');
-      })
+  //     it('properly removes the crate', async function () {
+  //       let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+  //       expect(deposit[0]).to.eq('100');
+  //       expect(deposit[1]).to.eq('100');
+  //       deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+  //       expect(deposit[0]).to.eq('0');
+  //       expect(deposit[1]).to.eq('0');
+  //     })
+  //   })
 
-      it('properly removes the crate', async function () {
-        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
-        expect(deposit[0]).to.eq('100');
-        expect(deposit[1]).to.eq('100');
-        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
-        expect(deposit[0]).to.eq('0');
-        expect(deposit[1]).to.eq('0');
-      })
-    })
+  //   //withdraws less than the full deposited amount from stem indexes of 2 and 1
+  //   describe("Withdraw 2 Crates exact", async function () {
+  //     beforeEach(async function () {
+  //       this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100', '50'], '150');
+  //     })
 
-    //withdraws less than the full deposited amount from stem indexes of 2 and 1
-    describe("Withdraw 2 Crates exact", async function () {
-      beforeEach(async function () {
-        this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100', '50'], '150');
-      })
+  //     it('Emits event', async function () { 
+  //       await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '50'], '150', ['100', '50']);
 
-      it('Emits event', async function () { 
-        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '50'], '150', ['100', '50']);
+  //       await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('100', '150');
+  //     })
 
-        await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('100', '150');
-      })
+  //     it('Decrements totals', async function () {
+  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('50');
+  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('50');
+  //       expect(await this.silo.totalStalk()).to.equal('500000');
+  //       //expect(await this.silo.totalSeeds()).to.equal('50');
+  //     })
 
-      it('Decrements totals', async function () {
-        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('50');
-        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('50');
-        expect(await this.silo.totalStalk()).to.equal('500000');
-        //expect(await this.silo.totalSeeds()).to.equal('50');
-      })
+  //     it('Decrements balances', async function () {
+  //       expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
+  //       //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
+  //     })
 
-      it('Decrements balances', async function () {
-        expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
-        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
-      })
+  //     it('properly removes the crate', async function () {
+  //       let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+  //       expect(deposit[0]).to.eq('0');
+  //       expect(deposit[1]).to.eq('0');
+  //       deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+  //       expect(deposit[0]).to.eq('50');
+  //       expect(deposit[1]).to.eq('50');
+  //     })
+  //   })
 
-      it('properly removes the crate', async function () {
-        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
-        expect(deposit[0]).to.eq('0');
-        expect(deposit[1]).to.eq('0');
-        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
-        expect(deposit[0]).to.eq('50');
-        expect(deposit[1]).to.eq('50');
-      })
-    })
+  //   describe("Withdraw 2 Crates under", async function () {
+  //     beforeEach(async function () {
+  //       this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100', '100'], '150');
+  //     })
 
-    describe("Withdraw 2 Crates under", async function () {
-      beforeEach(async function () {
-        this.result = await this.convert.connect(user).withdrawForConvertE(this.siloToken.address, ['1', '2'], ['100', '100'], '150');
-      })
+  //     it('Emits event', async function () { 
+  //       await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100','50'], '150', ['100','50']);
+  //       await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('100', '150');
+  //     })
 
-      it('Emits event', async function () { 
-        await expect(this.result).to.emit(this.convert, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100','50'], '150', ['100','50']);
-        await expect(this.result).to.emit(this.convert, 'MockConvert').withArgs('100', '150');
-      })
+  //     it('Decrements totals', async function () {
+  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('50');
+  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('50');
+  //       expect(await this.silo.totalStalk()).to.equal('500000');
+  //       //expect(await this.silo.totalSeeds()).to.equal('50');
+  //     })
 
-      it('Decrements totals', async function () {
-        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('50');
-        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('50');
-        expect(await this.silo.totalStalk()).to.equal('500000');
-        //expect(await this.silo.totalSeeds()).to.equal('50');
-      })
+  //     it('Decrements balances', async function () {
+  //       expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
+  //       //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
+  //     })
 
-      it('Decrements balances', async function () {
-        expect(await this.silo.balanceOfStalk(userAddress)).to.equal('500000');
-        //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('50');
-      })
-
-      it('properly removes the crate', async function () {
-        let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
-        expect(deposit[0]).to.eq('0');
-        expect(deposit[1]).to.eq('0');
-        deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
-        expect(deposit[0]).to.eq('50');
-        expect(deposit[1]).to.eq('50');
-      })
-    })
-  })
+  //     it('properly removes the crate', async function () {
+  //       let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+  //       expect(deposit[0]).to.eq('0');
+  //       expect(deposit[1]).to.eq('0');
+  //       deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+  //       expect(deposit[0]).to.eq('50');
+  //       expect(deposit[1]).to.eq('50');
+  //     })
+  //   })
+  // })
   
-  describe('Deposit For Convert', async function () {
-    describe("Revert", async function () {
-      it("Reverts if BDV is 0", async function () {
-        await expect(this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '0', '100')).to.be.revertedWith("Convert: BDV or amount is 0.")
-      })
+  // describe('Deposit For Convert', async function () {
+  //   describe("Revert", async function () {
+  //     it("Reverts if BDV is 0", async function () {
+  //       await expect(this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '0', '100')).to.be.revertedWith("Convert: BDV or amount is 0.")
+  //     })
 
-      it("Reverts if amount is 0", async function () {
-        await expect(this.convert.connect(user2).depositForConvertE(this.siloToken.address, '0', '100', '100')).to.be.revertedWith("Convert: BDV or amount is 0.")
-      })
-    })
+  //     it("Reverts if amount is 0", async function () {
+  //       await expect(this.convert.connect(user2).depositForConvertE(this.siloToken.address, '0', '100', '100')).to.be.revertedWith("Convert: BDV or amount is 0.")
+  //     })
+  //   })
 
-    describe('Deposit Tokens No Grown', async function () {
-      beforeEach(async function () {
-        this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '0');
-      });
+  //   describe('Deposit Tokens No Grown', async function () {
+  //     beforeEach(async function () {
+  //       this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '0');
+  //     });
 
-      it('Emits event', async function () {
-        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 2, '100', '100');
-      })
+  //     it('Emits event', async function () {
+  //       await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 2, '100', '100');
+  //     })
 
-      it('Decrements totals', async function () {
-        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
-        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
-        expect(await this.silo.totalStalk()).to.equal('3000100');
-        //expect(await this.silo.totalSeeds()).to.equal('300');
-      })
+  //     it('Decrements totals', async function () {
+  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
+  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
+  //       expect(await this.silo.totalStalk()).to.equal('3000100');
+  //       //expect(await this.silo.totalSeeds()).to.equal('300');
+  //     })
 
-      it('Decrements balances', async function () {
-        expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000000');
-        //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
-      })
+  //     it('Decrements balances', async function () {
+  //       expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000000');
+  //       //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+  //     })
 
-      it('properly removes the crate', async function () {
-        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 2);
-        expect(deposit[0]).to.eq('100');
-        expect(deposit[1]).to.eq('100');
-      })
-    })
+  //     it('properly removes the crate', async function () {
+  //       const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 2);
+  //       expect(deposit[0]).to.eq('100');
+  //       expect(deposit[1]).to.eq('100');
+  //     })
+  //   })
 
-    describe('Deposit Tokens some grown', async function () {
-      beforeEach(async function () {
-        this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '100');
-      });
+  //   describe('Deposit Tokens some grown', async function () {
+  //     beforeEach(async function () {
+  //       this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '100');
+  //     });
 
-      it('Emits event', async function () {
-        //seasons start at 1 and the current season is 3
-        //a deposit with 100 grown stalk, when the "seeds" count is 1, means that 1 season has passed since this deposit
-        //and the current grown stalk index should be 2, since a total of 2 seasons have passed (1->2, 2->3)
-        //so "1 grown stalk season ago" would be season 1
-        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 1, '100', '100');
-      })
+  //     it('Emits event', async function () {
+  //       //seasons start at 1 and the current season is 3
+  //       //a deposit with 100 grown stalk, when the "seeds" count is 1, means that 1 season has passed since this deposit
+  //       //and the current grown stalk index should be 2, since a total of 2 seasons have passed (1->2, 2->3)
+  //       //so "1 grown stalk season ago" would be season 1
+  //       await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 1, '100', '100');
+  //     })
 
-      it('Decrements totals', async function () {
-        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
-        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
-        expect(await this.silo.totalStalk()).to.equal('3000200');
-        //expect(await this.silo.totalSeeds()).to.equal('300');
-      })
+  //     it('Decrements totals', async function () {
+  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
+  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
+  //       expect(await this.silo.totalStalk()).to.equal('3000200');
+  //       //expect(await this.silo.totalSeeds()).to.equal('300');
+  //     })
 
-      it('Decrements balances', async function () {
-        expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000100');
-        //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
-      })
+  //     it('Decrements balances', async function () {
+  //       expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000100');
+  //       //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+  //     })
 
-      it('properly removes the crate', async function () {
-        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 1);
-        expect(deposit[0]).to.eq('100');
-        expect(deposit[1]).to.eq('100');
-      })
-    })
+  //     it('properly removes the crate', async function () {
+  //       const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 1);
+  //       expect(deposit[0]).to.eq('100');
+  //       expect(deposit[1]).to.eq('100');
+  //     })
+  //   })
 
-    describe('Deposit Tokens more grown', async function () {
-      beforeEach(async function () {
-        this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '250');
-      });
+  //   describe('Deposit Tokens more grown', async function () {
+  //     beforeEach(async function () {
+  //       this.result = await this.convert.connect(user2).depositForConvertE(this.siloToken.address, '100', '100', '250');
+  //     });
 
-      it('Emits event', async function () {
-        //at 250 grown stalk, this would need to have been deposited 2.5 seasons ago, or at grown stalk index of 2.5
-        //But guess what, we don't have decimals for 2.5, only 2, so you'll lose 0.5 seasons of grown stalk (30 mins)
-        //so with the current grown stalk index at 2, 2 seasons ago would be 0
-        await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 0, '100', '100');
-      })
+  //     it('Emits event', async function () {
+  //       //at 250 grown stalk, this would need to have been deposited 2.5 seasons ago, or at grown stalk index of 2.5
+  //       //But guess what, we don't have decimals for 2.5, only 2, so you'll lose 0.5 seasons of grown stalk (30 mins)
+  //       //so with the current grown stalk index at 2, 2 seasons ago would be 0
+  //       await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(user2Address, this.siloToken.address, 0, '100', '100');
+  //     })
 
-      it('Decrements totals', async function () {
-        expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
-        expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
-        expect(await this.silo.totalStalk()).to.equal('3000300');
-        //expect(await this.silo.totalSeeds()).to.equal('300');
-      })
+  //     it('Decrements totals', async function () {
+  //       expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
+  //       expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('300');
+  //       expect(await this.silo.totalStalk()).to.equal('3000300');
+  //       //expect(await this.silo.totalSeeds()).to.equal('300');
+  //     })
 
-      it('Decrements balances', async function () {
-        expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000200');
-        //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
-      })
+  //     it('Decrements balances', async function () {
+  //       expect(await this.silo.balanceOfStalk(user2Address)).to.equal('1000200');
+  //       //expect(await this.silo.balanceOfSeeds(user2Address)).to.equal('100');
+  //     })
 
-      it('properly removes the crate', async function () {
-        const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 0);
-        expect(deposit[0]).to.eq('100');
-        expect(deposit[1]).to.eq('100');
-      })
-    })
-  });
+  //     it('properly removes the crate', async function () {
+  //       const deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 0);
+  //       expect(deposit[0]).to.eq('100');
+  //       expect(deposit[1]).to.eq('100');
+  //     })
+  //   })
+  // });
 
-  describe("lambda convert", async function () {
-    it('returns correct value', async function () {
-      this.result = await this.convert.connect(user).callStatic.convert(
-        ConvertEncoder.convertLambdaToLambda(
-          '100',
-          this.siloToken.address
-        ),
-        ['2'],
-        ['100']
-      )
-      expect(this.result.toStem).to.be.equal(2)
-      expect(this.result.toAmount).to.be.equal('100')
-    })
+  // describe("lambda convert", async function () {
+  //   it('returns correct value', async function () {
+  //     this.result = await this.convert.connect(user).callStatic.convert(
+  //       ConvertEncoder.convertLambdaToLambda(
+  //         '100',
+  //         this.siloToken.address
+  //       ),
+  //       ['2'],
+  //       ['100']
+  //     )
+  //     expect(this.result.toStem).to.be.equal(2)
+  //     expect(this.result.toAmount).to.be.equal('100')
+  //   })
 
+  //   beforeEach(async function () {
+  //     this.result = await this.convert.connect(user).convert(
+  //       ConvertEncoder.convertLambdaToLambda(
+  //         '200',
+  //         this.siloToken.address
+  //       ),
+  //       ['1', '2'],
+  //       ['100', '100']
+  //     )
+  //   })
+
+  //   it('removes and adds deposit', async function () {
+  //     let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
+  //     expect(deposit[0]).to.eq('0');
+  //     expect(deposit[1]).to.eq('0');
+
+  //     deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
+  //     expect(deposit[0]).to.eq('200');
+  //     expect(deposit[1]).to.eq('200');
+  //   })
+
+  //   it('Decrements balances', async function () {
+  //     expect(await this.silo.balanceOfStalk(userAddress)).to.equal('2000000');
+  //     //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('200');
+  //   })
+
+  //   it('Decrements totals', async function () {
+  //     expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('200');
+  //     expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('200');
+  //     expect(await this.silo.totalStalk()).to.equal('2000000');
+  //     //expect(await this.silo.totalSeeds()).to.equal('200');
+  //   })
+
+  //   it('Emits events', async function () {
+  //     await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '100'], '200', ['100', '100']);
+  //     await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, this.siloToken.address, 2, '200', '200');
+  //   })
+  // })
+
+//  ------------------------------ ANTI LAMBDA CONVERT ----------------------------------
+// FOR BDV OF INDIVIDUAL DEPOSIT? (SiloExit.sol)
+//   /**
+//      * @notice Return the balance of Deposited BDV of `token` for a given `account`.
+//      */
+//   function balanceOfDepositedBdv(address account, address token)
+//   external
+//   view
+//   returns (uint256 depositedBdv)
+// {
+//   depositedBdv = s.a[account].mowStatuses[token].bdv;
+// }
+
+// GET DEPOSIT (LibTokenSilo.sol)
+  /**
+     * @dev Locate the `amount` and `bdv` for a user's Deposit in storage.
+     * 
+     * Silo V3 Deposits are stored within each {Account} as a mapping of:
+     *  `uint256 DepositID => { uint128 amount, uint128 bdv }`
+     *  The DepositID is the concatination of the token address and the stem.
+     * 
+     * Silo V2 deposits are only usable after a successful migration, see
+     * mowAndMigrate within the Migration facet.
+     *
+     */
+      //function getDeposit(
+      //     address account,
+      //     address token,
+      //     int96 stem
+      // ) internal view returns (uint256 amount, uint256 bdv) {
+      //     AppStorage storage s = LibAppStorage.diamondStorage();
+      //     uint256 depositId = LibBytes.packAddressAndStem(
+      //         token,
+      //         stem
+      //     );
+      //     amount = s.a[account].deposits[depositId].amount;
+      //     bdv = s.a[account].deposits[depositId].bdv;
+      // }
+
+    // CONVERT FACET CONVERT FUNCTION
+    //   function convert(
+    //     bytes calldata convertData,
+    //     int96[] memory stems,
+    //     uint256[] memory amounts
+    // )
+
+  describe("anti lambda convert", async function () {
+    // Implement a new Convert type that allows any user to decrease a Deposit’s BDV if the Recorded BDV 
+    // (the BDV stored on-chain with the Deposit) (storage.depositID.bdv) is greater than the Current BDV 
+    // (the number of tokens in the Deposit * the current BDV of that token).
+    
     beforeEach(async function () {
-      this.result = await this.convert.connect(user).convert(
-        ConvertEncoder.convertLambdaToLambda(
-          '200',
-          this.siloToken.address
-        ),
-        ['1', '2'],
+      // --------------------- USER2 DEPOSIT ----------------------
+      console.log("-------------------------- START DEPOSIT PRINTS --------------------------")
+      // also mint some silo tokens for user2
+      await this.siloToken.mint(user2Address, '10000');
+      // approve the silo to spend the silo token for user2 as well
+      await this.siloToken.connect(user2).approve(this.silo.address, '100000000000');
+      // user2 should also make a deposit of 100 at stem 2
+      await this.silo.connect(user2).deposit(this.siloToken.address, '100', EXTERNAL);
+      console.log("-------------------------- END DEPOSIT PRINTS --------------------------")
+      // ------------------ USER2 DEPOSIT INFO ---------------------
+      let user2deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 2)
+      const amount = user2deposit[0]
+      const recordedBdv = user2deposit[1]
+      console.log("------------------------USER2 DEPOSIT BEFORE CONVERT WITH ORIGINAL SELECTOR----------------------------")
+      console.log("Recorded BDV: " + recordedBdv + " Amount: " + amount)
+      // SIMULATE DEPOSIT BDV DECREASE FOR USER2 BY CHANGING BDV SELECTOR TO MOCKBDVDECREASE
+      this.silo.mockChangeBDVSelector(this.siloToken.address, this.silo.interface.getSighash("mockBDVDecrease(uint256 amount)"))
+      console.log("Selector changed")
+      currentBdv = await this.silo.mockBDVDecrease(amount)
+      console.log("Current BDV: " + currentBdv)
+      // ----------------------- CONVERT ------------------------
+      console.log("User calls anti lambda convert on user2 to decrease user2's deposit bdv to current bdv")
+      console.log("User2 address: " + user2Address)
+      console.log("Silo token address: " + this.siloToken.address)
+      console.log("-------------------------- END TEST PRINTS --------------------------")
+      // MockConvertFacet.sol
+      this.result = await this.convert.connect(user).callStatic.convert(
+        // CALLDATA                              // amount, token ,account
+        ConvertEncoder.convertAntiLambdaToLambda('100', this.siloToken.address , user2Address),
+        // STEMS []
+        ['2', '3'],
+        // AMOUNTS []
         ['100', '100']
       )
+      // Result returns (int96 toStem, uint256 fromAmount, uint256 toAmount, uint256 fromBdv, uint256 toBdv)
+      console.log("Result: " + this.result)
+      expect(this.result.toStem).to.be.equal(2)
+      expect(this.result.toAmount).to.be.equal('100')
+      expect(this.result.fromAmount).to.be.equal('100')
+      expect(this.result.fromBdv).to.be.equal('100')
+      expect(this.result.toBdv).to.be.equal('90')
     })
 
-    it('removes and adds deposit', async function () {
-      let deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 1);
-      expect(deposit[0]).to.eq('0');
-      expect(deposit[1]).to.eq('0');
-
-      deposit = await this.silo.getDeposit(userAddress, this.siloToken.address, 2);
-      expect(deposit[0]).to.eq('200');
-      expect(deposit[1]).to.eq('200');
+    it('correctly updates deposit stats', async function () {
+                                        // account ,    token,      stem
+      let deposit = await this.silo.getDeposit(user2Address, this.siloToken.address, 3);
+      expect(deposit[0]).to.eq('100'); // deposit[0] = amount of tokens
+      expect(deposit[1]).to.eq('90');  // deposit[1] = bdv
     })
 
-    it('Decrements balances', async function () {
-      expect(await this.silo.balanceOfStalk(userAddress)).to.equal('2000000');
-      //expect(await this.silo.balanceOfSeeds(userAddress)).to.equal('200');
+    it('correctly updates totals', async function () {
+      expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('300');
+      expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('290');
     })
-
-    it('Decrements totals', async function () {
-      expect(await this.silo.getTotalDeposited(this.siloToken.address)).to.equal('200');
-      expect(await this.silo.getTotalDepositedBdv(this.siloToken.address)).to.eq('200');
-      expect(await this.silo.totalStalk()).to.equal('2000000');
-      //expect(await this.silo.totalSeeds()).to.equal('200');
-    })
-
-    it('Emits events', async function () {
-      await expect(this.result).to.emit(this.silo, 'RemoveDeposits').withArgs(userAddress, this.siloToken.address, [1, 2], ['100', '100'], '200', ['100', '100']);
-      await expect(this.result).to.emit(this.silo, 'AddDeposit').withArgs(userAddress, this.siloToken.address, 2, '200', '200');
-    })
+  
   })
 });

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -41,11 +41,12 @@ describe('Convert', function () {
     this.season.deployStemsUpgrade();
 
     await this.silo.mockWhitelistToken(
-      this.siloToken.address, // token                         
-      this.silo.interface.getSighash("mockBDV(uint256 amount)"), // selector for bdv calculation
-      '10000', // stalkIssuedPerBdv
-      1e6 //aka "1 seed" // stalkEarnedPerSeason
+      this.siloToken.address,                   
+      this.silo.interface.getSighash("mockBDV(uint256 amount)"),
+      '10000',
+      1e6 //aka "1 seed"
     );
+
     // user1 deposits 2 times at stem 1 and 2 100 silo tokens , so 100 bdv for each deposit
     await this.season.siloSunrise(0);
     await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL);
@@ -65,7 +66,6 @@ describe('Convert', function () {
       1e6 //aka "1 seed" // stalkEarnedPerSeason
     );
   
-
   });
 
   beforeEach(async function () {
@@ -414,8 +414,6 @@ describe('Convert', function () {
         // AMOUNTS []
         ['100']
       )
-      // Result returns (int96 toStem, uint256 fromAmount, uint256 toAmount, uint256 fromBdv, uint256 toBdv)
-      console.log("Result: " + this.result + " " + this.result.fromAmount + " " + this.result.toAmount + " " + this.result.fromBdv + " " + this.result.toBdv)
     })
 
     it('Correctly updates deposit stats', async function () {
@@ -427,7 +425,7 @@ describe('Convert', function () {
     it('Correctly updates totals', async function () {
       expect(await this.silo.getTotalDeposited(this.newSiloToken.address)).to.equal('100');
       expect(await this.silo.getTotalDepositedBdv(this.newSiloToken.address)).to.eq('900000');
-      // 100000 stalk removed = 1 stalk/bdv  for newSiloToken * 100000 bdv removed from convert
+      // 100000 stalk removed = 1 stalk/bdv for newSiloToken * 100000 bdv removed from convert
       expect(await this.silo.totalStalk()).to.equal('2900100');
     })
 
@@ -467,7 +465,6 @@ describe('Convert', function () {
         // AMOUNTS []
         ['100']
       )
-      // Result returns (int96 toStem, uint256 fromAmount, uint256 toAmount, uint256 fromBdv, uint256 toBdv)
     })
 
     it('Correctly updates deposit stats', async function () {
@@ -479,7 +476,7 @@ describe('Convert', function () {
     it('Correctly updates totals', async function () {
       expect(await this.silo.getTotalDeposited(this.newSiloToken.address)).to.equal('100');
       expect(await this.silo.getTotalDepositedBdv(this.newSiloToken.address)).to.eq('1100000');
-      // 100000 stalk added = 1 stalk/bdv for newSiloToken * 100000 bdv removed from convert
+      // 100000 stalk added = 1 stalk/bdv for newSiloToken * 100000 bdv added from convert
       expect(await this.silo.totalStalk()).to.equal('3100100');
     })
 

--- a/protocol/test/Convert.test.js
+++ b/protocol/test/Convert.test.js
@@ -53,7 +53,6 @@ describe('Convert', function () {
     await this.season.siloSunrise(0);
     await this.silo.connect(user).deposit(this.siloToken.address, '100', EXTERNAL); //something about this deposit adds extra stalk
     
-    // ------------------------------ NEW CHANGES ------------------------------
     // To isolate the anti lamda functionality, we will create and whitelist a new silo token
     this.newSiloToken = await ethers.getContractFactory("MockToken");
     this.newSiloToken = await this.newSiloToken.deploy("Silo2", "SILO2")
@@ -397,15 +396,11 @@ describe('Convert', function () {
 
       // simulate deposit bdv decrease for user by changing bdv selector to newMockBDVDecrease ie 0.9e6
       await this.silo.mockChangeBDVSelector(this.newSiloToken.address, this.silo.interface.getSighash("newMockBDVDecrease()"))
-      console.log("Selector changed to newMockBDVDecrease")
       const currentBdv = await this.silo.newMockBDVDecrease()
       let depositResult = await this.silo.getDeposit(userAddress, this.newSiloToken.address, 0)
       const depositBdv = depositResult[1]
-      console.log("Deposit BDV: " + depositBdv)
-      console.log("Current BDV: " + currentBdv)
 
       // ----------------------- CONVERT ------------------------
-      console.log("User2 calls anti lambda convert on user to decrease user's recorded deposit bdv to current bdv")
       this.result = await this.convert.connect(user2).convert(
         // CALLDATA                              // amount, token ,account
         ConvertEncoder.convertAntiLambdaToLambda('100', this.newSiloToken.address , userAddress),
@@ -448,15 +443,11 @@ describe('Convert', function () {
 
       // simulate deposit bdv decrease for user2 by changing bdv selector to mockBdvIncrease ie 1.1e6
       await this.silo.mockChangeBDVSelector(this.newSiloToken.address, this.silo.interface.getSighash("newMockBDVIncrease()"))
-      console.log("Selector changed to newMockBDVIncrease")
       currentBdv = await this.silo.newMockBDVIncrease()
       let depositResult = await this.silo.getDeposit(userAddress, this.newSiloToken.address, 0)
       const depositBdv = depositResult[1]
-      console.log("Deposit BDV: " + depositBdv)
-      console.log("Current BDV: " + currentBdv)
 
       // ----------------------- CONVERT ------------------------
-      console.log("User2 calls anti lambda convert on user to increase user's recorded deposit bdv to current bdv")
       this.result = await this.convert.connect(user2).convert(
         // CALLDATA                              // amount, token ,account
         ConvertEncoder.convertAntiLambdaToLambda('100', this.newSiloToken.address , userAddress),

--- a/protocol/test/utils/encoder.js
+++ b/protocol/test/utils/encoder.js
@@ -8,7 +8,8 @@ const ConvertKind = {
   LAMBDA_LAMBDA: 4,
   BEANS_TO_WELL_LP: 5,
   WELL_LP_TO_BEANS: 6,
-  UNRIPE_TO_RIPE: 7
+  UNRIPE_TO_RIPE: 7,
+  ANTI_LAMBDA_LAMBDA: 8,
 }
 
 class ConvertEncoder {
@@ -82,6 +83,13 @@ class ConvertEncoder {
   defaultAbiCoder.encode(
     ['uint256', 'uint256', 'address'],
     [ConvertKind.UNRIPE_TO_RIPE, unripeAmount, unripeToken]
+  );
+
+
+  static convertAntiLambdaToLambda = (amount, token, account) =>
+  defaultAbiCoder.encode(
+    ['uint256', 'uint256', 'address' , 'address'],
+    [ConvertKind.ANTI_LAMBDA_LAMBDA, amount, token , account]
   );
 }
 


### PR DESCRIPTION
## Summary

Implemented a new Convert type that allows any user to decrease a Deposit’s BDV if the Recorded BDV (the BDV stored on-chain with the Deposit) is greater than the Current BDV (the number of tokens in the Deposit * the current BDV of that token).

## Problem:

Currently, the Recorded BDV of a given Deposit is asynchronous with its Current BDV. For example, if a user Deposits BEANETH into the Silo and the USD price of ETH falls significantly (and thus the BDV of BEANETH decreases), the Recorded BDV does not decrease, i.e., the user “locked in” the greater BDV at the time of Deposit. In practice, this may mean Beanstalk is over crediting BDV to Deposits relative to their value to the system.

Beanstalk only supports Convert types that do not decrease the BDV of the Deposit.

## Solution

- Implemented a new Convert type `ANTI_LAMBDA_LAMBDA` , callable by anyone, that Converts on behalf of a user.
- Added an additional parameter ```account``` in ```LibConvert.convert(…)``` , corresponding to the account to decrease the deposit of.
-  Created a new decoder ```antiLambdaConvert(bytes memory self)``` function that additionally decodes the account parameter.
- Replaced ```msg.sender``` in ```ConvertFacet``` ```.convert()``` ,```. _withdrawTokens()``` , ```. _depositTokensForConvert()``` functions and all needed places with ```account```.
- Challenged the new functionallity with tests in ```test/Convert.test.js```
- Added mock bdv selectors in ```MockSiloFacet``` to artificially manipulate the bdv of a deposit in tests.