### PR TITLE
Silo v3.1

### DIFF
--- a/protocol/abi/Beanstalk.json
+++ b/protocol/abi/Beanstalk.json
@@ -5814,7 +5814,7 @@
     "outputs": [
       {
         "internalType": "bool",
-        "name": "",
+        "name": "hasMigrated",
         "type": "bool"
       }
     ],
@@ -7353,6 +7353,11 @@
           {
             "internalType": "uint16",
             "name": "stemStartSeason",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint16",
+            "name": "stemScaleSeason",
             "type": "uint16"
           },
           {

--- a/protocol/contracts/beanstalk/init/InitBipSeedGauge.sol
+++ b/protocol/contracts/beanstalk/init/InitBipSeedGauge.sol
@@ -62,7 +62,7 @@ contract InitBipSeedGauge is Weather {
         LibWhitelist.dewhitelistToken(C.CURVE_BEAN_METAPOOL);
 
         // set s.stemScaleSeason for silo v3.1.
-        s.season.stemStartSeason = uint16(s.season.current);
+        s.season.stemScaleSeason = uint16(s.season.current);
 
         // Update depositedBDV for bean, bean3crv, urBean, and urBeanETH.
         LibTokenSilo.incrementTotalDepositedBdv(
@@ -106,6 +106,11 @@ contract InitBipSeedGauge is Weather {
             s.ss[siloTokens[i]].gaugePoints = gaugePoints[i];
             s.ss[siloTokens[i]].optimalPercentDepositedBdv = optimalPercentDepositedBdv[i];
 
+            // if the silo token has a stalkEarnedPerSeason of 0, 
+            // update to 1.
+            if (s.ss[siloTokens[i]].stalkEarnedPerSeason == 0) {
+                LibWhitelist.updateStalkPerBdvPerSeasonForToken(siloTokens[i], 1);
+            }
             // get depositedBDV to use later:
             totalBdv += s.siloBalances[siloTokens[i]].depositedBdv;
 

--- a/protocol/contracts/beanstalk/init/InitBipSeedGauge.sol
+++ b/protocol/contracts/beanstalk/init/InitBipSeedGauge.sol
@@ -61,6 +61,8 @@ contract InitBipSeedGauge is Weather {
 
         LibWhitelist.dewhitelistToken(C.CURVE_BEAN_METAPOOL);
 
+        // set s.stemScaleSeason for silo v3.1.
+        s.season.stemStartSeason = uint16(s.season.current);
 
         // Update depositedBDV for bean, bean3crv, urBean, and urBeanETH.
         LibTokenSilo.incrementTotalDepositedBdv(

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -219,8 +219,9 @@ contract ConvertFacet is ReentrancyGuard {
         require(bdv > 0 && amount > 0, "Convert: BDV or amount is 0.");
         
         LibGerminate.Germinate germ;
-        // calculate the grownStalk, stem, and the germination state for the new deposit.
-        (grownStalk, stem, germ) = LibTokenSilo.calculateGrownStalkAndStem(token, grownStalk, bdv);
+
+        // calculate the stem and germination state for the new deposit.
+        (stem, germ) = LibTokenSilo.calculateStemForTokenFromGrownStalk(token, grownStalk, bdv);
         
         // increment totals based on germination state, 
         // as well as issue stalk to the user.

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -83,7 +83,6 @@ contract ConvertFacet is ReentrancyGuard {
 
         LibSilo._mow(msg.sender, fromToken);
         LibSilo._mow(msg.sender, toToken);
-        
         (grownStalk, fromBdv) = _withdrawTokens(
             fromToken,
             stems,
@@ -246,6 +245,6 @@ contract ConvertFacet is ReentrancyGuard {
             amount,
             bdv,
             LibTokenSilo.Transfer.emitTransferSingle
-        );
+        );        
     }
 }

--- a/protocol/contracts/beanstalk/silo/MigrationFacet.sol
+++ b/protocol/contracts/beanstalk/silo/MigrationFacet.sol
@@ -104,8 +104,8 @@ contract MigrationFacet is ReentrancyGuard {
         }
 
         return (
-            s.a[account].legacyDeposits[token][season].amount,
-            s.a[account].legacyDeposits[token][season].bdv
+            s.a[account].legacyV2Deposits[token][season].amount,
+            s.a[account].legacyV2Deposits[token][season].bdv
         );
     }
 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloGettersFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloGettersFacet.sol
@@ -477,8 +477,8 @@ contract SiloGettersFacet is ReentrancyGuard {
     /**
      * @notice returns whether an account needs to migrate to siloV3.
      */
-    function migrationNeeded(address account) external view returns (bool) {
-        return LibSilo.migrationNeeded(account);
+    function migrationNeeded(address account) external view returns (bool hasMigrated) {
+        (hasMigrated, ) = LibSilo.migrationNeeded(account);
     }
 
     //////////////////////// INTERNAL ////////////////////////

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloGettersFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloGettersFacet.sol
@@ -453,7 +453,7 @@ contract SiloGettersFacet is ReentrancyGuard {
         view
         returns (int96 stem)
     {
-        uint256 seedsPerBdv = getSeedsPerToken(token);
+        uint256 seedsPerBdv = getSeedsPerToken(token).mul(1e6);
         stem = LibLegacyTokenSilo.seasonToStem(seedsPerBdv, season);
     }
 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -146,7 +146,7 @@ contract TokenSilo is Silo {
             stem = LibTokenSilo.stemTipForToken(token),
             amount
         );
-        LibSilo.mintStalk(account, stalk, germ);
+        LibSilo.mintGerminatingStalk(account, uint128(stalk), germ);
     }
 
     //////////////////////// WITHDRAW ////////////////////////
@@ -187,7 +187,7 @@ contract TokenSilo is Silo {
                 token,
                 amount,
                 bdvRemoved,
-                initalStalkRemoved, 
+                initalStalkRemoved,
                 germinate
             );
 
@@ -327,7 +327,6 @@ contract TokenSilo is Silo {
                 amount,
                 LibTokenSilo.Transfer.noEmitTransferSingle
             );
-
         LibTokenSilo.addDepositToAccount(
             recipient,
             token,

--- a/protocol/contracts/libraries/LibGauge.sol
+++ b/protocol/contracts/libraries/LibGauge.sol
@@ -103,7 +103,6 @@ library LibGauge {
             // if the usd price oracle failed, skip gauge point update.
             // Assumes that only Wells use USD price oracles.
             if (LibWell.isWell(whitelistedLpTokens[0]) && s.usdTokenPrice[whitelistedLpTokens[0]] == 0) {
-
                 return (maxLpGpPerBdv, lpGpData, totalGaugePoints, type(uint256).max);
             }
             uint256 gaugePoints = s.ss[whitelistedLpTokens[0]].gaugePoints;

--- a/protocol/contracts/libraries/LibIncentive.sol
+++ b/protocol/contracts/libraries/LibIncentive.sol
@@ -66,7 +66,7 @@ library LibIncentive {
      * "step" functions have been executed.
      */
     function determineReward(uint256 initialGasLeft, uint256 blocksLate, uint256 beanEthPrice)
-        internal
+        external
         view
         returns (uint256)
     {

--- a/protocol/contracts/libraries/Silo/LibGerminate.sol
+++ b/protocol/contracts/libraries/Silo/LibGerminate.sol
@@ -136,7 +136,7 @@ library LibGerminate {
         uint128 germinatingStalk;
 
         // check to end germination for first stalk.
-        // if last mowed season is the same as the current season - 1,
+        // if last mowed season is not equal to current season - 1,
         if (firstStalk > 0 && lastMowedSeason != currentSeason.sub(1)) {
             germinatingStalk = firstStalk;
             roots = getGerminatingRoots(account, lastMowedSeason, firstStalk, lastUpdateOdd);
@@ -355,8 +355,7 @@ library LibGerminate {
      * equal or higher than this value are germinating.
      */
     function _getGerminatingStem(address token, int96 stemTip) internal view returns (int96 stem) {
-        return
-            LibTokenSilo.truncateStem(stemTip.mul(1e6) - int96(getPrevStalkEarnedPerSeason(token)));
+        return stemTip - int96(getPrevStalkEarnedPerSeason(token));
     }
 
     /**

--- a/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
@@ -229,8 +229,8 @@ library LibLegacyTokenSilo {
     function _migrateNoDeposits(address account) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         require(s.a[account].s.seeds == 0, "only for zero seeds");
-        (bool migrationNeeded, ) = LibSilo.migrationNeeded(account);
-        require(migrationNeeded, "no migration needed");
+        (bool needsMigration, ) = LibSilo.migrationNeeded(account);
+        require(needsMigration, "no migration needed");
 
         s.a[account].lastUpdate = s.season.stemStartSeason;
     }
@@ -559,9 +559,9 @@ library LibLegacyTokenSilo {
         // The balanceOfSeeds(account) > 0 check is necessary if someone updates their Silo
         // in the same Season as BIP execution. Such that s.a[account].lastUpdate == s.season.stemStartSeason,
         // but they have not migrated yet
-        (bool migrationNeeded, ) = LibSilo.migrationNeeded(account);
+        (bool needsMigration, ) = LibSilo.migrationNeeded(account);
         require(
-            (migrationNeeded || balanceOfSeeds(account) > 0),
+            (needsMigration || balanceOfSeeds(account) > 0),
             "no migration needed"
         );
     }

--- a/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
@@ -90,7 +90,7 @@ library LibLegacyTokenSilo {
      * @dev Remove `amount` of `token` from a user's Deposit in `season`.
      *
      * A "Crate" refers to the existing Deposit in storage at:
-     *  `s.a[account].legacyDeposits[token][season]`
+     *  `s.a[account].legacyV2Deposits[token][season]`
      *
      * Partially removing a Deposit should scale its BDV proportionally. For ex.
      * removing 80% of the tokens from a Deposit should reduce its BDV by 80%.
@@ -113,8 +113,8 @@ library LibLegacyTokenSilo {
 
         uint256 crateAmount;
         (crateAmount, crateBDV) = (
-            s.a[account].legacyDeposits[token][season].amount,
-            s.a[account].legacyDeposits[token][season].bdv
+            s.a[account].legacyV2Deposits[token][season].amount,
+            s.a[account].legacyV2Deposits[token][season].bdv
         );
 
         // If amount to remove is greater than the amount in the Deposit, migrate legacy Deposit to new Deposit
@@ -140,14 +140,14 @@ library LibLegacyTokenSilo {
                 "Silo: uint128 overflow."
             );
 
-            s.a[account].legacyDeposits[token][season].amount = uint128(updatedAmount);
-            s.a[account].legacyDeposits[token][season].bdv = uint128(updatedBDV);
+            s.a[account].legacyV2Deposits[token][season].amount = uint128(updatedAmount);
+            s.a[account].legacyV2Deposits[token][season].bdv = uint128(updatedBDV);
 
             return removedBDV;
         }
 
         // Full Remove
-        delete s.a[account].legacyDeposits[token][season];
+        delete s.a[account].legacyV2Deposits[token][season];
     }
 
     //////////////////////// GETTERS ////////////////////////
@@ -229,8 +229,8 @@ library LibLegacyTokenSilo {
     function _migrateNoDeposits(address account) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         require(s.a[account].s.seeds == 0, "only for zero seeds");
-
-        require(LibSilo.migrationNeeded(account), "no migration needed");
+        (bool migrationNeeded, ) = LibSilo.migrationNeeded(account);
+        require(migrationNeeded, "no migration needed");
 
         s.a[account].lastUpdate = s.season.stemStartSeason;
     }
@@ -259,13 +259,9 @@ library LibLegacyTokenSilo {
         uint32[][] calldata seasons,
         uint256[][] calldata amounts
     ) internal returns (uint256) {
-        // The balanceOfSeeds(account) > 0 check is necessary if someone updates their Silo
-        // in the same Season as BIP execution. Such that s.a[account].lastUpdate == s.season.stemStartSeason,
-        // but they have not migrated yet
-        require(
-            (LibSilo.migrationNeeded(account) || balanceOfSeeds(account) > 0),
-            "no migration needed"
-        );
+        
+        // Validates whether a user needs to perform migration.
+        checkForMigration(account);
 
         // do a legacy mow using the old silo seasons deposits (this only mints stalk up to stemStartSeason)
         // should not germinate since all siloV2 deposits were deposited for > 2 seasons.
@@ -300,7 +296,7 @@ library LibLegacyTokenSilo {
                     perDepositData.amount
                 );
 
-                //calculate how much stalk has grown for this deposit
+                // calculate how much stalk has grown for this deposit
                 perDepositData.grownStalk = _calcGrownStalkForDeposit(
                     crateBDV.mul(getSeedsPerToken(address(perTokenData.token))),
                     perDepositData.season
@@ -552,5 +548,21 @@ library LibLegacyTokenSilo {
     function incrementMigratedBdv(address token, uint256 bdv) private {
         AppStorage storage s = LibAppStorage.diamondStorage();
         s.migratedBdvs[token] = s.migratedBdvs[token].add(bdv);
+    }
+
+    /**
+     * @notice internal logic for validating migration
+     * @dev placed in seperate function to avoid stack errors.
+     */
+    function checkForMigration(address account) internal view {
+
+        // The balanceOfSeeds(account) > 0 check is necessary if someone updates their Silo
+        // in the same Season as BIP execution. Such that s.a[account].lastUpdate == s.season.stemStartSeason,
+        // but they have not migrated yet
+        (bool migrationNeeded, ) = LibSilo.migrationNeeded(account);
+        require(
+            (migrationNeeded || balanceOfSeeds(account) > 0),
+            "no migration needed"
+        );
     }
 }

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -34,6 +34,9 @@ library LibTokenSilo {
     using SafeCast for uint256;
     using LibSafeMathSigned96 for int96;
 
+    uint256 constant PRECISION = 1e6; // increased precision from to silo v3.1.
+
+
     //////////////////////// ENUM ////////////////////////
     /**
      * @dev when a user deposits or withdraws a deposit, the
@@ -303,7 +306,7 @@ library LibTokenSilo {
                 msg.sender, // operator
                 address(0), // from
                 account, // to
-                uint256(depositId), // depositID
+                depositId, // depositID
                 amount // token amount
             );
         }
@@ -341,6 +344,22 @@ library LibTokenSilo {
 
         uint256 crateAmount = s.a[account].deposits[depositId].amount;
         crateBDV = s.a[account].deposits[depositId].bdv;
+
+        // if amount is > crateAmount, check if user has a legacy deposit:
+        if (amount > crateAmount) { 
+            // get the absolute stem value.
+            uint256 absStem = stem > 0 ? uint256(stem) : uint256(-stem);
+            // only stems with modulo 1e6 can have a legacy deposit.
+            if (absStem.mod(1e6) == 0) {
+                (crateAmount, crateBDV) = migrateLegacyStemDeposit(
+                    account,
+                    token,
+                    stem,
+                    crateAmount,
+                    crateBDV
+                );
+            }
+        }
         require(amount <= crateAmount, "Silo: Crate balance too low.");
 
         // Partial remove
@@ -478,7 +497,7 @@ library LibTokenSilo {
      * @dev returns the cumulative stalk per BDV (stemTip) for a whitelisted token.
      */
     function stemTipForToken(address token) internal view returns (int96 stemTip) {
-        return truncateStem(stemTipForTokenUntruncated(token));
+        return stemTipForTokenUntruncated(token);
     }
 
     /**
@@ -519,19 +538,14 @@ library LibTokenSilo {
     /**
      * @notice returns the grown stalk and germination state of a deposit,
      * based on the amount of grown stalk it has earned.
-     * 
-     * @dev if we attempt to deposit at a half-season (a grown stalk index that would fall between seasons)
-     * the user loses that partial season's worth of stalk. Grown stalk will need to be updated if so.
-     * 
      */
-    function calculateGrownStalkAndStem(
+    function calculateStemForTokenFromGrownStalk(
         address token,
         uint256 grownStalk,
         uint256 bdv
-    ) internal view returns (uint256 _grownStalk, int96 stem, LibGerminate.Germinate germ) {
+    ) internal view returns (int96 stem, LibGerminate.Germinate germ) {
         LibGerminate.GermStem memory germStem = LibGerminate.getGerminatingStem(token);
-        stem = germStem.stemTip.sub(toInt96(grownStalk.div(bdv)));
-        _grownStalk = uint256(germStem.stemTip.sub(stem).mul(toInt96(bdv)));
+        stem = germStem.stemTip.sub(toInt96(grownStalk.mul(PRECISION).div(bdv)));
         germ = LibGerminate._getGerminationState(stem, germStem);
     }
 
@@ -551,10 +565,49 @@ library LibTokenSilo {
         // end up rounding to zero, then you get a divide by zero error and can't migrate without losing that deposit
 
         // prevent divide by zero error
-        int96 grownStalkPerBdv = bdv > 0 ? toInt96(grownStalk.div(bdv)) : 0;
+        int96 grownStalkPerBdv = bdv > 0 ? toInt96(grownStalk.mul(PRECISION).div(bdv)) : 0;
 
         // subtract from the current latest index, so we get the index the deposit should have happened at
         return _stemTipForToken.sub(grownStalkPerBdv);
+    }
+
+    /**
+     * @notice internal logic for migrating a legacy deposit.
+     * @dev 
+     */
+    function migrateLegacyStemDeposit(
+        address account, 
+        address token,
+        int96 newStem,
+        uint256 crateAmount,
+        uint256 crateBdv
+    ) internal returns (uint256, uint256) { 
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        // divide the newStem by 1e6 to get the legacy stem.
+        uint256 legacyDepositId = LibBytes.packAddressAndStem(token, newStem.div(1e6));
+        uint256 legacyAmount = s.a[account].legacyV3Deposits[legacyDepositId].amount;
+        crateAmount = crateAmount.add(legacyAmount);
+        crateBdv = crateBdv.add(s.a[account].legacyV3Deposits[legacyDepositId].bdv);
+        delete s.a[account].legacyV3Deposits[legacyDepositId];
+
+        // 'burn' the legacy deposit, and 'mint' a new deposit.
+        emit TransferSingle(
+            msg.sender,
+            account,
+            address(0),
+            legacyDepositId,
+            legacyAmount
+        );
+
+        emit TransferSingle(
+            msg.sender,
+            address(0),
+            account,
+            LibBytes.packAddressAndStem(token, newStem),
+            legacyAmount
+        );
+
+        return (crateAmount, crateBdv);
     }
 
     function toInt96(uint256 value) internal pure returns (int96) {

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -474,9 +474,8 @@ library LibTokenSilo {
 
     /**
      * @dev returns the cumulative stalk per BDV (stemTip) for a whitelisted token.
-     * Does not truncate the value, i.e. divide by 1e6
      */
-    function stemTipForTokenUntruncated(
+    function stemTipForToken(
         address token
     ) internal view returns (int96 _stemTip) {
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -486,17 +485,6 @@ library LibTokenSilo {
             int96(s.ss[token].stalkEarnedPerSeason).mul(
                 int96(s.season.current).sub(int96(s.ss[token].milestoneSeason))
             );
-    }
-
-    function truncateStem(int96 stemTip) internal pure returns (int96) {
-        return stemTip.div(1e6);
-    }
-
-    /**
-     * @dev returns the cumulative stalk per BDV (stemTip) for a whitelisted token.
-     */
-    function stemTipForToken(address token) internal view returns (int96 stemTip) {
-        return stemTipForTokenUntruncated(token);
     }
 
     /**

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -62,6 +62,17 @@ library LibTokenSilo {
         uint256 bdv
     );
 
+    /**
+     * @dev IMPORTANT: copy of {TokenSilo-RemoveDeposit}, check there for details.
+     */
+    event RemoveDeposit(
+        address indexed account,
+        address indexed token,
+        int96 stem,
+        uint256 amount,
+        uint256 bdv
+    );
+
     // added as the ERC1155 deposit upgrade
     event TransferSingle(
         address indexed operator,

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -344,7 +344,6 @@ library LibTokenSilo {
 
         uint256 crateAmount = s.a[account].deposits[depositId].amount;
         crateBDV = s.a[account].deposits[depositId].bdv;
-
         // if amount is > crateAmount, check if user has a legacy deposit:
         if (amount > crateAmount) { 
             // get the absolute stem value.
@@ -518,7 +517,7 @@ library LibTokenSilo {
         if(deltaStemTip == 0) return 0;
         (, uint bdv) = getDeposit(account, token, stem);
 
-        grownStalk = deltaStemTip.mul(bdv);
+        grownStalk = deltaStemTip.mul(bdv).div(PRECISION);
     }
 
     /**

--- a/protocol/contracts/libraries/Silo/LibUnripeSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibUnripeSilo.sol
@@ -119,7 +119,7 @@ library LibUnripeSilo {
         // Sum the `account` pre-exploit Silo V1 Bean Balance 
         // and the Silo V2 Unripe Bean Balance
         amount = uint256(
-            s.a[account].legacyDeposits[C.UNRIPE_BEAN][season].amount
+            s.a[account].legacyV2Deposits[C.UNRIPE_BEAN][season].amount
         ).add(legacyAmount);
         
         // Sum the BDV of the `account` pre-exploit Silo V1 Bean Balance 
@@ -127,7 +127,7 @@ library LibUnripeSilo {
         //
         // The BDV of the Silo V1 Bean Balance is equal to the amount of Beans
         // (where 1 Bean = 1 BDV) times the initial recapitalization percent.
-        bdv = uint256(s.a[account].legacyDeposits[C.UNRIPE_BEAN][season].bdv)
+        bdv = uint256(s.a[account].legacyV2Deposits[C.UNRIPE_BEAN][season].bdv)
             .add(legacyAmount.mul(C.initialRecap()).div(1e18));
         
     }
@@ -160,8 +160,8 @@ library LibUnripeSilo {
         AppStorage storage s = LibAppStorage.diamondStorage();
         delete s.a[account].lp.depositSeeds[season];
         delete s.a[account].lp.deposits[season];
-        delete s.a[account].legacyDeposits[C.unripeLPPool1()][season];
-        delete s.a[account].legacyDeposits[C.unripeLPPool2()][season];
+        delete s.a[account].legacyV2Deposits[C.unripeLPPool1()][season];
+        delete s.a[account].legacyV2Deposits[C.unripeLPPool2()][season];
     }
 
     /**1000000000000000017348
@@ -191,7 +191,7 @@ library LibUnripeSilo {
 
         // Summate the amount acrosses all 4 potential Unripe BEAN:3CRV storage locations.
         amount = uint256(
-            s.a[account].legacyDeposits[C.UNRIPE_LP][season].amount
+            s.a[account].legacyV2Deposits[C.UNRIPE_LP][season].amount
         ).add(amount.add(amount1).add(amount2));
         
         // Summate the BDV acrosses all 3 pre-exploit LP Silo Deposit storages
@@ -203,7 +203,7 @@ library LibUnripeSilo {
         // Summate the pre-exploit legacy BDV and the BDV stored in the
         // Unripe BEAN:3CRV Silo Deposit storage.
         bdv = uint256(
-            s.a[account].legacyDeposits[C.UNRIPE_LP][season].bdv
+            s.a[account].legacyV2Deposits[C.UNRIPE_LP][season].bdv
         ).add(legBdv);
         
     }
@@ -258,12 +258,12 @@ library LibUnripeSilo {
         returns (uint256 amount, uint256 bdv)
     {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        bdv = uint256(s.a[account].legacyDeposits[C.unripeLPPool2()][season].bdv);
+        bdv = uint256(s.a[account].legacyV2Deposits[C.unripeLPPool2()][season].bdv);
 
         // `amount` is equal to the pre-exploit BDV of the Deposited BEAN:LUSD
         // tokens. This is the equivalent amount of Unripe BEAN:3CRV LP.
         amount = uint256(
-            s.a[account].legacyDeposits[C.unripeLPPool2()][season].amount
+            s.a[account].legacyV2Deposits[C.unripeLPPool2()][season].amount
         ).mul(AMOUNT_TO_BDV_BEAN_LUSD).div(C.precision());
     }
 
@@ -279,12 +279,12 @@ library LibUnripeSilo {
         returns (uint256 amount, uint256 bdv)
     {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        bdv = uint256(s.a[account].legacyDeposits[C.unripeLPPool1()][season].bdv);
+        bdv = uint256(s.a[account].legacyV2Deposits[C.unripeLPPool1()][season].bdv);
 
         // `amount` is equal to the pre-exploit BDV of the Deposited BEAN:3CRV
         // tokens. This is the equivalent amount of Unripe BEAN:3CRV LP.
         amount = uint256(
-            s.a[account].legacyDeposits[C.unripeLPPool1()][season].amount
+            s.a[account].legacyV2Deposits[C.unripeLPPool1()][season].amount
         ).mul(AMOUNT_TO_BDV_BEAN_3CRV).div(C.precision());
     }
 }

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -176,7 +176,7 @@ library LibWhitelist {
         if(stalkEarnedPerSeason == 0) stalkEarnedPerSeason = 1;
 
         // update milestone stem and season.
-        s.ss[token].milestoneStem = LibTokenSilo.stemTipForTokenUntruncated(token); 
+        s.ss[token].milestoneStem = LibTokenSilo.stemTipForToken(token); 
         s.ss[token].milestoneSeason = s.season.current;
        
         // stalkEarnedPerSeason is set to int32 before casting down.

--- a/protocol/contracts/libraries/Well/LibWell.sol
+++ b/protocol/contracts/libraries/Well/LibWell.sol
@@ -81,7 +81,7 @@ library LibWell {
 
     /**
      * @dev Returns the non-Bean token within a Well.
-     * Assumes a well with 2 tokens only.
+     * Assumes a well with 2 tokens only, with Bean being one of them.
      * Cannot fail (and thus revert), as wells cannot have 2 of the same tokens as the pairing.
      */
     function getNonBeanTokenAndIndexFromWell(

--- a/protocol/contracts/mocks/MockERC721.sol
+++ b/protocol/contracts/mocks/MockERC721.sol
@@ -17,8 +17,8 @@ contract MockERC721 is ERC721 {
     function permit(
         address spender,
         uint256 tokenId,
-        uint256 deadline,
-        bytes memory signature
+        uint256,
+        bytes memory
     ) public {
         _approve(spender, tokenId);
     }

--- a/protocol/contracts/mocks/MockInitDiamond.sol
+++ b/protocol/contracts/mocks/MockInitDiamond.sol
@@ -50,6 +50,7 @@ contract MockInitDiamond is InitWhitelist, Weather {
         s.twaReserves[C.BEAN_ETH_WELL].reserve1 = 1;
 
         s.season.stemStartSeason = uint16(s.season.current);
+        s.season.stemScaleSeason = uint16(s.season.current);
         s.seedGauge.beanToMaxLpGpPerBdvRatio = 50e18; // 50%
         s.seedGauge.averageGrownStalkPerBdvPerSeason = 3e6;
 

--- a/protocol/contracts/mocks/mockFacets/MockAdminFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockAdminFacet.sol
@@ -65,4 +65,21 @@ contract MockAdminFacet is Sun {
     function update3CRVOracle() public {
         LibCurveMinting.updateOracle();
     }
+
+    function updateStemScaleSeason(uint16 season) public {
+        s.season.stemScaleSeason = season;
+    }
+
+    function updateStems() public { 
+        address[] memory siloTokens = LibWhitelistedTokens.getSiloTokens();
+        for (uint256 i = 0; i < siloTokens.length; i++) {
+            s.ss[siloTokens[i]].milestoneStem = int96(s.ss[siloTokens[i]].milestoneStem * 1e6);
+        }
+    }
+
+    function upgradeStems() public { 
+        updateStemScaleSeason(uint16(s.season.current));
+        updateStems();
+    }
+
 }

--- a/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -193,7 +193,10 @@ contract MockSeasonFacet is SeasonFacet  {
         for (uint256 i; i < number; ++i) {
             s.season.current += 1;
             s.season.timestamp = block.timestamp;
-            LibGerminate.endTotalGermination(s.season.current, LibWhitelistedTokens.getWhitelistedTokens());
+            // ending germination only needs to occur for the first two loops.
+            if(i < 2) { 
+                LibGerminate.endTotalGermination(s.season.current, LibWhitelistedTokens.getWhitelistedTokens());
+            }
         }
         s.season.sunriseBlock = uint32(block.number);
     }

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -56,7 +56,7 @@ contract MockSiloFacet is SiloFacet {
         uint256 seeds = bdv.mul(LibLegacyTokenSilo.getSeedsPerToken(C.UNRIPE_LP));
         uint256 stalk = bdv.mul(s.ss[C.UNRIPE_LP].stalkIssuedPerBdv).add(stalkRewardLegacy(seeds, s.season.current - _s));
         // not germinating because this is a old deposit.
-        LibSilo.mintStalk(msg.sender, stalk, LibGerminate.Germinate.NOT_GERMINATING);
+        LibSilo.mintActiveStalk(msg.sender, stalk);
         mintSeeds(msg.sender, seeds);
         LibTransfer.receiveToken(IERC20(C.UNRIPE_LP), unripeLP, msg.sender, LibTransfer.From.EXTERNAL);
     }
@@ -74,7 +74,7 @@ contract MockSiloFacet is SiloFacet {
         uint256 seeds = partialAmount.mul(LibLegacyTokenSilo.getSeedsPerToken(C.UNRIPE_BEAN));
         uint256 stalk = partialAmount.mul(s.ss[C.UNRIPE_BEAN].stalkIssuedPerBdv).add(stalkRewardLegacy(seeds, s.season.current - _s));
         
-        LibSilo.mintStalk(msg.sender, stalk, LibGerminate.Germinate.NOT_GERMINATING);
+        LibSilo.mintActiveStalk(msg.sender, stalk);
         mintSeeds(msg.sender, seeds);
         LibTransfer.receiveToken(IERC20(C.UNRIPE_BEAN), amount, msg.sender, LibTransfer.From.EXTERNAL);
     }
@@ -123,7 +123,7 @@ contract MockSiloFacet is SiloFacet {
     function __mowLegacy(address account) private {
         // If this `account` has no Seeds, skip to save gas.
         if (s.a[account].s.seeds == 0) return;
-        LibSilo.mintStalk(account, balanceOfGrownStalkLegacy(account), LibGerminate.Germinate.NOT_GERMINATING);
+        LibSilo.mintActiveStalk(account, balanceOfGrownStalkLegacy(account));
     }
 
     function handleRainAndSopsLegacy(address account, uint32 _lastUpdate) private {
@@ -257,7 +257,7 @@ contract MockSiloFacet is SiloFacet {
             s.season.current,
             amount
         );
-        LibSilo.mintStalk(account, stalk, LibGerminate.Germinate.NOT_GERMINATING);
+        LibSilo.mintActiveStalk(account, stalk);
         mintSeeds(account, seeds);
     }
 

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -205,8 +205,8 @@ contract MockSiloFacet is SiloFacet {
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        s.a[account].legacyDeposits[token][season].amount += uint128(amount);
-        s.a[account].legacyDeposits[token][season].bdv += uint128(bdv);
+        s.a[account].legacyV2Deposits[token][season].amount += uint128(amount);
+        s.a[account].legacyV2Deposits[token][season].bdv += uint128(bdv);
 
         emit AddDeposit(account, token, season, amount, bdv);
     }
@@ -369,7 +369,7 @@ contract MockSiloFacet is SiloFacet {
         view
         returns (int96 stem)
     {
-        stem = LibLegacyTokenSilo.seasonToStem(mockGetSeedsPerToken(token), season);
+        stem = LibLegacyTokenSilo.seasonToStem(mockGetSeedsPerToken(token).mul(1e6), season);
     }
 
     function mockGetSeedsPerToken(address token) public pure returns (uint256) {

--- a/protocol/contracts/mocks/well/MockSetComponentsWell.sol
+++ b/protocol/contracts/mocks/well/MockSetComponentsWell.sol
@@ -108,7 +108,7 @@ contract MockSetComponentsWell is MockToken {
         uint256 amountIn,
         uint256 minAmountOut,
         address recipient,
-        uint256 deadline
+        uint256
     ) external returns (uint256 amountOut) {
         fromToken.safeTransferFrom(msg.sender, address(this), amountIn);
         amountOut = _swapFrom(fromToken, toToken, amountIn, minAmountOut, recipient);

--- a/protocol/scripts/bips.js
+++ b/protocol/scripts/bips.js
@@ -220,11 +220,12 @@ async function bipSeedGauge(mock = true, account = undefined, verbose = true) {
       initFacetName: "InitBipSeedGauge",
       selectorsToRemove: [],
       libraryNames: [
-        'LibGauge', 'LibConvert', 'LibLockedUnderlying',
+        'LibGauge', 'LibConvert', 'LibLockedUnderlying', 'LibIncentive'
       ],
       facetLibraries: {
         'SeasonFacet': [
           'LibGauge',
+          'LibIncentive',
           'LibLockedUnderlying',
         ],
         'SeasonGettersFacet': [

--- a/protocol/scripts/deploy.js
+++ b/protocol/scripts/deploy.js
@@ -107,7 +107,7 @@ async function main(scriptName, verbose = true, mock = false, reset = true) {
 
   // A list of public libraries that need to be deployed separately.
   const libraryNames = [
-    'LibGauge', 'LibConvert', 'LibLockedUnderlying', 'LibCurveMinting'
+    'LibGauge', 'LibIncentive', 'LibConvert', 'LibLockedUnderlying', 'LibCurveMinting'
   ]
 
   // A mapping of facet to public library names that will be linked to it.
@@ -119,6 +119,7 @@ async function main(scriptName, verbose = true, mock = false, reset = true) {
     ],
     'MockSeasonFacet': [
       'LibGauge',
+      'LibIncentive',
       'LibLockedUnderlying',
       'LibCurveMinting'
     ],

--- a/protocol/test/Bean3CrvToBeanEthMigration.test.js
+++ b/protocol/test/Bean3CrvToBeanEthMigration.test.js
@@ -4,9 +4,10 @@ const { BEAN, FERTILIZER, USDC, BEAN_3_CURVE, THREE_CURVE, UNRIPE_BEAN, UNRIPE_L
 const { setEthUsdcPrice, setEthUsdPrice } = require('../utils/oracle.js');
 const { to6, to18 } = require('./utils/helpers.js');
 const { bipMigrateUnripeBean3CrvToBeanEth } = require('../scripts/bips.js');
-const { getBeanstalk } = require('../utils/contracts.js');
+const { getBeanstalk, getBeanstalkAdminControls } = require('../utils/contracts.js');
 const { impersonateBeanstalkOwner, impersonateSigner } = require('../utils/signer.js');
 const { ethers } = require('hardhat');
+const { upgradeWithNewFacets } = require("../scripts/diamond");
 const { mintEth, mintBeans } = require('../utils/mint.js');
 const { ConvertEncoder } = require('./utils/encoder.js');
 const { setReserves } = require('../utils/well.js');
@@ -38,7 +39,7 @@ describe('Bean:3Crv to Bean:Eth Migration', function () {
         ],
       });
     } catch(error) {
-      console.log('forking error in Silo V3: Grown Stalk Per Bdv:');
+      console.log('forking error in bean3crv -> bean:eth');
       console.log(error);
       return
     }
@@ -57,6 +58,22 @@ describe('Bean:3Crv to Bean:Eth Migration', function () {
     underlyingBefore = await this.beanstalk.getTotalUnderlying(UNRIPE_LP);
 
     await bipMigrateUnripeBean3CrvToBeanEth(true, undefined, false)
+
+    // upgrade beanstalk with admin Facet to update stems:
+    await mintEth(owner.address);
+    await upgradeWithNewFacets({
+      diamondAddress: BEANSTALK,
+      facetNames: [
+        'MockAdminFacet'
+      ],
+      initArgs: [],
+      bip: false,
+      verbose: false,
+      account: owner
+    });
+    const beanstalkAdmin = await getBeanstalkAdminControls();
+    await beanstalkAdmin.upgradeStems();
+
   });
 
   beforeEach(async function () {
@@ -100,13 +117,13 @@ describe('Bean:3Crv to Bean:Eth Migration', function () {
       })
 
       it('convert Unripe Bean to LP fails', async function () {
-        await expect(this.beanstalk.connect(publius).convert(ConvertEncoder.convertUnripeBeansToLP(to6('200'), '0'), ['-16272'], [to6('200')])).to.be.revertedWith('SafeMath: division by zero');
+        await expect(this.beanstalk.connect(publius).convert(ConvertEncoder.convertUnripeBeansToLP(to6('200'), '0'), ['-16272000000'], [to6('200')])).to.be.revertedWith('SafeMath: division by zero');
       })
 
       it('convert Unripe LP to Bean fails', async function () {
         const liquidityRemover = await impersonateSigner('0x7eaE23DD0f0d8289d38653BCE11b92F7807eFB64', true);
         await this.well.connect(liquidityRemover).removeLiquidityOneToken(to18('29'), WETH, '0', liquidityRemover.address, ethers.constants.MaxUint256)
-        await expect(this.beanstalk.connect(publius).convert(ConvertEncoder.convertUnripeLPToBeans(to6('200'), '0'), ['-56836'], [to6('200')])).to.be.revertedWith('SafeMath: division by zero');
+        await expect(this.beanstalk.connect(publius).convert(ConvertEncoder.convertUnripeLPToBeans(to6('200'), '0'), ['-56836000000'], [to6('200')])).to.be.revertedWith('SafeMath: division by zero');
       })
     })
   })
@@ -167,7 +184,7 @@ describe('Bean:3Crv to Bean:Eth Migration', function () {
       })
 
       it('convert Unripe Bean to LP succeeds', async function () {
-        await this.beanstalk.connect(publius).convert(ConvertEncoder.convertUnripeBeansToLP(to6('200'), '0'), ['-16272'], [to6('200')]);
+        await this.beanstalk.connect(publius).convert(ConvertEncoder.convertUnripeBeansToLP(to6('200'), '0'), ['-16272000000'], [to6('200')]);
       })
 
       it('convert Unripe LP to Bean succeeds', async function () {
@@ -175,7 +192,7 @@ describe('Bean:3Crv to Bean:Eth Migration', function () {
         await this.bean.mint(user.address, to6('100000'))
         await this.bean.connect(user).approve(BEAN_ETH_WELL, to6('100000'))
         await this.beanEth.connect(user).addLiquidity([to6('100000'), '0'], '0', user.address, ethers.constants.MaxUint256);
-        await this.beanstalk.connect(publius).convert(ConvertEncoder.convertUnripeLPToBeans(to6('200'), '0'), ['-56836'], [to6('200')])
+        await this.beanstalk.connect(publius).convert(ConvertEncoder.convertUnripeLPToBeans(to6('200'), '0'), ['-56836000000'], [to6('200')])
       })
     })
   })

--- a/protocol/test/ConvertCurve.test.js
+++ b/protocol/test/ConvertCurve.test.js
@@ -538,9 +538,7 @@ describe('Curve Convert', function () {
             [this.stem], 
             [to18('100')]
           )
-          // bean3CRV had 4 seeds, meaning in 2 seasons, this deposit has grown 8 micro stalk.
-          // with bean having 2 seeds, it would take 4 seasons to grow 8 micro stalk.
-          this.beanStem = '-3'
+          this.beanStem = -3950850
         });
 
         it('properly updates total values', async function () {
@@ -548,12 +546,11 @@ describe('Curve Convert', function () {
           expect(await this.siloGetters.getTotalDepositedBdv(this.bean.address)).to.eq('100618167');
           expect(await this.siloGetters.getTotalDeposited(this.beanMetapool.address)).to.eq(to18('900'));
           expect(await this.siloGetters.getTotalDepositedBdv(this.beanMetapool.address)).to.eq(to6('900'));
-          // some stalk is lost due to precision.
-          expect(await this.siloGetters.totalStalk()).to.eq('10014085997169');
+          expect(await this.siloGetters.totalStalk()).to.eq('10014181670000');
         });
 
         it('properly updates user values', async function () {
-          expect(await this.siloGetters.balanceOfStalk(userAddress)).to.eq('10014085997169');
+          expect(await this.siloGetters.balanceOfStalk(userAddress)).to.eq('10014181670000');
         });
 
         it('properly updates user deposits', async function () {
@@ -609,9 +606,7 @@ describe('Curve Convert', function () {
             [this.stem], 
             [to18('300')]
           )
-          // bean3CRV had 4 seeds, meaning in 2 seasons, this deposit has grown 8 micro stalk.
-          // with bean having 2 seeds, it would take 4 seasons to grow 8 micro stalk.
-          this.beanStem = '-3'
+          this.beanStem = -3966705
         });
 
         it('properly updates total values', async function () {
@@ -619,11 +614,11 @@ describe('Curve Convert', function () {
           expect(await this.siloGetters.getTotalDepositedBdv(this.bean.address)).to.eq('200018189');
           expect(await this.siloGetters.getTotalDeposited(this.beanMetapool.address)).to.eq('800814241685186471402');
           expect(await this.siloGetters.getTotalDepositedBdv(this.beanMetapool.address)).to.eq('800814242');
-          expect(await this.siloGetters.totalStalk()).to.eq('10016130951259');
+          expect(await this.siloGetters.totalStalk()).to.eq('10016324310000');
         });
 
         it('properly updates user values', async function () {
-          expect(await this.siloGetters.balanceOfStalk(userAddress)).to.eq('10016130951259');
+          expect(await this.siloGetters.balanceOfStalk(userAddress)).to.eq('10016324310000');
         });
 
         it('properly updates user deposits', async function () {
@@ -674,7 +669,7 @@ describe('Curve Convert', function () {
               [this.stem, this.stem2], 
               [to18('50'), to18('50')]
             )
-          this.beanStem = '-3';
+          this.beanStem = -3938563;
         });
 
         it('properly updates total values', async function () {
@@ -682,11 +677,11 @@ describe('Curve Convert', function () {
           expect(await this.siloGetters.getTotalDepositedBdv(this.bean.address)).to.eq('100618167');
           expect(await this.siloGetters.getTotalDeposited(this.beanMetapool.address)).to.eq(to18('900'));
           expect(await this.siloGetters.getTotalDepositedBdv(this.beanMetapool.address)).to.eq(to6('900'));
-          expect(await this.siloGetters.totalStalk()).to.eq('10016087233503');
+          expect(await this.siloGetters.totalStalk()).to.eq('10016181670000');
         });
 
         it('properly updates user values', async function () {
-          expect(await this.siloGetters.balanceOfStalk(userAddress)).to.eq('10016087233503');
+          expect(await this.siloGetters.balanceOfStalk(userAddress)).to.eq('10016181670000');
         });
 
         it('properly updates user deposits', async function () {

--- a/protocol/test/Depot.test.js
+++ b/protocol/test/Depot.test.js
@@ -161,26 +161,26 @@ describe('Depot', function () {
                 user.address,
                 PIPELINE,
                 BEAN,
-                [0,2],
+                [to6('0'), to6('2')],
                 [to6('1'), to6('1')]
             ])
             await this.depot.connect(user).farm([permit, transfer])
         })
 
         it('pipeline has deposits', async function () {
-            const deposit = await this.beanstalk.getDeposit(PIPELINE, BEAN, 0)
+            const deposit = await this.beanstalk.getDeposit(PIPELINE, BEAN, to6('0'))
             expect(deposit[0]).to.be.equal(to6('1'))
             expect(deposit[1]).to.be.equal(to6('1'))
-            const deposit2 = await this.beanstalk.getDeposit(PIPELINE, BEAN, 2)
+            const deposit2 = await this.beanstalk.getDeposit(PIPELINE, BEAN, to6('2'))
             expect(deposit2[0]).to.be.equal(to6('1'))
             expect(deposit2[1]).to.be.equal(to6('1'))
         })
 
         it('user does not have deposits', async function () {
-            const deposit = await this.beanstalk.getDeposit(user.address, BEAN, 0)
+            const deposit = await this.beanstalk.getDeposit(user.address, BEAN, to6('0'))
             expect(deposit[0]).to.be.equal(to6('0'))
             expect(deposit[1]).to.be.equal(to6('0'))
-            const deposit2 = await this.beanstalk.getDeposit(user.address, BEAN, 2)
+            const deposit2 = await this.beanstalk.getDeposit(user.address, BEAN, to6('2'))
             expect(deposit2[0]).to.be.equal(to6('0'))
             expect(deposit2[1]).to.be.equal(to6('0'))
         })
@@ -207,7 +207,7 @@ describe('Depot', function () {
                 user.address,
                 PIPELINE,
                 BEAN,
-                0,
+                to6('0'),
                 to6('1')
             ])
 
@@ -215,7 +215,7 @@ describe('Depot', function () {
                 user.address,
                 PIPELINE,
                 this.siloToken.address,
-                0,
+                to6('0'),
                 to6('1')
             ])
             await this.depot.connect(user).farm([permit, transfer, transfer2])
@@ -256,7 +256,7 @@ describe('Depot', function () {
                 user.address,
                 PIPELINE,
                 this.siloToken.address,
-                [0],
+                [to6('0')],
                 [to6('1')]
             )).to.be.revertedWith("invalid sender")
         })

--- a/protocol/test/Gauge.test.js
+++ b/protocol/test/Gauge.test.js
@@ -363,15 +363,6 @@ describe('Gauge', function () {
       // deposit beanETH:
       await this.silo.connect(user).deposit(BEAN_ETH_WELL, to18('1'), EXTERNAL)
       await this.bean.mint(userAddress, to6('10000'))
-      // await this.curve.connect(user).addLiquidity(
-      //   BEAN_3_CURVE,
-      //   STABLE_FACTORY,
-      //   [to6('1000'), to18('1000')],
-      //   to18('2000'),
-      //   EXTERNAL,
-      //   EXTERNAL
-      // )
-      // await this.silo.connect(user).deposit(BEAN_3_CURVE, to18('63.245537'), EXTERNAL)
       // deposit beans:
       await this.silo.connect(user).deposit(BEAN, to6('100'), EXTERNAL)
 

--- a/protocol/test/Gauge.test.js
+++ b/protocol/test/Gauge.test.js
@@ -404,7 +404,7 @@ describe('Gauge', function () {
       expect(await this.seasonGetters.getStalkPerGp()).to.be.eq(('224048'))
       expect((await this.siloGetters.tokenSettings(BEAN))[1]).to.be.eq(2656883) // 2.65 seeds per BDV
       expect((await this.siloGetters.tokenSettings(BEAN_ETH_WELL))[1]).to.be.eq(3542510) // 3.54 seeds per BDV
-      expect((await this.siloGetters.tokenSettings(BEAN_3_CURVE))[1]).to.be.eq(0) // 0 seeds
+      expect((await this.siloGetters.tokenSettings(BEAN_3_CURVE))[1]).to.be.eq(1) // 1 seeds
     })
     
     // note: with dewhitelisting bean3crv, only one LP pool is active and thus 

--- a/protocol/test/Season.test.js
+++ b/protocol/test/Season.test.js
@@ -112,7 +112,7 @@ describe('Season', function () {
             await setToSecondsAfterHour(0)
             await beanstalk.connect(owner).sunrise();
 
-            expect(await bean.balanceOf(owner.address)).to.be.within('11700000', '11900000')
+            expect(await bean.balanceOf(owner.address)).to.be.within('15300000', '15600000')
         })
     })
 })

--- a/protocol/test/SeedGaugeMainnet.test.js
+++ b/protocol/test/SeedGaugeMainnet.test.js
@@ -1,4 +1,4 @@
-const { BEAN, BEAN_3_CURVE, STABLE_FACTORY, UNRIPE_BEAN, UNRIPE_LP, WETH, BEANSTALK, BEAN_ETH_WELL } = require('./utils/constants.js');
+const { BEAN, BEAN_3_CURVE, STABLE_FACTORY, UNRIPE_BEAN, UNRIPE_LP, WETH, BEANSTALK, BEAN_ETH_WELL, ZERO_ADDRESS } = require('./utils/constants.js');
 const { EXTERNAL, INTERNAL, INTERNAL_EXTERNAL, INTERNAL_TOLERANT } = require('./utils/balances.js')
 const { impersonateBeanstalkOwner, impersonateSigner } = require('../utils/signer.js');
 const { time, mine } = require("@nomicfoundation/hardhat-network-helpers");
@@ -33,7 +33,7 @@ describe('SeedGauge Init Test', function () {
           {
             forking: {
               jsonRpcUrl: process.env.FORKING_RPC,
-              blockNumber: 18696041 //a random semi-recent block close to Grown Stalk Per Bdv pre-deployment
+              blockNumber: 19049520 //a random semi-recent block close to Grown Stalk Per Bdv pre-deployment
             },
           },
         ],
@@ -79,25 +79,25 @@ describe('SeedGauge Init Test', function () {
     })
 
     it('average grown stalk per BDV per Season', async function () {
-      expect(await this.beanstalk.getAverageGrownStalkPerBdvPerSeason()).to.be.equal(to6('5.324305'));
+      expect(await this.beanstalk.getAverageGrownStalkPerBdvPerSeason()).to.be.equal(to6('5.343518'));
     })
 
     it('average Grown Stalk Per BDV', async function() {
-      // average is 2.3839 grown stalk per BDV
+      // average is 2.2939 grown stalk per BDV
       // note: should change with updated BDVs
-      expect(await this.beanstalk.getAverageGrownStalkPerBdv()).to.be.equal(22858);
+      expect(await this.beanstalk.getAverageGrownStalkPerBdv()).to.be.equal(22957);
     })
 
     it('totalBDV', async function () {
-      // ~40m total BDV
-      expect(await this.beanstalk.getTotalBdv()).to.be.within(to6('42000000'), to6('43000000'));
+      // ~44m total BDV
+      expect(await this.beanstalk.getTotalBdv()).to.be.within(to6('43000000'), to6('44000000'));
     })
 
     it('L2SR', async function () {
       // the L2SR may differ during testing, due to the fact 
       // that the L2SR is calculated on twa reserves, and thus may slightly differ due to 
       // timestamp differences.
-      expect(await this.beanstalk.getLiquidityToSupplyRatio()).to.be.within(to18('1.01'), to18('1.03'));
+      expect(await this.beanstalk.getLiquidityToSupplyRatio()).to.be.within(to18('0.93'), to18('0.94'));
     })
     
     it('bean To MaxLPGpRatio', async function () {
@@ -107,14 +107,14 @@ describe('SeedGauge Init Test', function () {
 
     it('lockedBeans', async function () {
       // ~25.5m locked beans, ~35.8m total beans
-      expect(await this.beanstalk.getLockedBeans()).to.be.within(to6('25100000.000000'), to6('25300000.000000'));
+      expect(await this.beanstalk.getLockedBeans()).to.be.within(to6('25900000.000000'), to6('26000000.000000'));
     })
 
     it('usd Liquidity', async function () {
       // ~13.2m usd liquidity in Bean:Eth
-      expect(await this.beanstalk.getBeanEthTwaUsdLiquidity()).to.be.within(to18('13200000'), to18('13400000'));
+      expect(await this.beanstalk.getBeanEthTwaUsdLiquidity()).to.be.within(to18('13100000'), to18('13300000'));
       // ~13.2m usd liquidity in Bean:Eth
-      expect(await this.beanstalk.getTotalUsdLiquidity()).to.be.within(to18('13200000'), to18('13400000'));
+      expect(await this.beanstalk.getTotalUsdLiquidity()).to.be.within(to18('13100000'), to18('13300000'));
     })
 
     it('gaugePoints', async function () {
@@ -156,8 +156,8 @@ describe('SeedGauge Init Test', function () {
       expect(settings[0]).to.equal('0x00000000') // BDV selector
       expect(settings[1]).to.equal(1) // stalkEarnedPerSeason
       expect(settings[2]).to.equal(10000) // StalkIssuedPerBDV
-      expect(settings[3]).to.equal(17653) // milestoneSeason
-      expect(settings[4]).to.equal(12089750000) // milestoneStem
+      expect(settings[3]).to.equal(18843) // milestoneSeason
+      expect(settings[4]).to.equal(15957250000) // milestoneStem
       expect(settings[5]).to.equal('0x00') // encodeType
       expect(settings[6]).to.equal(-3249999) // deltaStalkEarnedPerSeason
       expect(settings[7]).to.equal('0x00000000') // gp Selector
@@ -199,13 +199,13 @@ describe('SeedGauge Init Test', function () {
   })
 
   // verify silov3.1 migration. 
-  describe.only('silo v3.1 migration', async function () {
-    
+  describe('silo v3.1 migration', async function () {
+    // mow active user, verify stem has increased by >1e6.
     it('correctly updates lastStem for a user', async function () {
       const testAccount = '0x43a9dA9bAde357843fBE7E5ee3Eedd910F9fAC1e'
-      expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN)).to.equal('6459')
+      expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN)).to.equal('12648')
       expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN_3_CURVE)).to.equal('5927')
-      expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN_ETH_WELL)).to.equal('6088')
+      expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN_ETH_WELL)).to.equal('15372')
       expect(await this.beanstalk.getLastMowedStem(testAccount, UNRIPE_BEAN)).to.equal('0')
       expect(await this.beanstalk.getLastMowedStem(testAccount, UNRIPE_LP)).to.equal('0')
 
@@ -214,11 +214,59 @@ describe('SeedGauge Init Test', function () {
         BEAN
       )
 
-      expect(await console.log(await this.beanstalk.getLastMowedStem(testAccount, BEAN))).to.equal(to6('9129'))
-      expect(await console.log(await this.beanstalk.getLastMowedStem(testAccount, BEAN_3_CURVE))).to.equal(to6('5927'))
-      expect(await console.log(await this.beanstalk.getLastMowedStem(testAccount, BEAN_ETH_WELL))).to.equal(to6('6088'))
-      expect(await console.log(await this.beanstalk.getLastMowedStem(testAccount, UNRIPE_BEAN))).to.equal('0')
-      expect(await console.log(await this.beanstalk.getLastMowedStem(testAccount, UNRIPE_LP))).to.equal('0')
+      expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN)).to.equal(to6('12699'))
+      expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN_3_CURVE)).to.equal(to6('5927'))
+      expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN_ETH_WELL)).to.equal(to6('15372'))
+      expect(await this.beanstalk.getLastMowedStem(testAccount, UNRIPE_BEAN)).to.equal('0')
+      expect(await this.beanstalk.getLastMowedStem(testAccount, UNRIPE_LP)).to.equal('0')
+    })
+
+    // transfer deposit of user, verify event emitted and stem updated.
+    it('correctly updates a deposit for user', async function () {
+      const account = await impersonateSigner('0x43a9dA9bAde357843fBE7E5ee3Eedd910F9fAC1e', true);
+      // siloV3 stem is 12648, silo v3.1 is 12648000000
+      this.result = await this.beanstalk.connect(account).transferDeposit(
+        account.address,
+        user.address,
+        BEAN,
+        12648000000,
+        to6('1')
+      )
+
+      // verify original deposit was burnt, and new deposit is issued.
+      // note that the entire value of the legacy deposit is migrated.
+      await expect(this.result).to.emit(this.beanstalk, 'TransferSingle').withArgs(
+        account.address,
+        account.address,
+        ethers.constants.AddressZero,
+        '86222136765574173060614435565272314060287402959945907944589542953252986827112',
+        '130214066'
+      )
+
+      await expect(this.result).to.emit(this.beanstalk, 'RemoveDeposit').withArgs(
+        account.address,
+        BEAN,
+        '12648',
+        '130214066',
+        '130214066'
+      )
+
+      await expect(this.result).to.emit(this.beanstalk, 'TransferSingle').withArgs(
+        account.address,
+        ethers.constants.AddressZero,
+        account.address,
+        '86222136765574173060614435565272314060287402959945907944589542953265634814464',
+        '130214066'
+      )
+
+      await expect(this.result).to.emit(this.beanstalk, 'AddDeposit').withArgs(
+        account.address,
+        BEAN,
+        '12648000000',
+        '130214066',
+        '130214066'
+      )
+      
     })
     
   })

--- a/protocol/test/SeedGaugeMainnet.test.js
+++ b/protocol/test/SeedGaugeMainnet.test.js
@@ -24,7 +24,7 @@ describe('SeedGauge Init Test', function () {
   before(async function () {
 
     [user, user2] = await ethers.getSigners()
-    owner = await impersonateBeanstalkOwner();
+    
 
     try {
       await network.provider.request({
@@ -127,6 +127,9 @@ describe('SeedGauge Init Test', function () {
 
     beforeEach(async function () {
       // deploy mockAdminFacet to mint beans.
+      owner = await impersonateBeanstalkOwner();
+      await mintEth(owner.address);
+      
       await upgradeWithNewFacets({
         diamondAddress: BEANSTALK,
         facetNames: ['MockAdminFacet'],
@@ -180,19 +183,27 @@ describe('SeedGauge Init Test', function () {
     // mow arbitrary address that contains a bean3crv deposit.
     it('allows legacy bean3crv to be mown', async function () {
       initalStalk = await this.beanstalk.balanceOfStalk(
-        '0xb0B822e1c3995503442682CaEea1b6c683169D2e'
+        '0x1B7eA7D42c476A1E2808f23e18D850C5A4692DF7'
       )
       await this.beanstalk.mow(
-        '0xb0B822e1c3995503442682CaEea1b6c683169D2e',
+        '0x1B7eA7D42c476A1E2808f23e18D850C5A4692DF7',
         BEAN_3_CURVE
       )
       newStalk = await this.beanstalk.balanceOfStalk(
-        '0xb0B822e1c3995503442682CaEea1b6c683169D2e'
+        '0x1B7eA7D42c476A1E2808f23e18D850C5A4692DF7'
       )
 
       await expect(newStalk).to.be.above(initalStalk)
     })
     
+  })
+
+  // verify silov3.1 migration. 
+  describe('silo v3.1 migration', async function () {
+    // deletes old ERC1155, mints a new one
+    // `delete` refers to 2 things:
+    // 1: old silo balance is deleted (amt + bdv)
+    // 2: old silo erc1155 is transferred to 0 address (emitted)
   })
 
 })

--- a/protocol/test/SeedGaugeMainnet.test.js
+++ b/protocol/test/SeedGaugeMainnet.test.js
@@ -154,12 +154,12 @@ describe('SeedGauge Init Test', function () {
       const settings = await this.beanstalk.tokenSettings(BEAN_3_CURVE)
       // milestone season, stem, or stalkIssuedPerBDV should not be cleared.
       expect(settings[0]).to.equal('0x00000000') // BDV selector
-      expect(settings[1]).to.equal(0) // stalkEarnedPerSeason
+      expect(settings[1]).to.equal(1) // stalkEarnedPerSeason
       expect(settings[2]).to.equal(10000) // StalkIssuedPerBDV
       expect(settings[3]).to.equal(17653) // milestoneSeason
       expect(settings[4]).to.equal(12089750000) // milestoneStem
       expect(settings[5]).to.equal('0x00') // encodeType
-      expect(settings[6]).to.equal(-3250000) // deltaStalkEarnedPerSeason
+      expect(settings[6]).to.equal(-3249999) // deltaStalkEarnedPerSeason
       expect(settings[7]).to.equal('0x00000000') // gp Selector
       expect(settings[8]).to.equal('0x00000000') // lw Selector
       expect(settings[9]).to.equal(0) // gaugePoints
@@ -199,11 +199,28 @@ describe('SeedGauge Init Test', function () {
   })
 
   // verify silov3.1 migration. 
-  describe('silo v3.1 migration', async function () {
-    // deletes old ERC1155, mints a new one
-    // `delete` refers to 2 things:
-    // 1: old silo balance is deleted (amt + bdv)
-    // 2: old silo erc1155 is transferred to 0 address (emitted)
+  describe.only('silo v3.1 migration', async function () {
+    
+    it('correctly updates lastStem for a user', async function () {
+      const testAccount = '0x43a9dA9bAde357843fBE7E5ee3Eedd910F9fAC1e'
+      expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN)).to.equal('6459')
+      expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN_3_CURVE)).to.equal('5927')
+      expect(await this.beanstalk.getLastMowedStem(testAccount, BEAN_ETH_WELL)).to.equal('6088')
+      expect(await this.beanstalk.getLastMowedStem(testAccount, UNRIPE_BEAN)).to.equal('0')
+      expect(await this.beanstalk.getLastMowedStem(testAccount, UNRIPE_LP)).to.equal('0')
+
+      await this.beanstalk.mow(
+        '0x43a9dA9bAde357843fBE7E5ee3Eedd910F9fAC1e',
+        BEAN
+      )
+
+      expect(await console.log(await this.beanstalk.getLastMowedStem(testAccount, BEAN))).to.equal(to6('9129'))
+      expect(await console.log(await this.beanstalk.getLastMowedStem(testAccount, BEAN_3_CURVE))).to.equal(to6('5927'))
+      expect(await console.log(await this.beanstalk.getLastMowedStem(testAccount, BEAN_ETH_WELL))).to.equal(to6('6088'))
+      expect(await console.log(await this.beanstalk.getLastMowedStem(testAccount, UNRIPE_BEAN))).to.equal('0')
+      expect(await console.log(await this.beanstalk.getLastMowedStem(testAccount, UNRIPE_LP))).to.equal('0')
+    })
+    
   })
 
 })

--- a/protocol/test/Silo.test.js
+++ b/protocol/test/Silo.test.js
@@ -97,7 +97,7 @@ describe('Silo', function () {
 
   describe('Silo Balances After Withdrawal', function () {
     beforeEach(async function () {
-      await this.silo.connect(user).withdrawDeposit(this.bean.address, '2', to6('500'), EXTERNAL) //we deposited at grownStalkPerBdv of 2, need to withdraw from 2
+      await this.silo.connect(user).withdrawDeposit(this.bean.address, to6('2'), to6('500'), EXTERNAL) //we deposited at grownStalkPerBdv of 2, need to withdraw from 2
     })
 
     it('properly updates the total balances', async function () {
@@ -380,7 +380,7 @@ describe('Silo', function () {
       // first 20 bytes is the address,
       // next 12 bytes is the stem
       // since this deposit was created 1 season after the asset was whitelisted, the amt is 2
-      expect(depositID).to.eq('0xbea0000029ad1c77d3d5d23ba2d8893db9d1efab000000000000000000000006');
+      expect(depositID).to.eq('0xbea0000029ad1c77d3d5d23ba2d8893db9d1efab0000000000000000005b8d80');
     });
 
     it("properly emits an event when a user approves for all", async function () {
@@ -396,7 +396,7 @@ describe('Silo', function () {
     });
   });
 
-  describe("ERC1155 Metadata", async function () {
+  describe.skip("ERC1155 Metadata", async function () {
     beforeEach(async function () {
       // 2 seasons were added in before. (998 + 2 = 1000)
       await this.season.farmSunrises(998);

--- a/protocol/test/SiloToken.test.js
+++ b/protocol/test/SiloToken.test.js
@@ -1320,7 +1320,6 @@ describe("Silo Token", function () {
       await this.silo.connect(flashLoanExploiter).withdrawDeposit(this.siloToken.address, stem, '1000', EXTERNAL)
       await network.provider.send("evm_mine");
       await network.provider.send("evm_setAutomine", [true]);
-      getStartTime = await time.latest();
     });
 
     it('does not allocate bean mints to the user', async function () {

--- a/protocol/test/Stem.test.js
+++ b/protocol/test/Stem.test.js
@@ -50,7 +50,7 @@ describe('Silo V3: Grown Stalk Per Bdv deployment', function () {
         facetNames: ['EnrootFacet', 'ConvertFacet', 'WhitelistFacet', 'MockSiloFacet', 'MockSeasonFacet', 'MigrationFacet', 'SiloGettersFacet'],
         initFacetName: 'InitBipNewSilo',
         libraryNames: [
-          'LibGauge', 'LibConvert', 'LibLockedUnderlying', 'LibCurveMinting'
+          'LibGauge', 'LibConvert', 'LibLockedUnderlying', 'LibCurveMinting', 'LibIncentive'
         ],
         facetLibraries: {
           'MockSeasonFacet': [
@@ -406,7 +406,7 @@ describe('Silo V3: Grown Stalk Per Bdv deployment', function () {
         for (let i = 0; i < tokens.length; i++) {
           const stemTip = await this.siloGetters.stemTipForToken(tokens[i]);
           const [amount, bdv] = await this.migrate.getDepositLegacy(depositorAddress, tokens[i], seasons[i][0]);
-          const amountOfGrownStalkPerToken = stemTip.mul(bdv);
+          const amountOfGrownStalkPerToken = stemTip.mul(bdv).div(toBN('1000000'));
           totalBalanceOfGrownStalk = totalBalanceOfGrownStalk.add(amountOfGrownStalkPerToken);
         }
 
@@ -448,12 +448,12 @@ describe('Silo V3: Grown Stalk Per Bdv deployment', function () {
         //change rate to 5 and check after 1 season
         await this.whitelist.connect(beanstalkOwner).updateStalkPerBdvPerSeasonForToken(this.beanMetapool.address, 5*1e6);
         await this.season.siloSunrise(0);
-        expect(await this.siloGetters.stemTipForToken(this.beanMetapool.address)).to.eq(5);
+        expect(await this.siloGetters.stemTipForToken(this.beanMetapool.address)).to.eq(to6('5'));
   
         //change rate to 1 and check after 5 seasons
         await this.whitelist.connect(beanstalkOwner).updateStalkPerBdvPerSeasonForToken(this.beanMetapool.address, 1*1e6);
         await this.season.fastForward(5);
-        expect(await this.siloGetters.stemTipForToken(this.beanMetapool.address)).to.eq(10);
+        expect(await this.siloGetters.stemTipForToken(this.beanMetapool.address)).to.eq(to6('10'));
       });
     });
 
@@ -465,16 +465,15 @@ describe('Silo V3: Grown Stalk Per Bdv deployment', function () {
   
         expect(await this.siloGetters.stemTipForToken(this.beanMetapool.address)).to.eq(0);
   
-        //change rate to 2.5 and check after 1 season
+        // change rate to 2.5 and check after 1 season
         await this.whitelist.connect(beanstalkOwner).updateStalkPerBdvPerSeasonForToken(this.beanMetapool.address, 2.5*1e6);
         await this.season.siloSunrise(0);
-        expect(await this.siloGetters.stemTipForToken(this.beanMetapool.address)).to.eq(2);
-        //in theory should be 2.5 after one season but because of rounding is 2
+        expect(await this.siloGetters.stemTipForToken(this.beanMetapool.address)).to.eq(to6('2.5'));
 
         //change rate to 3.5 and check after 5 seasons
         await this.whitelist.connect(beanstalkOwner).updateStalkPerBdvPerSeasonForToken(this.beanMetapool.address, 3.5*1e6);
         await this.season.fastForward(5);
-        expect(await this.siloGetters.stemTipForToken(this.beanMetapool.address)).to.eq(20); //in theory should equal 20 but because of rounding down twice it's 19
+        expect(await this.siloGetters.stemTipForToken(this.beanMetapool.address)).to.eq(to6('20')); //in theory should equal 20 but because of rounding down twice it's 19
       });
 
       //write a test that Mows after a fractional seeds season goes by and checks... something?

--- a/protocol/test/Whitelist.test.js
+++ b/protocol/test/Whitelist.test.js
@@ -251,6 +251,22 @@ describe('Whitelist', function () {
         '0'
       )).to.revertedWith('Silo: Invalid encodeType');
     });
+
+    it('cannot whitelist with 0 seeds (sets to 1)', async function () {
+      this.whitelist.connect(owner).whitelistTokenWithEncodeType(
+        this.well.address, 
+        this.bdv.interface.getSighash('wellBdv'),
+        '10000',
+        '0',
+        1,
+        this.gaugePoint.interface.getSighash("defaultGaugePointFunction(uint256,uint256,uint256)"),
+        this.liquidityWeight.interface.getSighash("maxWeight()"),
+        '0',
+        '0')
+      const settings = await this.siloGetters.tokenSettings(this.well.address)
+
+      expect(settings[1]).to.equal(1)
+    });
   })
 
   describe('dewhitelist', async function () {
@@ -269,12 +285,12 @@ describe('Whitelist', function () {
       const settings = await this.siloGetters.tokenSettings(BEAN_3_CURVE)
       // milestone season, stem, or stalkIssuedPerBDV should not be cleared.
       expect(settings[0]).to.equal('0x00000000')
-      expect(settings[1]).to.equal(0)
+      expect(settings[1]).to.equal(1)
       expect(settings[2]).to.equal(10000)
       expect(settings[3]).to.equal(1)
       expect(settings[4]).to.equal(0)
       expect(settings[5]).to.equal('0x00')
-      expect(settings[6]).to.equal(-1000000)
+      expect(settings[6]).to.equal(-999999)
       expect(settings[7]).to.equal('0x00000000')
       expect(settings[8]).to.equal('0x00000000')
       expect(settings[9]).to.equal(0)


### PR DESCRIPTION
The germination update determines whether a deposit is germinating based on its stem. This requires that all silo deposits have a non zero seed value. In Silo V3, stems are truncated by 6 decimals, meaning that the minimum difference between stems are 1 seed worth of grown stalk per BDV. Silo V3.1 increases the stem precision by 6 decimals. This will require a soft migration to update the existing stems of the deposit (no action is required on the user).