### PR TITLE
EBIP-14: Remove Vesting Period

### DIFF
--- a/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/Silo.sol
@@ -84,6 +84,19 @@ contract Silo is SiloExit {
         _;
     }
 
+    //////////////////////// INTERNAL: VESTING ////////////////////////
+
+    /**
+     * @notice Verifies that the function is not called in the vesting period.
+     * @dev Added with ebip-13. Will be removed upon seed gauge BIP.
+     * This modifier is added to the following functions:
+     * {SiloFacet.withdrawDeposit(s)}
+     */
+    modifier checkVesting() {
+        require(!LibSilo.inVestingPeriod(), "Silo: In vesting period");
+        _;
+    }
+
     //////////////////////// INTERNAL: PLANT ////////////////////////
 
     /**
@@ -96,12 +109,6 @@ contract Silo is SiloExit {
     function _plant(address account) internal returns (uint256 beans, int96 stemTip) {
         // Need to Mow for `account` before we calculate the balance of 
         // Earned Beans.
-        
-        // per the zero withdraw update, planting is handled differently 
-        // depending whether or not the user plants during the vesting period of beanstalk. 
-        // during the vesting period, the earned beans are not issued to the user.
-        // thus, the roots calculated for a given user is different. 
-        // This is handled by the super mow function, which stores the difference in roots.
         LibSilo._mow(account, C.BEAN);
         uint256 accountStalk = s.a[account].s.stalk;
 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloExit.sol
@@ -184,16 +184,7 @@ contract SiloExit is ReentrancyGuard {
         // There will be no Roots before the first Deposit is made.
         if (s.s.roots == 0) return 0;
 
-        uint256 stalk;
-        if(LibSilo.inVestingPeriod()){
-            stalk = s.s.stalk.sub(s.newEarnedStalk)
-                .mul(s.a[account].roots.add(s.a[account].deltaRoots)) // add the delta roots of the user
-                .div(s.s.roots.add(s.vestingPeriodRoots)); // add delta of global roots 
-        } else {
-            stalk = s.s.stalk
-                .mul(s.a[account].roots)
-                .div(s.s.roots);
-        }
+        uint256 stalk = s.s.stalk.mul(s.a[account].roots).div(s.s.roots);
         
         // Beanstalk rounds down when minting Roots. Thus, it is possible that
         // balanceOfRoots / totalRoots * totalStalk < s.a[account].s.stalk.

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloFacet.sol
@@ -92,7 +92,7 @@ contract SiloFacet is TokenSilo {
         int96 stem,
         uint256 amount,
         LibTransfer.To mode
-    ) external payable mowSender(token) nonReentrant {
+    ) external payable mowSender(token) nonReentrant checkVesting {
         _withdrawDeposit(msg.sender, token, stem, amount);
         LibTransfer.sendToken(IERC20(token), amount, msg.sender, mode);
     }
@@ -116,7 +116,7 @@ contract SiloFacet is TokenSilo {
         int96[] calldata stems,
         uint256[] calldata amounts,
         LibTransfer.To mode
-    ) external payable mowSender(token) nonReentrant {
+    ) external payable mowSender(token) nonReentrant checkVesting {
         uint256 amount = _withdrawDeposits(msg.sender, token, stems, amounts);
         LibTransfer.sendToken(IERC20(token), amount, msg.sender, mode);
     }

--- a/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
@@ -181,8 +181,7 @@ contract Sun is Oracle {
         // `s.earnedBeans` is an accounting mechanism that tracks the total number
         // of Earned Beans that are claimable by Stalkholders. When claimed via `plant()`,
         // it is decremented. See {Silo.sol:_plant} for more details.
-        // SafeCast not necessary as `seasonStalk.toUint128();` will fail if amount > type(uint128).max.
-        s.earnedBeans = s.earnedBeans.add(uint128(amount));
+        s.earnedBeans = s.earnedBeans.add(amount);
 
         // Mint Stalk (as Earned Stalk). Farmers can claim their Earned Stalk via {SiloFacet.sol:plant}.
         //
@@ -192,19 +191,17 @@ contract Sun is Oracle {
         // for gas savings.
         uint256 seasonStalk = amount.mul(C.STALK_PER_BEAN);
         s.s.stalk = s.s.stalk.add(seasonStalk);
-        // `s.newEarnedStalk` is an accounting mechanism that tracks the  number
-        // of Earned stalk that is allocated during the season. 
-        // This is used in _balanceOfEarnedBeans() to linearly distrubute 
-        // beans over the course of the season.
-        s.newEarnedStalk = seasonStalk.toUint128();
-        s.vestingPeriodRoots = 0;
 
-        // SafeCast not necessary as `seasonStalk.toUint128();` will fail if amount > type(uint128).max.
+        // removed at ebip-13. Will be replaced upon seed gauge BIP.
+        // s.newEarnedStalk = seasonStalk.toUint128();
+        // s.vestingPeriodRoots = 0;
+
         s.siloBalances[C.BEAN].deposited = s
             .siloBalances[C.BEAN]
             .deposited
-            .add(uint128(amount));
+            .add(amount.toUint128());
 
+        // SafeCast not necessary as the block above will fail if amount > type(uint128).max.
         s.siloBalances[C.BEAN].depositedBdv = s
             .siloBalances[C.BEAN]
             .depositedBdv

--- a/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyTokenSilo.sol
@@ -293,7 +293,7 @@ library LibLegacyTokenSilo {
 
 
         //do a legacy mow using the old silo seasons deposits
-        LibSilo.mintGrownStalk(account, balanceOfGrownStalkUpToStemsDeployment(account)); //should only mint stalk up to stemStartSeason
+        LibSilo.mintStalk(account, balanceOfGrownStalkUpToStemsDeployment(account)); //should only mint stalk up to stemStartSeason
         updateLastUpdateToNow(account);
         //at this point we've completed the guts of the old mow function, now we need to do the migration
  
@@ -364,7 +364,7 @@ library LibLegacyTokenSilo {
         }
  
         // user deserves stalk grown between stemStartSeason and now
-        LibSilo.mintGrownStalk(account, migrateData.totalGrownStalk);
+        LibSilo.mintStalk(account, migrateData.totalGrownStalk);
 
         //return seeds diff for checking in the "part 2" of this function (stack depth kept it from all fitting in one)
         return balanceOfSeeds(account).sub(migrateData.totalSeeds);

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -37,7 +37,7 @@ const { to6 } = require("./test/utils/helpers.js");
 const { task } = require("hardhat/config");
 const { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } = require("hardhat/builtin-tasks/task-names");
 const { bipNewSilo, mockBeanstalkAdmin } = require("./scripts/bips.js");
-const { ebip9, ebip10, ebip11, ebip12, ebip13 } = require("./scripts/ebips.js");
+const { ebip9, ebip10, ebip11, ebip13, ebip14 } = require("./scripts/ebips.js");
 
 //////////////////////// UTILITIES ////////////////////////
 
@@ -222,12 +222,12 @@ task("migrate-bip38", async function () {
   await finishBeanEthMigration();
 });
 
-task("ebip13", async function () {
-  await ebip13();
+task("ebip14", async function () {
+  await ebip14();
 })
 
-task("ebip12", async function () {
-  await ebip12();
+task("ebip13", async function () {
+  await ebip13();
 })
 
 task("ebip11", async function () {

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -37,7 +37,7 @@ const { to6 } = require("./test/utils/helpers.js");
 const { task } = require("hardhat/config");
 const { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } = require("hardhat/builtin-tasks/task-names");
 const { bipNewSilo, mockBeanstalkAdmin } = require("./scripts/bips.js");
-const { ebip9, ebip10, ebip11, ebip13 } = require("./scripts/ebips.js");
+const { ebip9, ebip10, ebip11, ebip12, ebip13 } = require("./scripts/ebips.js");
 
 //////////////////////// UTILITIES ////////////////////////
 
@@ -226,6 +226,10 @@ task("ebip13", async function () {
   await ebip13();
 })
 
+task("ebip12", async function () {
+  await ebip12();
+})
+
 task("ebip11", async function () {
   await ebip11();
 })
@@ -303,7 +307,7 @@ module.exports = {
         settings: {
           optimizer: {
             enabled: true,
-            runs: 1000
+            runs: 100
           }
         }
       },

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -108,7 +108,7 @@ async function ebip11(mock = true, account = undefined) {
   });
 }
 
-async function ebip13(mock = true, account = undefined) {
+async function ebip12(mock = true, account = undefined) {
   if (account == undefined) {
     account = await impersonateBeanstalkOwner();
     await mintEth(account.address);
@@ -117,6 +117,29 @@ async function ebip13(mock = true, account = undefined) {
   await upgradeWithNewFacets({
     diamondAddress: BEANSTALK,
     facetNames: ["ConvertFacet"],
+    bip: false,
+    object: !mock,
+    verbose: true,
+    account: account
+  });
+}
+
+async function ebip13(mock = false, account = undefined) {
+  if (account == undefined) {
+    account = await impersonateBeanstalkOwner();
+    await mintEth(account.address);
+  }
+
+  await upgradeWithNewFacets({
+    diamondAddress: BEANSTALK,
+    facetNames: [
+      "SeasonFacet",
+      "SiloFacet", 
+      "MigrationFacet",
+      "LegacyClaimWithdrawalFacet",
+      "ConvertFacet",
+      "EnrootFacet"
+    ],
     bip: false,
     object: !mock,
     verbose: true,
@@ -147,4 +170,5 @@ exports.ebip8 = ebip8;
 exports.ebip9 = ebip9;
 exports.ebip10 = ebip10;
 exports.ebip11 = ebip11;
+exports.ebip12 = ebip12;
 exports.ebip13 = ebip13;

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -170,5 +170,4 @@ exports.ebip8 = ebip8;
 exports.ebip9 = ebip9;
 exports.ebip10 = ebip10;
 exports.ebip11 = ebip11;
-exports.ebip12 = ebip12;
 exports.ebip13 = ebip13;

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -171,3 +171,4 @@ exports.ebip9 = ebip9;
 exports.ebip10 = ebip10;
 exports.ebip11 = ebip11;
 exports.ebip13 = ebip13;
+exports.ebip14 = ebip14;

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -108,7 +108,7 @@ async function ebip11(mock = true, account = undefined) {
   });
 }
 
-async function ebip12(mock = true, account = undefined) {
+async function ebip13(mock = true, account = undefined) {
   if (account == undefined) {
     account = await impersonateBeanstalkOwner();
     await mintEth(account.address);
@@ -124,7 +124,7 @@ async function ebip12(mock = true, account = undefined) {
   });
 }
 
-async function ebip13(mock = false, account = undefined) {
+async function ebip14(mock = false, account = undefined) {
   if (account == undefined) {
     account = await impersonateBeanstalkOwner();
     await mintEth(account.address);

--- a/protocol/test/Silo.test.js
+++ b/protocol/test/Silo.test.js
@@ -396,14 +396,9 @@ describe('Silo', function () {
 
 
   /**
-   * These sets of tests handle the issuance of beans during the vesting period, the first n (n = 10) 
-   * blocks of the season. In this period, the farmer is not allocated the earned beans until after the vesting period.
-   * Withdrawing during this period will forfeit the earned beans, distrubuted to the other farmers.
-   * 
-   * @dev due to integer division, there are cases where the user may get 1 less micro bean (~1e-6) than expected.
-   * we accept this error in favor of security.
+   * Vesting period now reverts and thus tests are skipped/invalid.
    */
