### PR TITLE
BIP-X: Soil Issuance Update

### DIFF
--- a/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
@@ -240,10 +240,10 @@ contract Sun is Oracle {
      */
     function setSoilBelowPeg(int256 twaDeltaB) internal {
         
-        // calculate deltaB from instantenious reserves
+        // Calculate deltaB from instantaneous reserves
         // NOTE: deltaB is calculated only from the Bean:ETH Well at this time
         // If more wells are added, this will need to be updated
-        (int256 instDeltaB, ,) = LibWellMinting.instanteniousDeltaB(C.BEAN_ETH_WELL);
+        (int256 instDeltaB, ,) = LibWellMinting.instantaneousDeltaB(C.BEAN_ETH_WELL);
         
         console.log("/////////// setSoilBelowPeg ///////////");
 
@@ -255,8 +255,6 @@ contract Sun is Oracle {
 
         // When below peg, change Soil issued at gm to be the minimum of (1) -twaDeltaB
         // and (2) the -deltaB calculated using the instantaneous reserves from Multi Flow
-
-        // int256 newSoil = -twaDeltaB < -instDeltaB ? -twaDeltaB : -instDeltaB;
 
         uint256 newSoil = Math.min(uint256(-twaDeltaB), uint256(-instDeltaB));
 

--- a/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
@@ -253,10 +253,11 @@ contract Sun is Oracle {
         console.log("instDeltaB");
         console.logInt(instDeltaB);
 
-        // When below peg, change Soil issued at gm to be the minimum of (1) -twaDeltaB
+        // When below peg, Soil issued at gm is the minimum of (1) -twaDeltaB
         // and (2) the -deltaB calculated using the instantaneous reserves from Multi Flow
 
-        uint256 newSoil = Math.min(uint256(-twaDeltaB), uint256(-instDeltaB));
+        // If the inst delta b is 0 it means that the oracle failed so the twa delta b is used
+        uint256 newSoil = instDeltaB == 0 ? uint256(-twaDeltaB) : Math.min(uint256(-twaDeltaB), uint256(-instDeltaB));
 
         console.log("newSoil");
         console.log(newSoil);

--- a/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
@@ -70,9 +70,9 @@ contract Sun is Oracle {
 
         // Below peg
         else {
-            // setSoilBelowPeg();
-            // ....
-            setSoil(uint256(-deltaB));
+            setSoilBelowPeg(deltaB);
+            // OLD
+            // setSoil(uint256(-deltaB));
             s.season.abovePeg = false;
         }
     }
@@ -228,15 +228,20 @@ contract Sun is Oracle {
         setSoil(newSoil);
     }
 
-    
-    // function setSoilBelowPeg(uint256 newSoil) internal {
-    //     // get instatenous reserves
-    //     uint256[] memory reserves = IInstantaneousPump(C.BEANSTALK_PUMP).readInstantaneousReserves(C.BEANSTALK, C.BYTES_ZERO);
-    //     // calclulate delta b from reserves
-    //     int256 reserveDeltaB = calcDeltaB(reserves, s.season.timestamp);
-    //     // get the min 
-    //     setSoil(newSoil);
-    // }
+
+    function setSoilBelowPeg(int preDeltaB) internal {
+        
+        // calculate deltaB from instantenious reserves
+        int256 deltaBFromInstanteniousReserves = LibWellMinting.instanteniousDeltaB(C.BEAN_ETH_WELL);
+
+        //  When below peg, change Soil issued at gm to be the minimum of (1) -preDeltaB
+        // and (2) the -deltaB calculated using the instantaneous reserves from Multi Flow
+
+        int256 newSoil = min(-preDeltaB, -deltaBFromInstanteniousReserves);
+
+        // set new soil
+        setSoil(newSoil);
+    }
 
     
     function setSoil(uint256 amount) internal {

--- a/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
@@ -70,6 +70,8 @@ contract Sun is Oracle {
 
         // Below peg
         else {
+            // setSoilBelowPeg();
+            // ....
             setSoil(uint256(-deltaB));
             s.season.abovePeg = false;
         }
@@ -225,6 +227,16 @@ contract Sun is Oracle {
         }
         setSoil(newSoil);
     }
+
+    
+    // function setSoilBelowPeg(uint256 newSoil) internal {
+    //     // get instatenous reserves
+    //     uint256[] memory reserves = IInstantaneousPump(C.BEANSTALK_PUMP).readInstantaneousReserves(C.BEANSTALK, C.BYTES_ZERO);
+    //     // calclulate delta b from reserves
+    //     int256 reserveDeltaB = calcDeltaB(reserves, s.season.timestamp);
+    //     // get the min 
+    //     setSoil(newSoil);
+    // }
 
     
     function setSoil(uint256 amount) internal {

--- a/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
@@ -9,7 +9,6 @@ import {LibFertilizer, SafeMath} from "contracts/libraries/LibFertilizer.sol";
 import {LibSafeMath128} from "contracts/libraries/LibSafeMath128.sol";
 import {Oracle, C} from "./Oracle.sol";
 import {LibWellMinting} from "contracts/libraries/Minting/LibWellMinting.sol";
-import "hardhat/console.sol";
 
 /**
  * @title Sun
@@ -240,29 +239,15 @@ contract Sun is Oracle {
      */
     function setSoilBelowPeg(int256 twaDeltaB) internal {
         
-        // Calculate deltaB from instantaneous reserves
+        // Calculate deltaB from instantaneous reserves.
         // NOTE: deltaB is calculated only from the Bean:ETH Well at this time
-        // If more wells are added, this will need to be updated
+        // If more wells are added, this will need to be updated.
         (int256 instDeltaB, ,) = LibWellMinting.instantaneousDeltaB(C.BEAN_ETH_WELL);
-        
-        console.log("/////////// setSoilBelowPeg ///////////");
 
-        console.log("twaDeltaB");
-        console.logInt(twaDeltaB);
-
-        console.log("instDeltaB");
-        console.logInt(instDeltaB);
-
-        // When below peg, Soil issued at gm is the minimum of (1) -twaDeltaB
-        // and (2) the -deltaB calculated using the instantaneous reserves from Multi Flow
-
-        // If the inst delta b is 0 it means that the oracle failed so the twa delta b is used
+        // If the inst delta b is 0 it means that the oracle failed so the twa delta b is used.
         uint256 newSoil = instDeltaB == 0 ? uint256(-twaDeltaB) : Math.min(uint256(-twaDeltaB), uint256(-instDeltaB));
 
-        console.log("newSoil");
-        console.log(newSoil);
-
-        // set new soil
+        // Set new soil.
         setSoil(newSoil);
     }
 

--- a/protocol/contracts/libraries/Minting/LibWellMinting.sol
+++ b/protocol/contracts/libraries/Minting/LibWellMinting.sol
@@ -15,6 +15,7 @@ import {LibWell} from "contracts/libraries/Well/LibWell.sol";
 import {IBeanstalkWellFunction} from "contracts/interfaces/basin/IBeanstalkWellFunction.sol";
 import {SignedSafeMath} from "@openzeppelin/contracts/math/SignedSafeMath.sol";
 import {LibEthUsdOracle} from "contracts/libraries/Oracle/LibEthUsdOracle.sol";
+import 'hardhat/console.sol';   
 
 /**
  * @title Well Minting Oracle Library
@@ -224,6 +225,7 @@ library LibWellMinting {
 
             // If the Bean reserve is less than the minimum, the minting oracle should be considered off.
             if (instReserves[beanIndex] < C.WELL_MINIMUM_BEAN_BALANCE) {
+                console.log("BEAN BALANCE BELOW MIN ---> INSTANTANEOUS DELTA B = 0");
                 return (0, new uint256[](0), new uint256[](0));
             }
 

--- a/protocol/contracts/libraries/Minting/LibWellMinting.sol
+++ b/protocol/contracts/libraries/Minting/LibWellMinting.sol
@@ -8,6 +8,7 @@ pragma experimental ABIEncoderV2;
 import {LibAppStorage, AppStorage} from "../LibAppStorage.sol";
 import {SafeMath, C, LibMinting} from "./LibMinting.sol";
 import {ICumulativePump} from "contracts/interfaces/basin/pumps/ICumulativePump.sol";
+import {IInstantaneousPump} from "contracts/interfaces/basin/pumps/IInstantaneousPump.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Call, IWell} from "contracts/interfaces/basin/IWell.sol";
 import {LibWell} from "contracts/libraries/Well/LibWell.sol";
@@ -192,6 +193,62 @@ library LibWellMinting {
             )).sub(int256(twaReserves[beanIndex]));
 
             return (deltaB, snapshot, twaReserves, ratios);
+        }
+        catch {}
+    }
+
+
+
+    /**
+     * @dev Calculates the instatenious delta B since the input snapshot for
+     * a given Well address.
+     */
+    function instanteniousDeltaB(address well) internal view returns 
+        (int256, bytes memory, uint256[] memory, uint256[] memory) {
+
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        // Try to call `readInstantaneousReserves` and handle failure gracefully, so Sunrise does not revert.
+        // On failure, reset the Oracle by returning an empty snapshot and a delta B of 0.
+
+                                                                        // well address , data[]
+        try IInstantaneousPump(C.BEANSTALK_PUMP).readInstantaneousReserves(well, C.BYTES_ZERO) returns (uint[] memory instReserves) {
+            // get well tokens
+            IERC20[] memory tokens = IWell(well).tokens();
+
+            // get ratios and bean index
+            (
+                uint256[] memory ratios,
+                uint256 beanIndex,
+                bool success
+            ) = LibWell.getRatiosAndBeanIndex(tokens, block.timestamp.sub(s.season.timestamp));
+
+            /////////////////////////// HANDLE FAILURE ///////////////////////////
+
+            // If the Bean reserve is less than the minimum, the minting oracle should be considered off.
+            if (instReserves[beanIndex] < C.WELL_MINIMUM_BEAN_BALANCE) {
+                return (0, new uint256[](0), new uint256[](0));
+            }
+
+            // If the USD Oracle oracle call fails, the minting oracle should be considered off.
+            if (!success) {
+                return (0, instReserves, new uint256[](0));
+            }
+
+            /////////////////////////// CONTINUE ///////////////////////////
+
+            // get well function
+            Call memory wellFunction = IWell(well).wellFunction();
+
+            // Delta B is the difference between the target Bean reserve at the peg price
+            // and the time instantenious Bean balance in the Well.
+            int256 deltaB = int256(IBeanstalkWellFunction(wellFunction.target).calcReserveAtRatioSwap(
+                instReserves,
+                beanIndex,
+                ratios,
+                wellFunction.data
+            )).sub(int256(instReserves[beanIndex]));
+
+            return (deltaB, instReserves, ratios);
         }
         catch {}
     }

--- a/protocol/contracts/libraries/Minting/LibWellMinting.sol
+++ b/protocol/contracts/libraries/Minting/LibWellMinting.sol
@@ -198,17 +198,15 @@ library LibWellMinting {
     }
 
 
-
     /**
-     * @dev Calculates the instatenious delta B since the input snapshot for
-     * a given Well address.
+     * @dev Calculates the instatenious delta B for a given Well address.
+     * @param well The address of the Well
+     * @return deltaB The instatenious delta B balance since the last `capture` call.
      */
     function instanteniousDeltaB(address well) internal view returns 
-        (int256, bytes memory, uint256[] memory, uint256[] memory) {
+        (int256, uint256[] memory, uint256[] memory) {
 
         AppStorage storage s = LibAppStorage.diamondStorage();
-        // Try to call `readInstantaneousReserves` and handle failure gracefully, so Sunrise does not revert.
-        // On failure, reset the Oracle by returning an empty snapshot and a delta B of 0.
 
                                                                         // well address , data[]
         try IInstantaneousPump(C.BEANSTALK_PUMP).readInstantaneousReserves(well, C.BYTES_ZERO) returns (uint[] memory instReserves) {
@@ -240,7 +238,7 @@ library LibWellMinting {
             Call memory wellFunction = IWell(well).wellFunction();
 
             // Delta B is the difference between the target Bean reserve at the peg price
-            // and the time instantenious Bean balance in the Well.
+            // and the instantenious Bean balance in the Well.
             int256 deltaB = int256(IBeanstalkWellFunction(wellFunction.target).calcReserveAtRatioSwap(
                 instReserves,
                 beanIndex,

--- a/protocol/contracts/libraries/Minting/LibWellMinting.sol
+++ b/protocol/contracts/libraries/Minting/LibWellMinting.sol
@@ -15,7 +15,6 @@ import {LibWell} from "contracts/libraries/Well/LibWell.sol";
 import {IBeanstalkWellFunction} from "contracts/interfaces/basin/IBeanstalkWellFunction.sol";
 import {SignedSafeMath} from "@openzeppelin/contracts/math/SignedSafeMath.sol";
 import {LibEthUsdOracle} from "contracts/libraries/Oracle/LibEthUsdOracle.sol";
-import 'hardhat/console.sol';   
 
 /**
  * @title Well Minting Oracle Library
@@ -173,6 +172,7 @@ library LibWellMinting {
                 bool success
             ) = LibWell.getRatiosAndBeanIndex(tokens, block.timestamp.sub(s.season.timestamp));
 
+            // HANDLE FAILURE
             // If the Bean reserve is less than the minimum, the minting oracle should be considered off.
             if (twaReserves[beanIndex] < C.WELL_MINIMUM_BEAN_BALANCE) {
                 return (0, snapshot, new uint256[](0), new uint256[](0));
@@ -201,7 +201,7 @@ library LibWellMinting {
 
     /**
      * @dev Calculates the instantaneous delta B for a given Well address.
-     * @param well The address of the Well
+     * @param well The address of the Well.
      * @return deltaB The instantaneous delta B balance since the last `capture` call.
      */
     function instantaneousDeltaB(address well) internal view returns 
@@ -211,21 +211,19 @@ library LibWellMinting {
 
                                                                         // well address , data[]
         try IInstantaneousPump(C.BEANSTALK_PUMP).readInstantaneousReserves(well, C.BYTES_ZERO) returns (uint[] memory instReserves) {
-            // get well tokens
+            // Get well tokens
             IERC20[] memory tokens = IWell(well).tokens();
 
-            // get ratios and bean index
+            // Get ratios and bean index
             (
                 uint256[] memory ratios,
                 uint256 beanIndex,
                 bool success
             ) = LibWell.getRatiosAndBeanIndex(tokens, block.timestamp.sub(s.season.timestamp));
 
-            /////////////////////////// HANDLE FAILURE ///////////////////////////
-
+            // HANDLE FAILURE
             // If the Bean reserve is less than the minimum, the minting oracle should be considered off.
             if (instReserves[beanIndex] < C.WELL_MINIMUM_BEAN_BALANCE) {
-                console.log("BEAN BALANCE BELOW MIN ---> INSTANTANEOUS DELTA B = 0");
                 return (0, new uint256[](0), new uint256[](0));
             }
 
@@ -234,9 +232,7 @@ library LibWellMinting {
                 return (0, instReserves, new uint256[](0));
             }
 
-            /////////////////////////// CONTINUE ///////////////////////////
-
-            // get well function
+            // Get well function
             Call memory wellFunction = IWell(well).wellFunction();
 
             // Delta B is the difference between the target Bean reserve at the peg price

--- a/protocol/contracts/libraries/Minting/LibWellMinting.sol
+++ b/protocol/contracts/libraries/Minting/LibWellMinting.sol
@@ -199,11 +199,11 @@ library LibWellMinting {
 
 
     /**
-     * @dev Calculates the instatenious delta B for a given Well address.
+     * @dev Calculates the instantaneous delta B for a given Well address.
      * @param well The address of the Well
-     * @return deltaB The instatenious delta B balance since the last `capture` call.
+     * @return deltaB The instantaneous delta B balance since the last `capture` call.
      */
-    function instanteniousDeltaB(address well) internal view returns 
+    function instantaneousDeltaB(address well) internal view returns 
         (int256, uint256[] memory, uint256[] memory) {
 
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -238,7 +238,7 @@ library LibWellMinting {
             Call memory wellFunction = IWell(well).wellFunction();
 
             // Delta B is the difference between the target Bean reserve at the peg price
-            // and the instantenious Bean balance in the Well.
+            // and the instantaneous Bean balance in the Well.
             int256 deltaB = int256(IBeanstalkWellFunction(wellFunction.target).calcReserveAtRatioSwap(
                 instReserves,
                 beanIndex,

--- a/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -314,6 +314,12 @@ contract MockSeasonFacet is SeasonFacet  {
         emit DeltaB(deltaB);
     }
 
+    function captureWellEInstantenous(address well) external returns (int256 instDeltaB) {
+        (instDeltaB, ,) = LibWellMinting.instanteniousDeltaB(well);
+        s.season.timestamp = block.timestamp;
+        emit DeltaB(instDeltaB);
+    }
+
     function updateTWAPCurveE() external returns (uint256[2] memory balances) {
         (balances, s.co.balances) = LibCurveMinting.twaBalances();
         s.season.timestamp = block.timestamp;

--- a/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -314,8 +314,8 @@ contract MockSeasonFacet is SeasonFacet  {
         emit DeltaB(deltaB);
     }
 
-    function captureWellEInstantenous(address well) external returns (int256 instDeltaB) {
-        (instDeltaB, ,) = LibWellMinting.instanteniousDeltaB(well);
+    function captureWellEInstantaneous(address well) external returns (int256 instDeltaB) {
+        (instDeltaB, ,) = LibWellMinting.instantaneousDeltaB(well);
         s.season.timestamp = block.timestamp;
         emit DeltaB(instDeltaB);
     }

--- a/protocol/test/Sun.test.js
+++ b/protocol/test/Sun.test.js
@@ -10,6 +10,8 @@ const { setEthUsdPrice, setEthUsdcPrice } = require('../utils/oracle.js');
 const { deployBasin } = require('../scripts/basin.js');
 const ZERO_BYTES = ethers.utils.formatBytes32String('0x0')
 const { advanceTime } = require('../utils/helpers.js');
+const { whitelistWell, deployMockBeanEthWell } = require('../utils/well.js');
+const { check } = require('prettier');
 
 let user, user2, owner;
 let userAddress, ownerAddress, user2Address;
@@ -70,8 +72,15 @@ describe('Sun', function () {
     await setEthUsdPrice('999.998018');
     await setEthUsdcPrice('1000');
 
-    this.well = await deployBasin(true, undefined, false, true)
-    await this.season.siloSunrise(0)
+    // this.well = await deployBasin(true, undefined, false, true);
+    await this.season.siloSunrise(0);
+
+    ///////////////////////////  SOIL FIX ///////////////////////////
+    [this.well, this.wellFunction, this.pump] = await deployMockBeanEthWell()
+    await whitelistWell(this.well.address, '10000', to6('4'))
+    await this.season.captureWellE(this.well.address)
+    this.seasonGetter = await ethers.getContractAt('SeasonGettersFacet', this.diamond.address)
+
   })
 
   beforeEach(async function () {
@@ -82,10 +91,55 @@ describe('Sun', function () {
     await revertToSnapshot(snapshotId)
   })
 
+
+  ///////////////////////////  SOIL FIX ///////////////////////////
   it("delta B < 1", async function () {
+                                            // DELTA B, CASE ID
     this.result = await this.season.sunSunrise('-100', 8);
     await expect(this.result).to.emit(this.season, 'Soil').withArgs(3, '100');
   })
+
+  it.only( "deltaB < 1, using insatenious pump reserves", async function () {
+
+    //////////////// Setup for deltaB<0 from well minting tests ///////////////////////////
+
+    // go forward 1800 blocks
+    await advanceTime(1800)
+    // set reserves to 2M Beans and 1000 Eth
+    await this.well.setReserves([to6('2000000'), to18('1000')])
+    // go forward 1800 blocks
+    await advanceTime(1800)
+    // send 0 eth to beanstalk
+    await user.sendTransaction({
+      to: beanstalk.address,
+      value: 0
+    })
+
+    // Get the current block timestamp as the start time
+    let START_TIME = (await ethers.provider.getBlock('latest')).timestamp;
+
+    // Advance time 1 hour
+    await timeSkip(START_TIME + 60*60);
+    
+    // twaDeltaB = -100000000
+    expect(await this.season.callStatic.captureWellE(this.well.address)).to.be.equal('-100000000')
+
+    // instantenousDeltaB = -585786437627
+    expect(await this.season.callStatic.captureWellEInstantenous(this.well.address)).to.be.equal('-585786437627')
+
+    // poolDeltaB = -100000000 --> calls check() that returns the time weighted average delta B in a given Well --> so twaDeltaB
+    expect(await this.seasonGetter.poolDeltaB(this.well.address)).to.be.equal('-100000000')
+
+    // Call sunrise
+    // this.result = await this.season.gm(owner.address, EXTERNAL);
+    this.result = await this.season.sunSunrise('-100', 8);
+
+    // check deltaB
+    await expect(this.result).to.emit(this.season, 'Soil').withArgs(3, '100');
+  })
+
+  /////////////////////////// END  SOIL FIX ///////////////////////////
+
 
   it("delta B == 1", async function () {
     this.result = await this.season.sunSunrise('0', 8);
@@ -337,9 +391,16 @@ describe('Sun', function () {
     await expect(this.season.siloSunrise('340282366920938463463374607431768211456')).to.be.revertedWith('SafeCast: value doesn\'t fit in 128 bits');
   })
 
-  it("rewards more than type(uint128).max Soil below peg", async function () {
-    await expect(this.season.sunSunrise('-340282366920938463463374607431768211456', '0')).to.be.revertedWith('SafeCast: value doesn\'t fit in 128 bits');
-  })
+
+
+  // /////////////////////////// FAILS BEACAUSE OF SOIL FIX ///////////////////////////
+  // it("rewards more than type(uint128).max Soil below peg", async function () {
+  //                                           // delta B,                        CASE ID
+  //   await expect(this.season.sunSunrise('-340282366920938463463374607431768211456', '0')).to.be.revertedWith('SafeCast: value doesn\'t fit in 128 bits');
+  // })
+
+
+
 })
 
 function viewGenericUint256Logs(logs) {

--- a/protocol/test/Sun.test.js
+++ b/protocol/test/Sun.test.js
@@ -72,16 +72,9 @@ describe('Sun', function () {
     await setEthUsdPrice('999.998018');
     await setEthUsdcPrice('1000');
 
-    // for some reason this breaks the fertilizer tests if it's not here
     this.well = await deployBasin(true, undefined, false, true);
 
     await this.season.siloSunrise(0);
-
-    ///////////////////////////  SOIL FIX ///////////////////////////
-    // [this.well2, this.wellFunction, this.pump] = await deployMockBeanEthWell()
-    // await whitelistWell(this.well.address, '10000', to6('4'))
-    // await this.season.captureWellE(this.well.address)
-    // this.seasonGetter = await ethers.getContractAt('SeasonGettersFacet', this.diamond.address)
 
   })
 
@@ -93,32 +86,7 @@ describe('Sun', function () {
     await revertToSnapshot(snapshotId)
   })
 
-  ///////////////////////////  SOIL FIX ///////////////////////////
-
-  it("When deltaB < 0, it captures state, using insatenious and cummulative pump reserves", async function () {
-
-    // go fo forward 1800 blocks
-    await advanceTime(1800)
-    // set reserves to 2M Beans and 1000 Eth
-    // await this.well.setReserves([to6('2000000'), to18('1000')])
-    await setReserves(owner, this.well, [to6('2000000'), to18('1000')]);
-    await setReserves(owner, this.well, [to6('2000000'), to18('1000')]);
-    // go forward 1800 blocks
-    await advanceTime(1800)
-    // send 0 eth to beanstalk
-    await user.sendTransaction({
-      to: this.diamond.address,
-      value: 0
-    })
-
-    // twaDeltaB = -100000000
-    expect(await this.season.captureWellE(this.well.address)).to.emit('-100000000');
-    // instantenousDeltaB = -585786437627
-    expect(await this.season.captureWellEInstantaneous(this.well.address)).to.emit('-585786437627');
-  })
-
   it("When deltaB < 0 it sets the soil to be the min of -twaDeltaB and -instantaneous deltaB", async function () {
-
     // go fo forward 1800 blocks
     await advanceTime(1800)
     // set reserves to 2M Beans and 1000 Eth
@@ -134,7 +102,7 @@ describe('Sun', function () {
     })
 
     // twaDeltaB = -100000000
-    // instantenousDeltaB = -585786437627
+    // instantaneousDeltaB = -585786437627
                                             // twaDeltaB, case ID
     this.result = await this.season.sunSunrise('-100000000', 8);
     await expect(this.result).to.emit(this.season, 'Soil').withArgs(3, '100000000');
@@ -148,7 +116,6 @@ describe('Sun', function () {
     // set reserves to 1 Bean and 1 Eth
     // If the Bean reserve is less than the minimum of 1000 beans,
     // LibWellMinting.instantaneousDeltaB returns a deltaB of 0
-    // 
     await setReserves(owner, this.well, [to6('1'), to18('1')]);
     await setReserves(owner, this.well, [to6('1'), to18('1')]);
     // go forward 1800 blocks
@@ -166,16 +133,13 @@ describe('Sun', function () {
   })
 
   it("rewards more than type(uint128).max Soil below peg", async function () {
-    // Here, since we havent changed the reserves the instantaneous deltaB is 0
+    // Here, since we haven't changed the reserves the instantaneous deltaB is 0
     // And we maniuplate the twaDeltaB to be a number that is greater than type(uint128).max
     // Because we consider that a value of 0 returned by the oracle to be a failure, we set the soil to be the twaDeltaB
     // which is greater than type(uint128).max and therefore reverts
                                             // twadeltaB,                        CASE ID
     await expect(this.season.sunSunrise('-340282366920938463463374607431768211456', '8')).to.be.revertedWith('SafeCast: value doesn\'t fit in 128 bits');
   })
-
-  /////////////////////////// END  SOIL FIX ///////////////////////////
-
 
   it("delta B == 1", async function () {
     this.result = await this.season.sunSunrise('0', 8);

--- a/protocol/test/WellMinting.test.js
+++ b/protocol/test/WellMinting.test.js
@@ -56,11 +56,15 @@ describe('Well Minting', function () {
       })
     })
 
-    it("Captures", async function () {
+    it("Captures twa", async function () {
       expect(await this.season.callStatic.captureWellE(this.well.address)).to.be.equal('0')
     })
+
+    it("Captures instantaneous", async function () {
+      expect(await this.season.callStatic.captureWellEInstantaneous(this.well.address)).to.be.equal('0')
+    })
   
-    it("Checks", async function () {
+    it("Checks twa", async function () {
       expect(await this.seasonGetter.poolDeltaB(this.well.address)).to.be.equal('0')
     })
 
@@ -77,13 +81,18 @@ describe('Well Minting', function () {
       })
     })
 
-    it("Captures a delta B > 0", async function () {
+    it("Captures a twa delta B > 0", async function () {
       expect(await this.season.callStatic.captureWellE(this.well.address)).to.be.equal('133789634067')
     })
+
+    it("Captures an instantaneous delta B > 0", async function () {
+      expect(await this.season.callStatic.captureWellEInstantaneous(this.well.address)).to.be.equal('207106781186')
+    })
   
-    it("Checks a delta B > 0", async function () {
+    it("Checks a twa delta B > 0", async function () {
       expect(await this.seasonGetter.poolDeltaB(this.well.address)).to.be.equal('133789634067')
     })
+    
   })
 
   describe("Delta B < 0", async function () {
@@ -97,11 +106,15 @@ describe('Well Minting', function () {
       })
     })
 
-    it("Captures a delta B < 0", async function () {
+    it("Captures a twa delta B < 0", async function () {
       expect(await this.season.callStatic.captureWellE(this.well.address)).to.be.equal('-225006447371')
     })
 
-    it("Checks a delta B < 0", async function () {
+    it("Captures an instantaneous delta B < 0", async function () {
+      expect(await this.season.callStatic.captureWellEInstantaneous(this.well.address)).to.be.equal('-585786437627')
+    })
+
+    it("Checks a twa delta B < 0", async function () {
       expect(await this.seasonGetter.poolDeltaB(this.well.address)).to.be.equal('-225006447371')
     })
   })
@@ -117,11 +130,15 @@ describe('Well Minting', function () {
       })
     })
 
-    it("Captures a Beans below min", async function () {
+    it("Captures a Beans below min twa", async function () {
       expect(await this.season.callStatic.captureWellE(this.well.address)).to.be.equal('0')
     })
 
-    it("Checks a Beans below min", async function () {
+    it("Captures a Beans below min instantaneous", async function () {
+      expect(await this.season.callStatic.captureWellEInstantaneous(this.well.address)).to.be.equal('0')
+    })
+
+    it("Checks a Beans below min twa ", async function () {
       expect(await this.seasonGetter.poolDeltaB(this.well.address)).to.be.equal('0')
     })
 


### PR DESCRIPTION
## Summary

When $\Delta B_{\overline{t-1}} < 0$, change Soil issued at `gm` to be the minimum of (1) $-\Delta B$ calculated using the instantaneous reserves from Multi Flow and (2) $-\Delta B_{\overline{t-1}}$.

## Problem

Beanstalk occasionally overissues Soil at `gm` because Soil issuance below peg is solely based on $-\Delta B_{\overline{t-1}}$.

Beanstalk can read inter-block MEV manipulation resistant instantaneous reserves for whitelisted Well LP tokens via Multi Flow, but does not yet use these values to determine Soil issuance below peg.

### Context

Consider an example where Beanstalk is at -300k deltaB for the first 58 minutes of a Season. At the 58th minute, i.e., 10 blocks before the next `gm` call, a Farmer buys and Sows 200k Beans, bringing the current deltaB to -100k.

Assuming no other trades in the final 2 minutes of the Season, the Soil issued at `gm` will be slightly less than 300k, despite Beanstalk only needing 100k Beans to be bought to return to peg. Before Multi Flow, this was necessary for sufficient manipulation resistance.

## Solution
- Introduced a new ```setSoilBelowPeg()``` function that queries the instantaneous deltaB from the bean:eth well, compares it with the precalculated twa deltaB from the start of the season and sets the soil to be the minimum of the inverse of the 2 .
- Implemented  ```instantaneousDeltaB()``` in ```LibWellMinting.sol``` that calculates the deltaB using the instantaneous reserves from a given well.
- Added tests to challenge the new deltaB calculation in  ```WellMinting.test.js```.
- Added tests to challenge the soil update in ```Sun.test.js```. 