### PR TITLE
Implement read-only provider

### DIFF
--- a/projects/sdk/src/lib/BeanstalkSDK.ts
+++ b/projects/sdk/src/lib/BeanstalkSDK.ts
@@ -22,6 +22,7 @@ export type Provider = ethers.providers.JsonRpcProvider;
 export type Signer = ethers.Signer;
 export type BeanstalkConfig = Partial<{
   provider: Provider;
+  readProvider?: Provider;
   signer: Signer;
   rpcUrl: string;
   subgraphUrl: string;
@@ -41,6 +42,7 @@ export class BeanstalkSDK {
   public DEBUG: boolean;
   public signer?: Signer;
   public provider: Provider;
+  public readProvider?: Provider;
   public providerOrSigner: Signer | Provider;
   public source: DataSource;
   public subgraphUrl: string;
@@ -116,6 +118,7 @@ export class BeanstalkSDK {
     } else {
       this.provider = (config.signer?.provider as Provider) ?? config.provider!;
     }
+    this.readProvider = config.readProvider;
     this.providerOrSigner = config.signer ?? config.provider!;
 
     this.DEBUG = config.DEBUG ?? false;

--- a/projects/sdk/src/lib/contracts.ts
+++ b/projects/sdk/src/lib/contracts.ts
@@ -29,7 +29,7 @@ import {
   Math,
   Math__factory,
   UsdOracle,
-  UsdOracle__factory,
+  UsdOracle__factory
 } from "src/constants/generated";
 import { BaseContract } from "ethers";
 
@@ -53,6 +53,7 @@ export class Contracts {
   static sdk: BeanstalkSDK;
 
   public readonly beanstalk: Beanstalk;
+  public readonly beanstalkRead: Beanstalk;
   public readonly beanstalkPrice: BeanstalkPrice;
   public readonly fertilizer: BeanstalkFertilizer;
 
@@ -90,6 +91,7 @@ export class Contracts {
 
     // Instances
     this.beanstalk = Beanstalk__factory.connect(beanstalkAddress, sdk.providerOrSigner);
+    this.beanstalkRead = Beanstalk__factory.connect(beanstalkAddress, sdk.readProvider ?? sdk.providerOrSigner);
     this.beanstalkPrice = BeanstalkPrice__factory.connect(beanstalkPriceAddress, sdk.providerOrSigner);
     this.fertilizer = BeanstalkFertilizer__factory.connect(beanstalkFertilizerAddress, sdk.providerOrSigner);
 

--- a/projects/sdk/src/lib/events/EventManager.ts
+++ b/projects/sdk/src/lib/events/EventManager.ts
@@ -62,18 +62,18 @@ export class EventManager {
     const toBlock = opts.toBlock ?? "latest";
 
     return Promise.all([
-      this.sdk.contracts.beanstalk.queryFilter(
-        this.sdk.contracts.beanstalk.filters.AddDeposit(account, opts.token?.address),
+      this.sdk.contracts.beanstalkRead.queryFilter(
+        this.sdk.contracts.beanstalkRead.filters.AddDeposit(account, opts.token?.address),
         fromBlock,
         toBlock
       ),
-      this.sdk.contracts.beanstalk.queryFilter(
-        this.sdk.contracts.beanstalk.filters.RemoveDeposit(account, opts.token?.address),
+      this.sdk.contracts.beanstalkRead.queryFilter(
+        this.sdk.contracts.beanstalkRead.filters.RemoveDeposit(account, opts.token?.address),
         fromBlock,
         toBlock
       ),
-      this.sdk.contracts.beanstalk.queryFilter(
-        this.sdk.contracts.beanstalk.filters.RemoveDeposits(account, opts.token?.address),
+      this.sdk.contracts.beanstalkRead.queryFilter(
+        this.sdk.contracts.beanstalkRead.filters.RemoveDeposits(account, opts.token?.address),
         fromBlock,
         toBlock
       )
@@ -87,19 +87,19 @@ export class EventManager {
     const toBlock = opts.toBlock ?? "latest";
 
     return Promise.all([
-      this.sdk.contracts.beanstalk.queryFilter(
-        this.sdk.contracts.beanstalk.filters["Sow(address,uint256,uint256,uint256)"](account),
+      this.sdk.contracts.beanstalkRead.queryFilter(
+        this.sdk.contracts.beanstalkRead.filters["Sow(address,uint256,uint256,uint256)"](account),
         fromBlock,
         toBlock
       ),
-      this.sdk.contracts.beanstalk.queryFilter(this.sdk.contracts.beanstalk.filters.Harvest(account), fromBlock, toBlock),
-      this.sdk.contracts.beanstalk.queryFilter(
-        this.sdk.contracts.beanstalk.filters.PlotTransfer(account, null), // from
+      this.sdk.contracts.beanstalkRead.queryFilter(this.sdk.contracts.beanstalkRead.filters.Harvest(account), fromBlock, toBlock),
+      this.sdk.contracts.beanstalkRead.queryFilter(
+        this.sdk.contracts.beanstalkRead.filters.PlotTransfer(account, null), // from
         fromBlock,
         toBlock
       ),
-      this.sdk.contracts.beanstalk.queryFilter(
-        this.sdk.contracts.beanstalk.filters.PlotTransfer(null, account), // to
+      this.sdk.contracts.beanstalkRead.queryFilter(
+        this.sdk.contracts.beanstalkRead.filters.PlotTransfer(null, account), // to
         fromBlock,
         toBlock
       )

--- a/projects/ui/src/components/App/SdkProvider.tsx
+++ b/projects/ui/src/components/App/SdkProvider.tsx
@@ -54,6 +54,7 @@ const useBeanstalkSdkContext = () => {
 
     const _sdk = new BeanstalkSDK({
       provider: provider as any,
+      readProvider: provider as any,
       signer: signer ?? undefined,
       source: datasource,
       DEBUG: IS_DEVELOPMENT_ENV,

--- a/projects/ui/src/graph/client.ts
+++ b/projects/ui/src/graph/client.ts
@@ -65,31 +65,6 @@ const mergeUsingSeasons: (keyArgs: string[]) => FieldPolicy = (keyArgs) => ({
         existing.length - 1 // clamp to last index
       );
 
-      console.debug('[apollo/client/read@seasons] READ:');
-      console.debug(
-        `| left:  index = ${left}, season = ${readField(
-          'season',
-          existing[left]
-        )}`
-      );
-      console.debug(
-        `| right: index = ${right}, season = ${readField(
-          'season',
-          existing[right]
-        )}`
-      );
-      console.debug(`| existing.length = ${existing.length}`);
-      console.debug(
-        `| existing[0] = ${readField('season', existing[0])}`,
-        existing
-      );
-      console.debug(
-        `| existing[${existing.length - 1}] = ${readField(
-          'season',
-          existing[existing.length - 1]
-        )}`
-      );
-
       // If one of the endpoints is missing, force refresh
       if (!existing[left] || !existing[right]) return;
 


### PR DESCRIPTION
This change adds a read only provider to the beanstalk SDK which allows the UI (or other consumers) to implement a different provider for read-only operations.

Specifically, this allows us to configure the UI to read silo balances using this provider, and this provider will be set to use BeanstalkFarms' Alchemy account... meaning no more RPC limit errors for users who have wallets/providers with low limits.