-  describe("Earned Beans issuance during vesting period", async function () {
+  describe.skip("Earned Beans issuance during vesting period", async function () {
     before(async function () {
       this.result = await this.silo.connect(user3).deposit(this.bean.address, to6('1000'), EXTERNAL)
       this.result = await this.silo.connect(user4).deposit(this.bean.address, to6('1000'), EXTERNAL)
@@ -898,6 +893,22 @@ describe('Silo', function () {
 
         })
       });
+    });
+  });
+
+  describe("Withdrawing during vesting period", async function () {
+    it('properly reverts', async function () {
+      await this.season.teleportSunrise(10);
+      await this.silo.connect(user).deposit(this.bean.address, '1000', EXTERNAL);
+      const stem = await this.silo.seasonToStem(this.bean.address, '10');
+
+      await expect(
+        this.silo.connect(user).withdrawDeposit(this.bean.address, stem, '1000', EXTERNAL)
+      ).to.be.revertedWith('Silo: In vesting period')
+      await expect(
+        this.silo.connect(user).withdrawDeposits(this.bean.address, [stem], ['1000'], EXTERNAL)
+      ).to.be.revertedWith('Silo: In vesting period')
+
     });
   });
 });

--- a/protocol/test/SiloToken.test.js
+++ b/protocol/test/SiloToken.test.js
@@ -222,6 +222,7 @@ describe("Silo Token", function () {
       await this.season.teleportSunrise(10);
       // this.season.deployStemsUpgrade();
       await this.silo.connect(user).deposit(this.siloToken.address, '1000', EXTERNAL);
+      await mineUpTo((await ethers.provider.getBlockNumber()) + 11 + 1);
     })
     describe('reverts', function () {
       it('reverts if amount is 0', async function () {
@@ -318,6 +319,7 @@ describe("Silo Token", function () {
           await this.season.siloSunrise(0);
           await this.silo.connect(user).deposit(this.siloToken.address, '1000', EXTERNAL);
           userBalanceBefore = await this.siloToken.balanceOf(userAddress);
+          await mineUpTo((await ethers.provider.getBlockNumber()) + 11 + 1);
           this.result = await this.silo.connect(user).withdrawDeposits(this.siloToken.address, [0,1],['500','1000'], EXTERNAL);
         });
     
@@ -352,6 +354,7 @@ describe("Silo Token", function () {
           await this.season.siloSunrise(0);
           await this.silo.connect(user).deposit(this.siloToken.address, '1000', EXTERNAL);
           userBalanceBefore = await this.siloToken.balanceOf(userAddress);
+          await mineUpTo((await ethers.provider.getBlockNumber()) + 11 + 1);
           this.result = await this.silo.connect(user).withdrawDeposits(this.siloToken.address, [0,1],['1000','1000'], EXTERNAL);
         });
     
@@ -1638,7 +1641,10 @@ describe("Silo Token", function () {
     });
   });
 
-  describe("flash loan exploit", async function () {
+  /**
+   * Vesting period now reverts and thus tests are skipped/invalid.
+   */
+  describe.skip("flash loan exploit", async function () {
     before(async function () {
       await this.siloToken.mint(flashLoanExploiterAddress, '1000');
       await this.siloToken.connect(flashLoanExploiter).approve(this.silo.address, '100000000000'); 


### PR DESCRIPTION
# EBIP-14: Remove Vesting Period

Committed: February 5, 2024

---

- [Submitter](#submitter)
- [Summary](#summary)
- [Links](#links)
- [Problem](#problem)
- [Solution](#solution)
- [Contract Changes](#contract-changes)
- [Effective](#effective)

## Submitter

Beanstalk Community Multisig

## Summary

* As a result of a potential attack vector around stealing Earned Beans during the Vesting Period:
    * Remove the Vesting Period logic altogether; and
    * Upgrade `withdrawDeposit(s)` to revert when called during the first 10 blocks of a Season.

## Links

Per the process outlined in the [BCM Emergency Response Procedures](https://docs.bean.money/almanac/governance/beanstalk/bcm-process#emergency-response-procedures), the BCM can take swift action to protect Beanstalk in the event of a bug or security vulnerability.

- [EBIP-14 GitHub PR](https://github.com/BeanstalkFarms/Beanstalk/pull/762)
- GitHub Commit Hash: [4f7f45832d2fd7b7d9e8ef81125f1392a307433c](https://github.com/BeanstalkFarms/Beanstalk/tree/4f7f45832d2fd7b7d9e8ef81125f1392a307433c)
- [Safe Transaction](https://app.safe.global/transactions/tx?safe=eth:0xa9bA2C40b263843C04d344727b954A545c81D043&id=multisig_0xa9bA2C40b263843C04d344727b954A545c81D043_0xbb405de87054477ac5beca741961d4d4cb229c801266d4d3b16a0c052f4a1465)
- [Etherscan Transaction](https://etherscan.io/tx/0x4b7e79cc9d02c8f75f250182d86ecf87b1c1afd5072d7fe05db187c8f5258e59)

## Problem

A bug report was submitted on Immunefi that allowed a user to potentially steal unclaimed Earned Beans during the 10 block Vesting Period at the beginning of the Season, depending on the value of `s.newEarnedStalk`. 

This was due to an inconsistency in the number of `roots` minted when Depositing compared to the number of `roots` burnt when Withdrawing. By repeatedly Withdrawing and Depositing Beans, an attacker could increase the Stalk/`root` ratio and thus inflate their total Stalk balance before then calling `plant`. This attack could have been profitable based on the value of `s.newEarnedStalk`.

## Solution

Given that the Seed Gauge System replaces the Vesting Period, in the meantime the best route is to remove the Vesting Period logic altogether and revert when `withdrawDeposit(s)` is called during the first 10 blocks of the Season. 

At the time of execution of this EBIP, based on the value stored at `s.newEarnedStalk`, this attack was not profitable. However, the attack was profitable at various times over the last few months (i.e., some Earned Beans could be stolen for profit).

All changes were reviewed by Cyfrin.

## Contract Changes

### Season Facet

The following `SeasonFacet` is removed from Beanstalk:
* [`0x5eAfF0d247ee998bb4827B24292EAdC7f14f3EfC`](https://etherscan.io/address/0x5eAfF0d247ee998bb4827B24292EAdC7f14f3EfC#code)

The following `SeasonFacet` is added to Beanstalk:
* [`0x7667b52cbbe2D7CA54334C7c00F1396faF660DeA`](https://etherscan.io/address/0x7667b52cbbe2D7CA54334C7c00F1396faF660DeA#code)

#### `SeasonFacet` Function Changes

| Name                 | Selector     | Action  | Type | New Functionality |
|:---------------------|:-------------|:--------|:-----|:------------------|
| `abovePeg`           | `0x2a27c499` | Replace | View |                   |
| `curveOracle`        | `0x07a3b202` | Replace | View |                   |
| `paused`             | `0x5c975abb` | Replace | View |                   |
| `plentyPerRoot`      | `0xe60d7a83` | Replace | View |                   |
| `poolDeltaB`         | `0x471bcdbe` | Replace | View |                   |
| `rain`               | `0x43def26e` | Replace | View |                   |
| `season`             | `0xc50b0fb0` | Replace | View |                   |
| `seasonTime`         | `0xca7b7d7b` | Replace | View |                   |
| `sunriseBlock`       | `0x3b2ecb70` | Replace | View |                   |
| `time`               | `0x16ada547` | Replace | View |                   |
| `totalDeltaB`        | `0x06c499d8` | Replace | View |                   |
| `weather`            | `0x686b6159` | Replace | View |                   |
| `wellOracleSnapshot` | `0x597490c0` | Replace | View |                   |
| `gm`                 | `0x64ee4b80` | Replace | Call | ✓                 |
| `sunrise`            | `0xfc06d2a6` | Replace | Call | ✓                 |

### Silo Facet

The following `SiloFacet` is removed from Beanstalk:
* [`0xf4B3629D1aa74eF8ab53Cc22728896B960F3a74E`](https://etherscan.io/address/0xf4B3629D1aa74eF8ab53Cc22728896B960F3a74E#code)

The following `SiloFacet` is added to Beanstalk:
* [`0xFb33Af0Cc65d5dE71399c0A395846F53Fff76D71`](https://etherscan.io/address/0xFb33Af0Cc65d5dE71399c0A395846F53Fff76D71#code)

#### `SiloFacet` Function Changes

| Name                    | Selector     | Action  | Type | New Functionality |
|:------------------------|:-------------|:--------|:-----|:------------------|
| `balanceOf`             | `0x00fdd58e` | Replace | View |                   |
| `balanceOfBatch`        | `0x4e1273f4` | Replace | View |                   |
| `balanceOfDepositedBDV` | `0xbc8514cf` | Replace | View |                   |
| `balanceOfEarnedBeans`  | `0x3e465a2e` | Replace | View | ✓                 |
| `balanceOfEarnedStalk`  | `0x341b94d5` | Replace | View | ✓                 |
| `balanceOfGrownStalk`   | `0x8915ba24` | Replace | View |                   |
| `balanceOfPlenty`       | `0x896651e8` | Replace | View |                   |
| `balanceOfRainRoots`    | `0x69fbad94` | Replace | View |                   |
| `balanceOfRoots`        | `0xba39dc02` | Replace | View |                   |
| `balanceOfSop`          | `0xa7bf680f` | Replace | View |                   |
| `balanceOfStalk`        | `0x8eeae310` | Replace | View | ✓                 |
| `bdv`                   | `0x8c1e6f22` | Replace | View |                   |
| `getDeposit`            | `0x61449212` | Replace | View |                   |
| `getDepositId`          | `0x98f2b8ad` | Replace | View |                   |
| `getLastMowedStem`      | `0x7fc06e12` | Replace | View |                   |
| `getMowStatus`          | `0xdc25a650` | Replace | View |                   |
| `getSeedsPerToken`      | `0x9f9962e4` | Replace | View |                   |
| `getTotalDeposited`     | `0x0c9c31bd` | Replace | View |                   |
| `getTotalDepositedBDV`  | `0x9d6a924e` | Replace | View |                   |
| `grownStalkForDeposit`  | `0x3a1b0606` | Replace | View |                   |
| `inVestingPeriod`       | `0x0b2939d1` | Replace | View |                   |
| `lastSeasonOfPlenty`    | `0xbe6547d2` | Replace | View |                   |
| `lastUpdate`            | `0xcb03fb1e` | Replace | View |                   |
| `migrationNeeded`       | `0xc38b3c18` | Replace | View |                   |
| `seasonToStem`          | `0x896ab1c6` | Replace | View |                   |
| `stemStartSeason`       | `0xbc771977` | Replace | View |                   |
| `stemTipForToken`       | `0xabed2d41` | Replace | View |                   |
| `tokenSettings`         | `0xe923e8d4` | Replace | View |                   |
| `totalEarnedBeans`      | `0xfd9de166` | Replace | View |                   |
| `totalRoots`            | `0x46544166` | Replace | View |                   |
| `totalStalk`            | `0x7b52fadf` | Replace | View |                   |
| `claimPlenty`           | `0x45947ba9` | Replace | Call |                   |
| `deposit`               | `0xf19ed6be` | Replace | Call |                   |
| `mow`                   | `0x150d5173` | Replace | Call |                   |
| `mowMultiple`           | `0x7d44f5bb` | Replace | Call |                   |
| `plant`                 | `0x779b3c5c` | Replace | Call | ✓                 |
| `safeBatchTransferFrom` | `0x2eb2c2d6` | Replace | Call |                   |
| `safeTransferFrom`      | `0xf242432a` | Replace | Call |                   |
| `transferDeposit`       | `0x081d77ba` | Replace | Call |                   |
| `transferDeposits`      | `0xc56411f6` | Replace | Call |                   |
| `withdrawDeposit`       | `0xe348f82b` | Replace | Call | ✓                 |
| `withdrawDeposits`      | `0x27e047f1` | Replace | Call | ✓                 |

### Migration Facet

The following `MigrationFacet` is removed from Beanstalk:
* [`0x9F2444e6cFAAB6ea16Fc05B989f1017508F84A41`](https://etherscan.io/address/0x9F2444e6cFAAB6ea16Fc05B989f1017508F84A41#code)

The following `MigrationFacet` is added to Beanstalk:
* [`0xbE73a5C684B1b53d7C7758B9a614Bcfdb24f822d`](https://etherscan.io/address/0xbE73a5C684B1b53d7C7758B9a614Bcfdb24f822d#code)

#### `MigrationFacet` Function Changes

| Name                                     | Selector     | Action  | Type | New Functionality |
|:-----------------------------------------|:-------------|:--------|:-----|:------------------|
| `balanceOfGrownStalkUpToStemsDeployment` | `0x505f43ea` | Replace | View |                   |
| `balanceOfLegacySeeds`                   | `0x1be2cfd8` | Replace | View |                   |
| `getDepositLegacy`                       | `0xa9be1acb` | Replace | View |                   |
| `totalMigratedBDV`                       | `0x2b8cde0d` | Replace | View |                   |
| `mowAndMigrate`                          | `0x1f4f3d55` | Replace | Call |                   |
| `mowAndMigrateNoDeposits`                | `0xaed942e9` | Replace | Call |                   |

### Legacy Claim Withdrawal Facet

The following `LegacyClaimWithdrawalFacet` is removed from Beanstalk:
* [`0x93703ADC951B76451e3006960cFB3F927D7E7ef6`](https://etherscan.io/address/0x93703ADC951B76451e3006960cFB3F927D7E7ef6#code)

The following `LegacyClaimWithdrawalFacet` is added to Beanstalk:
* [`0xf6A39e7eF4605F47294aF93AA9eE8ee839D15292`](https://etherscan.io/address/0xf6A39e7eF4605F47294aF93AA9eE8ee839D15292#code)

#### `LegacyClaimWithdrawalFacet` Function Changes

| Name                | Selector     | Action   | Type | New Functionality |
|:--------------------|:-------------|:---------|:-----|:------------------|
| `claimWithdrawal`   | `0x488e94dc` | Replace  | Call |                   |
| `claimWithdrawals`  | `0x764a9874` | Replace  | Call |                   |
| `getTotalWithdrawn` | `0xb1c7a20f` | Replace  | View |                   |
| `getWithdrawal`     | `0xe23c96a4` | Replace  | View |                   |

### Convert Facet

The following `ConvertFacet` is removed from Beanstalk:
* [`0x7d19277B836D4787dC338251fbEd2e5841cF8c02`](https://etherscan.io/address/0x7d19277B836D4787dC338251fbEd2e5841cF8c02#code)

The following `ConvertFacet` is added to Beanstalk:
* [`0x38Dbe7445D3C51f27E41996de5b0EA19e3E47BA6`](https://etherscan.io/address/0x38Dbe7445D3C51f27E41996de5b0EA19e3E47BA6#code)

#### `ConvertFacet` Function Changes

| Name                         | Selector     | Action  | Type | New Functionality |
|:-----------------------------|:-------------|:--------|:-----|:------------------|
| `convert`                    | `0xb362a6e8` | Replace | Call |                   |

### Enroot Facet

The following `EnrootFacet` is removed from Beanstalk:
* [`0x1C2a836184d2fa7e4d0750Af73423a076cd169CE`](https://etherscan.io/address/0x1C2a836184d2fa7e4d0750Af73423a076cd169CE#code)

The following `EnrootFacet` is added to Beanstalk:
* [`0x5CB70cf085368698198CB45D517445d4413eB695`](https://etherscan.io/address/0x5CB70cf085368698198CB45D517445d4413eB695#code)

#### `EnrootFacet` Function Changes

| Name                   | Selector     | Action  | Type | New Functionality |
|:-----------------------|:-------------|:--------|:-----|:------------------|
| `enrootDeposit`        | `0x0b58f073` | Replace | Call |                   |
| `enrootDeposits`       | `0x88fcd169` | Replace | Call |                   |

### Event Changes

None.

## Beans Minted

None.

## Effective

Effective immediately upon commitment by the BCM, which has already happened.
