### PR TITLE
Add dynamic Whitelist Status list

### DIFF
--- a/protocol/abi/Beanstalk.json
+++ b/protocol/abi/Beanstalk.json
@@ -4174,166 +4174,6 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "token",
-        "type": "address"
-      }
-    ],
-    "name": "dewhitelistToken",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "gaugePointSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "liquidityWeightSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint64",
-        "name": "optimalPercentDepositedBdv",
-        "type": "uint64"
-      }
-    ],
-    "name": "updateGaugeForToken",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "internalType": "uint32",
-        "name": "stalkEarnedPerSeason",
-        "type": "uint32"
-      }
-    ],
-    "name": "updateStalkPerBdvPerSeasonForToken",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "selector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint16",
-        "name": "stalkIssuedPerBdv",
-        "type": "uint16"
-      },
-      {
-        "internalType": "uint32",
-        "name": "stalkEarnedPerSeason",
-        "type": "uint32"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "gaugePointSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "liquidityWeightSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint128",
-        "name": "gaugePoints",
-        "type": "uint128"
-      },
-      {
-        "internalType": "uint64",
-        "name": "optimalPercentDepositedBdv",
-        "type": "uint64"
-      }
-    ],
-    "name": "whitelistToken",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "selector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint32",
-        "name": "stalkIssuedPerBdv",
-        "type": "uint32"
-      },
-      {
-        "internalType": "uint32",
-        "name": "stalkEarnedPerSeason",
-        "type": "uint32"
-      },
-      {
-        "internalType": "bytes1",
-        "name": "encodeType",
-        "type": "bytes1"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "gaugePointSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "liquidityWeightSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint128",
-        "name": "gaugePoints",
-        "type": "uint128"
-      },
-      {
-        "internalType": "uint64",
-        "name": "optimalPercentDepositedBdv",
-        "type": "uint64"
-      }
-    ],
-    "name": "whitelistTokenWithEncodeType",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
         "name": "account",
         "type": "address"
       }
@@ -5176,6 +5016,294 @@
     "name": "setApprovalForAll",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "dewhitelistToken",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getSiloTokens",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getWhitelistStatus",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "isWhitelisted",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isWhitelistedLp",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isWhitelistedWell",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct Storage.WhitelistStatus",
+        "name": "_whitelistStatuses",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWhitelistStatuses",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "isWhitelisted",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isWhitelistedLp",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isWhitelistedWell",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct Storage.WhitelistStatus[]",
+        "name": "_whitelistStatuses",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWhitelistedLpTokens",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWhitelistedTokens",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWhitelistedWellLpTokens",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "gaugePointSelector",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "liquidityWeightSelector",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "uint64",
+        "name": "optimalPercentDepositedBdv",
+        "type": "uint64"
+      }
+    ],
+    "name": "updateGaugeForToken",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "stalkEarnedPerSeason",
+        "type": "uint32"
+      }
+    ],
+    "name": "updateStalkPerBdvPerSeasonForToken",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "selector",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "uint16",
+        "name": "stalkIssuedPerBdv",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint32",
+        "name": "stalkEarnedPerSeason",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "gaugePointSelector",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "liquidityWeightSelector",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "uint128",
+        "name": "gaugePoints",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint64",
+        "name": "optimalPercentDepositedBdv",
+        "type": "uint64"
+      }
+    ],
+    "name": "whitelistToken",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "selector",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "uint32",
+        "name": "stalkIssuedPerBdv",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "stalkEarnedPerSeason",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes1",
+        "name": "encodeType",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "gaugePointSelector",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "liquidityWeightSelector",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "uint128",
+        "name": "gaugePoints",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint64",
+        "name": "optimalPercentDepositedBdv",
+        "type": "uint64"
+      }
+    ],
+    "name": "whitelistTokenWithEncodeType",
+    "outputs": [],
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -7034,46 +7162,7 @@
   },
   {
     "inputs": [],
-    "name": "getLastStalkGrowthRateUpdate",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "getLiquidityToSupplyRatio",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getNewAverageGrownStalkPerBdvPerSeason",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getNextStalkGrowthRateUpdate",
     "outputs": [
       {
         "internalType": "uint256",
@@ -7112,11 +7201,6 @@
             "internalType": "uint128",
             "name": "beanToMaxLpGpPerBdvRatio",
             "type": "uint128"
-          },
-          {
-            "internalType": "uint32",
-            "name": "lastStalkGrowthUpdate",
-            "type": "uint32"
           }
         ],
         "internalType": "struct Storage.SeedGauge",
@@ -7642,13 +7726,6 @@
       }
     ],
     "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "updateAverageStalkPerBdvPerSeason",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   }
 ]

--- a/protocol/contracts/beanstalk/AppStorage.sol
+++ b/protocol/contracts/beanstalk/AppStorage.sol
@@ -274,6 +274,21 @@ contract Storage {
     }
 
     /**
+     * @notice Whitelist Status a token that has been Whitelisted before.
+     * @param token the address of the token.
+     * @param a whether the address is whitelisted.
+     * @param isWhitelistedLp whether the address is a whitelisted LP token.
+     * @param isWhitelistedWell whether the address is a whitelisted Well token.
+     */
+
+    struct WhitelistStatus {
+        address token;
+        bool isWhitelisted;
+        bool isWhitelistedLp;
+        bool isWhitelistedWell;
+    }
+
+    /**
      * @notice System-level Silo state variables.
      * @param stalk The total amount of active Stalk (including Earned Stalk, excluding Grown Stalk).
      * @param deprecated_seeds DEPRECATED: The total amount of active Seeds (excluding Earned Seeds).
@@ -553,6 +568,7 @@ contract Storage {
  * @param casesV2 Stores the 144 Weather and seedGauge cases.
  * @param oddGerminating Stores germinating data during odd seasons.
  * @param evenGerminating Stores germinating data during even seasons.
+ * @param whitelistedStatues Stores a list of Whitelist Statues for all tokens that have been Whitelisted and have not had their Whitelist Status manually removed.
  */
 struct AppStorage {
     uint8 deprecated_index;
@@ -632,4 +648,6 @@ struct AppStorage {
 
     // mapping from season => unclaimed germinating stalk and roots 
     mapping(uint32 => Storage.Sr) unclaimedGerminating;
+
+    Storage.WhitelistStatus[] whitelistStatuses;
 }

--- a/protocol/contracts/beanstalk/init/InitBipSeedGauge.sol
+++ b/protocol/contracts/beanstalk/init/InitBipSeedGauge.sol
@@ -16,7 +16,7 @@ import {Weather} from "contracts/beanstalk/sun/SeasonFacet/Weather.sol";
 import {LibSafeMathSigned96} from "contracts/libraries/LibSafeMathSigned96.sol";
 import {LibSafeMath128} from "contracts/libraries/LibSafeMath128.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/SafeCast.sol";
-
+import {InitWhitelistStatuses} from "contracts/beanstalk/init/InitWhitelistStatuses.sol";
 
 interface IGaugePointFacet {
     function defaultGaugePointFunction(
@@ -31,10 +31,10 @@ interface ILiquidityWeightFacet {
 }
 
 /**
- * @author Brean
+ * @author Brean, Brendan
  * @title InitBipSeedGauge initalizes the seed gauge, updates siloSetting Struct
  **/
-contract InitBipSeedGauge is Weather {
+contract InitBipSeedGauge is Weather, InitWhitelistStatuses {
     using SafeMath for uint256;
     using LibSafeMathSigned96 for int96;
     using LibSafeMath128 for uint128;
@@ -58,6 +58,8 @@ contract InitBipSeedGauge is Weather {
         // prior to dewhitelisting Bean3CRV.
         s.ss[C.CURVE_BEAN_METAPOOL].milestoneStem = 
             int96(s.ss[C.CURVE_BEAN_METAPOOL].milestoneStem.mul(1e6));
+
+        addWhitelistStatuses(true);
 
         LibWhitelist.dewhitelistToken(C.CURVE_BEAN_METAPOOL);
 

--- a/protocol/contracts/beanstalk/init/InitWhitelistStatuses.sol
+++ b/protocol/contracts/beanstalk/init/InitWhitelistStatuses.sol
@@ -15,12 +15,6 @@ import {C} from "contracts/C.sol";
 
 contract InitWhitelistStatuses {
 
-    uint32 private constant BEAN_3CRV_STALK = 10000;
-    uint32 private constant BEAN_3CRV_SEEDS = 4;
-
-    uint32 private constant BEAN_STALK = 10000; //stalk per bdv (bdv is 6, stalk is 10, so need 4 here)
-    uint32 private constant BEAN_SEEDS = 2; //seeds per bdv of bean (1e6 is one bean)
-
     function addWhitelistStatuses(bool beanEth) internal {
         addBeanStatus();
         if (beanEth) addBeanEthStatus();

--- a/protocol/contracts/beanstalk/init/InitWhitelistStatuses.sol
+++ b/protocol/contracts/beanstalk/init/InitWhitelistStatuses.sol
@@ -1,0 +1,76 @@
+/*
+ SPDX-License-Identifier: MIT
+*/
+
+pragma solidity =0.7.6;
+pragma experimental ABIEncoderV2;
+
+import {LibWhitelistedTokens} from "contracts/libraries/Silo/LibWhitelistedTokens.sol";
+import {C} from "contracts/C.sol";
+
+/**
+ * @author Brendan
+ * @title Initializes the whitelist statuses for Whitelisted Beanstalk Assets before Whitelisted Statuses were introduced.
+**/
+
+contract InitWhitelistStatuses {
+
+    uint32 private constant BEAN_3CRV_STALK = 10000;
+    uint32 private constant BEAN_3CRV_SEEDS = 4;
+
+    uint32 private constant BEAN_STALK = 10000; //stalk per bdv (bdv is 6, stalk is 10, so need 4 here)
+    uint32 private constant BEAN_SEEDS = 2; //seeds per bdv of bean (1e6 is one bean)
+
+    function addWhitelistStatuses(bool beanEth) internal {
+        addBeanStatus();
+        if (beanEth) addBeanEthStatus();
+        addBean3CrvStatus();
+        addUnripeBeanStatus();
+        addUnripeLPStatus();
+    }
+
+    function addBean3CrvStatus() internal {
+        LibWhitelistedTokens.addWhitelistStatus(
+            C.CURVE_BEAN_METAPOOL,
+            true,
+            true,
+            false
+        );
+    }
+
+    function addBeanStatus() internal {
+        LibWhitelistedTokens.addWhitelistStatus(
+            C.BEAN,
+            true,
+            false,
+            false
+        );
+    }
+
+    function addUnripeBeanStatus() internal {
+        LibWhitelistedTokens.addWhitelistStatus(
+            C.UNRIPE_BEAN,
+            true,
+            false,
+            false
+        );
+    }
+
+    function addUnripeLPStatus() internal {
+        LibWhitelistedTokens.addWhitelistStatus(
+            C.UNRIPE_LP,
+            true,
+            false,
+            false
+        );
+    }
+
+    function addBeanEthStatus() internal {
+        LibWhitelistedTokens.addWhitelistStatus(
+            C.BEAN_ETH_WELL,
+            true,
+            true,
+            true
+        );
+    }
+}

--- a/protocol/contracts/beanstalk/silo/WhitelistFacet/WhitelistFacet.sol
+++ b/protocol/contracts/beanstalk/silo/WhitelistFacet/WhitelistFacet.sol
@@ -7,7 +7,8 @@ pragma experimental ABIEncoderV2;
 
 import {LibDiamond} from "contracts/libraries/LibDiamond.sol";
 import {LibWhitelist} from "contracts/libraries/Silo/LibWhitelist.sol";
-import {AppStorage} from "../AppStorage.sol";
+import {AppStorage} from "contracts/beanstalk/AppStorage.sol";
+import {WhitelistedTokens} from "contracts/beanstalk/silo/WhitelistFacet/WhitelistedTokens.sol";
 
 /**
  * @author Publius
@@ -15,7 +16,7 @@ import {AppStorage} from "../AppStorage.sol";
  * @notice Manages the Silo Whitelist including Adding to, Updating
  * and Removing from the Silo Whitelist
  **/
-contract WhitelistFacet {
+contract WhitelistFacet is WhitelistedTokens {
     /**
      * @notice Removes a token from the Silo Whitelist.
      * @dev Can only be called by Beanstalk or Beanstalk owner.
@@ -135,4 +136,5 @@ contract WhitelistFacet {
             optimalPercentDepositedBdv
         );
     }
+    
 }

--- a/protocol/contracts/beanstalk/silo/WhitelistFacet/WhitelistedTokens.sol
+++ b/protocol/contracts/beanstalk/silo/WhitelistFacet/WhitelistedTokens.sol
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+pragma solidity =0.7.6;
+pragma experimental ABIEncoderV2;
+
+import {LibWhitelistedTokens} from "contracts/libraries/Silo/LibWhitelistedTokens.sol";
+import {Storage} from "contracts/beanstalk/AppStorage.sol";
+
+/**
+ * @title WhitelistedTokens
+ * @author Brendan
+ * @notice Returns information related to WhitelistStatuses.
+ */
+contract WhitelistedTokens {
+    /**
+     * @notice Returns all tokens that have been whitelisted and has not had its Whitelist Status manually removed.
+     * @dev includes Dewhitelisted tokens with existing Deposits.
+     */
+    function getSiloTokens() external view returns (address[] memory tokens) {
+        return LibWhitelistedTokens.getSiloTokens();
+    }
+
+    /**
+     * @notice Returns the current Whitelisted tokens, including Unripe tokens.
+     */
+    function getWhitelistedTokens() external view returns (address[] memory tokens) {
+        return LibWhitelistedTokens.getWhitelistedTokens();
+    }
+
+    /**
+     * @notice Returns the current Whitelisted LP tokens. 
+     * @dev Unripe LP is not an LP token.
+     */
+    function getWhitelistedLpTokens() external view returns (address[] memory tokens) {
+        return LibWhitelistedTokens.getWhitelistedLpTokens();
+    }
+
+    /**
+     * @notice Returns the current Whitelisted Well LP tokens.
+     */
+    function getWhitelistedWellLpTokens() external view returns (address[] memory tokens) {
+        return LibWhitelistedTokens.getWhitelistedWellLpTokens();
+    }
+
+    /**
+     * @notice Returns the Whitelist statues for all tokens with a non-zero Deposit.
+     */
+    function getWhitelistStatuses() external view returns (Storage.WhitelistStatus[] memory _whitelistStatuses) {
+        return LibWhitelistedTokens.getWhitelistedStatuses();
+    }
+
+    /**
+     * @notice Returns the Whitelist statu for a given Deposit.
+     */
+    function getWhitelistStatus(address token) external view returns (Storage.WhitelistStatus memory _whitelistStatuses) {
+        return LibWhitelistedTokens.getWhitelistedStatus(token);
+    }
+
+}

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -99,7 +99,8 @@ library LibWhitelist {
         verifyLiquidityWeightSelector(liquidityWeightSelector);
 
         // add whitelist status
-        LibWhitelistedTokens.addWhitelistStatus(token,
+        LibWhitelistedTokens.addWhitelistStatus(
+            token,
             true, // Whitelisted by default.
             token != address(C.bean()) && !LibUnripe.isUnripe(token), // Assumes tokens that are not Unripe and not Bean are LP tokens.
             selector == LibWell.WELL_BDV_SELECTOR
@@ -244,34 +245,5 @@ library LibWhitelist {
         (bool success, ) = address(this).staticcall(abi.encodeWithSelector(selector));
         require(success, "Whitelist: Invalid LiquidityWeight selector");
     }
-
-    /**
-     * @notice Checks whether a token is in an array.
-     */
-    function checkTokenInArray(address token, address[] memory array) private pure {
-        // verify that the token is in the array.
-        bool success;
-        for (uint i; i < array.length; i++) {
-            if (token == array[i]) {
-                success = true; 
-                break;
-            }   
-        }
-        require(success, "Whitelist: Token not in whitelisted token array");
-    }
-
-    /**
-     * @notice Checks whether a token is in an array.
-     */
-    function checkTokenNotInArray(address token, address[] memory array) private pure {
-        // verify that the token is not in the array.
-        bool success = true;
-        for (uint i; i < array.length; i++) {
-            if (token == array[i]) {
-                success = false; 
-                break;
-            }
-        }
-        require(success, "Whitelist: Token in incorrect whitelisted token array");
-    }
+    
 }

--- a/protocol/contracts/libraries/Silo/LibWhitelistedTokens.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelistedTokens.sol
@@ -8,8 +8,6 @@ pragma experimental ABIEncoderV2;
 import {C} from "../../C.sol";
 import {AppStorage, Storage, LibAppStorage} from "contracts/libraries/LibAppStorage.sol";
 
-import {console} from "hardhat/console.sol";
-
 /**
  * @title LibWhitelistedTokens
  * @author Brean, Brendan

--- a/protocol/contracts/libraries/Silo/LibWhitelistedTokens.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelistedTokens.sol
@@ -189,10 +189,7 @@ library LibWhitelistedTokens {
     function removeWhitelistStatus(address token) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         uint256 tokenStatusIndex = findWhitelistStatusIndex(token);
-        s.whitelistStatuses[tokenStatusIndex].token = s.whitelistStatuses[s.whitelistStatuses.length - 1].token;
-        s.whitelistStatuses[tokenStatusIndex].isWhitelisted = s.whitelistStatuses[s.whitelistStatuses.length - 1].isWhitelisted;
-        s.whitelistStatuses[tokenStatusIndex].isWhitelistedLp = s.whitelistStatuses[s.whitelistStatuses.length - 1].isWhitelistedLp;
-        s.whitelistStatuses[tokenStatusIndex].isWhitelistedWell = s.whitelistStatuses[s.whitelistStatuses.length - 1].isWhitelistedWell;
+        s.whitelistStatuses[tokenStatusIndex] = s.whitelistStatuses[s.whitelistStatuses.length - 1];
         s.whitelistStatuses.pop();
 
         emit RemoveWhitelistStatus(token, tokenStatusIndex);

--- a/protocol/contracts/libraries/Silo/LibWhitelistedTokens.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelistedTokens.sol
@@ -6,55 +6,211 @@ pragma solidity =0.7.6;
 pragma experimental ABIEncoderV2;
 
 import {C} from "../../C.sol";
+import {AppStorage, Storage, LibAppStorage} from "contracts/libraries/LibAppStorage.sol";
+
+import {console} from "hardhat/console.sol";
 
 /**
  * @title LibWhitelistedTokens
- * @author Brean
- * @notice LibWhitelistedTokens returns the current Whitelisted tokens.
- * @dev a library is used, rather than keeping the addresses in storages,
- * as a gas optimization.
+ * @author Brean, Brendan
+ * @notice LibWhitelistedTokens holds different lists of types of Whitelisted Tokens.
  * 
- * This library should be updated when new tokens are added to silo.
+ * @dev manages the WhitelistStatuses for all tokens in the Silo in order to track lists.
+ * Note: dewhitelisting a token doesn't remove it's WhitelistStatus entirely–It just modifies it.
+ * Once a token has no more Deposits in the Silo, it's WhitelistStatus should be removed through calling `removeWhitelistStatus`.
  */
 library LibWhitelistedTokens {
+
+
+    /** 
+     * @notice Emitted when a Whitelis Status is added.
+     */
+    event AddWhitelistStatus(
+        address token,
+        uint256 index,
+        bool isWhitelisted,
+        bool isWhitelistedLp,
+        bool isWhitelistedWell
+    );
+
+    /**
+     * @notice Emitted when a Whitelist Status is removed.
+     */
+    event RemoveWhitelistStatus(
+        address token,
+        uint256 index
+    );
+
+    /**
+     * @notice Emitted when a Whitelist Status is updated.
+     */
+    event UpdateWhitelistStatus(
+        address token,
+        uint256 index,
+        bool isWhitelisted,
+        bool isWhitelistedLp,
+        bool isWhitelistedWell
+    );
+
     /**
      * @notice Returns all tokens that are currently or previously in the silo, 
      * including Unripe tokens.
+     * @dev includes Dewhitelisted tokens with existing Deposits.
      */
-    function getSiloTokens() internal pure returns (address[] memory tokens) {
-        tokens = new address[](5);
-        tokens[0] = C.BEAN;
-        tokens[1] = C.BEAN_ETH_WELL;
-        tokens[2] = C.CURVE_BEAN_METAPOOL;
-        tokens[3] = C.UNRIPE_BEAN;
-        tokens[4] = C.UNRIPE_LP;
+    function getSiloTokens() internal view returns (address[] memory tokens) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        uint256 numberOfSiloTokens = s.whitelistStatuses.length;
+
+        tokens = new address[](numberOfSiloTokens);
+
+        for (uint256 i = 0; i < numberOfSiloTokens; i++) {
+            tokens[i] = s.whitelistStatuses[i].token;
+        }
     }
 
     /**
      * @notice Returns the current Whitelisted tokens, including Unripe tokens.
      */
-    function getWhitelistedTokens() internal pure returns (address[] memory tokens) {
-        tokens = new address[](4);
-        tokens[0] = C.BEAN;
-        tokens[1] = C.BEAN_ETH_WELL;
-        tokens[2] = C.UNRIPE_BEAN;
-        tokens[3] = C.UNRIPE_LP;
+    function getWhitelistedTokens() internal view returns (address[] memory tokens) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        uint256 numberOfSiloTokens = s.whitelistStatuses.length;
+        uint256 tokensLength;
+    
+        tokens = new address[](numberOfSiloTokens);
+
+        for (uint256 i = 0; i < numberOfSiloTokens; i++) {
+            if (s.whitelistStatuses[i].isWhitelisted) {
+                tokens[tokensLength++] = s.whitelistStatuses[i].token;
+            }
+        }
+        assembly {
+            mstore(tokens, tokensLength)
+        }
     }
 
     /**
      * @notice Returns the current Whitelisted LP tokens. 
      * @dev Unripe LP is not an LP token.
      */
-    function getWhitelistedLpTokens() internal pure returns (address[] memory tokens) {
-        tokens = new address[](1);
-        tokens[0] = C.BEAN_ETH_WELL;
+    function getWhitelistedLpTokens() internal view returns (address[] memory tokens) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        uint256 numberOfSiloTokens = s.whitelistStatuses.length;
+        uint256 tokensLength;
+
+        tokens = new address[](numberOfSiloTokens);
+
+        for (uint256 i = 0; i < numberOfSiloTokens; i++) {
+            if (s.whitelistStatuses[i].isWhitelistedLp) {
+                // assembly {
+                //     mstore(tokens, add(mload(tokens), 1))
+                // }
+                tokens[tokensLength++] = s.whitelistStatuses[i].token;
+            }
+        }
+        assembly {
+            mstore(tokens, tokensLength)
+        }
     }
 
     /**
-     * @notice Returns the list of Whitelisted Well LP tokens.
+     * @notice Returns the current Whitelisted Well LP tokens.
      */
-    function getWhitelistedWellLpTokens() internal pure returns (address[] memory tokens) {
-        tokens = new address[](1);
-        tokens[0] = C.BEAN_ETH_WELL;
+    function getWhitelistedWellLpTokens() internal view returns (address[] memory tokens) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        uint256 numberOfSiloTokens = s.whitelistStatuses.length;
+        uint256 tokensLength;
+
+        tokens = new address[](numberOfSiloTokens);
+
+        for (uint256 i = 0; i < numberOfSiloTokens; i++) {
+            if (s.whitelistStatuses[i].isWhitelistedWell) {
+                tokens[tokensLength++] = s.whitelistStatuses[i].token;
+            }
+        }
+        assembly {
+            mstore(tokens, tokensLength)
+        }
+    }
+
+    /**
+     * @notice Returns the Whitelist statues for all tokens that have been whitelisted and not manually removed.
+     */
+    function getWhitelistedStatuses() internal view returns (Storage.WhitelistStatus[] memory _whitelistStatuses) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        _whitelistStatuses = s.whitelistStatuses;
+    }
+
+    /**
+     * @notice Returns the Whitelist status for a given token.
+     */
+    function getWhitelistedStatus(address token) internal view returns (Storage.WhitelistStatus memory _whitelistStatus) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        uint256 tokenStatusIndex = findWhitelistStatusIndex(token);
+        _whitelistStatus = s.whitelistStatuses[tokenStatusIndex];
+    }
+
+    /**
+     * @notice Adds a Whitelist Status for a given `token`.
+     */
+    function addWhitelistStatus(address token, bool isWhitelisted, bool isWhitelistedLp, bool isWhitelistedWell) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        s.whitelistStatuses.push(Storage.WhitelistStatus(
+            token,
+            isWhitelisted,
+            isWhitelistedLp,
+            isWhitelistedWell
+        ));
+
+        emit AddWhitelistStatus(token, s.whitelistStatuses.length - 1, isWhitelisted, isWhitelistedLp, isWhitelistedWell);
+    }
+
+    /**
+     * @notice Modifies the exisiting Whitelist Status of `token`.
+     */
+    function updateWhitelistStatus(address token, bool isWhitelisted, bool isWhitelistedLp, bool isWhitelistedWell) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        uint256 tokenStatusIndex = findWhitelistStatusIndex(token);
+        s.whitelistStatuses[tokenStatusIndex].isWhitelisted = isWhitelisted;
+        s.whitelistStatuses[tokenStatusIndex].isWhitelistedLp = isWhitelistedLp;
+        s.whitelistStatuses[tokenStatusIndex].isWhitelistedWell = isWhitelistedWell;
+
+        emit UpdateWhitelistStatus(
+            token,
+            tokenStatusIndex,
+            isWhitelisted,
+            isWhitelistedLp,
+            isWhitelistedWell
+        );
+    }
+
+    /**
+     * @notice Removes `token`'s Whitelist Status.
+     */
+    function removeWhitelistStatus(address token) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        uint256 tokenStatusIndex = findWhitelistStatusIndex(token);
+        s.whitelistStatuses[tokenStatusIndex].token = s.whitelistStatuses[s.whitelistStatuses.length - 1].token;
+        s.whitelistStatuses[tokenStatusIndex].isWhitelisted = s.whitelistStatuses[s.whitelistStatuses.length - 1].isWhitelisted;
+        s.whitelistStatuses[tokenStatusIndex].isWhitelistedLp = s.whitelistStatuses[s.whitelistStatuses.length - 1].isWhitelistedLp;
+        s.whitelistStatuses[tokenStatusIndex].isWhitelistedWell = s.whitelistStatuses[s.whitelistStatuses.length - 1].isWhitelistedWell;
+        s.whitelistStatuses.pop();
+
+        emit RemoveWhitelistStatus(token, tokenStatusIndex);
+    }
+
+    /**
+     * @notice Finds the index of a given `token`'s Whitelist Status.
+     */
+    function findWhitelistStatusIndex(address token) private view returns (uint256) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        uint256 whitelistedStatusLength = s.whitelistStatuses.length;
+        uint256 i;
+        while (s.whitelistStatuses[i].token != token) {
+            i++;
+            if (i >= whitelistedStatusLength) {
+                revert("LibWhitelistedTokens: Token not found");
+            }
+        }
+        return i;
     }
 }

--- a/protocol/contracts/mocks/MockInitDiamond.sol
+++ b/protocol/contracts/mocks/MockInitDiamond.sol
@@ -11,6 +11,7 @@ import {MockToken} from "../mocks/MockToken.sol";
 import {AppStorage, Storage} from "../beanstalk/AppStorage.sol";
 import {C} from "../C.sol";
 import {InitWhitelist} from "contracts/beanstalk/init/InitWhitelist.sol";
+import {InitWhitelistStatuses} from "contracts/beanstalk/init/InitWhitelistStatuses.sol";
 import {LibDiamond} from "../libraries/LibDiamond.sol";
 import {LibCases} from "../libraries/LibCases.sol";
 import {LibGauge} from "contracts/libraries/LibGauge.sol";
@@ -20,7 +21,7 @@ import {Weather} from "contracts/beanstalk/sun/SeasonFacet/Weather.sol";
  * @author Publius
  * @title Mock Init Diamond
 **/
-contract MockInitDiamond is InitWhitelist, Weather {
+contract MockInitDiamond is InitWhitelist, InitWhitelistStatuses, Weather {
 
     function init() external {
         LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
@@ -58,6 +59,7 @@ contract MockInitDiamond is InitWhitelist, Weather {
         emit LibGauge.UpdateAverageStalkPerBdvPerSeason(s.seedGauge.averageGrownStalkPerBdvPerSeason);
 
         whitelistPools();
+        addWhitelistStatuses(false);
     }
 
 }

--- a/protocol/contracts/mocks/mockFacets/MockWhitelistFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockWhitelistFacet.sol
@@ -5,7 +5,8 @@
 pragma solidity =0.7.6;
 pragma experimental ABIEncoderV2;
 
-import "contracts/beanstalk/silo/WhitelistFacet.sol";
+import "contracts/beanstalk/silo/WhitelistFacet/WhitelistFacet.sol";
+import {LibWhitelistedTokens} from "contracts/libraries/Silo/LibWhitelistedTokens.sol";
 
 /**
  * @author Brean
@@ -62,10 +63,52 @@ contract MockWhitelistFacet is WhitelistFacet {
         uint32 season
     );
 
+    /** 
+     * @notice Emitted when a Whitelis Status is added.
+     */
+    event AddWhitelistStatus(
+        address token,
+        uint256 index,
+        bool isWhitelisted,
+        bool isWhitelistedLp,
+        bool isWhitelistedWell
+    );
+
+    /**
+     * @notice Emitted when a Whitelist Status is removed.
+     */
+    event RemoveWhitelistStatus(
+        address token,
+        uint256 index
+    );
+
+    /**
+     * @notice Emitted when a Whitelist Status is updated.
+     */
+    event UpdateWhitelistStatus(
+        address token,
+        uint256 index,
+        bool isWhitelisted,
+        bool isWhitelistedLp,
+        bool isWhitelistedWell
+    );
+
     /**
      * @notice Emitted when a token is removed from the Silo Whitelist.
      * @param token ERC-20 token being removed from the Silo Whitelist.
      */
     event DewhitelistToken(address indexed token);
+
+    function updateWhitelistStatus(address token, bool isWhitelisted, bool isWhitelistedLp, bool isWhitelistedWell) external {
+        LibWhitelistedTokens.updateWhitelistStatus(token, isWhitelisted, isWhitelistedLp, isWhitelistedWell);
+    }
+
+    function removeWhitelistStatus(address token) external {
+        LibWhitelistedTokens.removeWhitelistStatus(token);
+    }
+
+    function addWhitelistStatus(address token, bool isWhitelisted, bool isWhitelistedLp, bool isWhitelistedWell) external {
+        LibWhitelistedTokens.addWhitelistStatus(token, isWhitelisted, isWhitelistedLp, isWhitelistedWell);
+    }
 
 }

--- a/protocol/test/Season.test.js
+++ b/protocol/test/Season.test.js
@@ -40,6 +40,8 @@ describe('Season', function () {
         await this.unripe.addUnripeToken(UNRIPE_BEAN, BEAN, ZERO_BYTES);
         await this.unripe.addUnripeToken(UNRIPE_LP, BEAN_ETH_WELL, ZERO_BYTES);
 
+        this.whitelist = await ethers.getContractAt('WhitelistFacet', this.diamond.address);
+        this.result = await this.whitelist.connect(owner).dewhitelistToken(BEAN_3_CURVE);
 
         // add wells
         [this.well, this.wellFunction, this.pump] = await deployMockBeanEthWell()

--- a/protocol/test/Sun.test.js
+++ b/protocol/test/Sun.test.js
@@ -52,6 +52,9 @@ describe('Sun', function () {
     await this.beanThreeCurve.set_balances([toBean('10000'), to18('10000')]);
     await this.beanThreeCurve.reset_cumulative();
 
+    this.whitelist = await ethers.getContractAt('WhitelistFacet', this.diamond.address);
+    this.result = await this.whitelist.connect(owner).dewhitelistToken(BEAN_3_CURVE);
+
     await this.usdc.mint(owner.address, to6('10000'))
     await this.bean.mint(owner.address, to6('10000'))
     await this.weth.mint(owner.address, to18('10000'))

--- a/protocol/test/Weather.test.js
+++ b/protocol/test/Weather.test.js
@@ -7,6 +7,7 @@ const { deployMockWellWithMockPump, whitelistWell} = require('../utils/well.js')
 const { setEthUsdPrice, setEthUsdcPrice, setEthUsdtPrice } = require('../scripts/usdOracle.js');
 
 const { advanceTime } = require('../utils/helpers.js');
+const { impersonateBeanstalkOwner } = require('../utils/signer.js');
 const ZERO_BYTES = ethers.utils.formatBytes32String('0x0')
 
 // // Set the test data
@@ -47,6 +48,9 @@ describe('Complex Weather', function () {
     await this.fertilizer.setFertilizerE(true, to6('10000'))
     await this.unripe.addUnripeToken(UNRIPE_BEAN, BEAN, ZERO_BYTES);
     await this.unripe.addUnripeToken(UNRIPE_LP, BEAN_ETH_WELL, ZERO_BYTES);
+
+    const whitelist = await ethers.getContractAt('WhitelistFacet', contracts.beanstalkDiamond.address);
+    await whitelist.connect(await impersonateBeanstalkOwner()).dewhitelistToken(BEAN_3_CURVE);
 
     // wells
     [this.well, this.wellFunction, this.pump] = await deployMockWellWithMockPump()

--- a/protocol/test/Whitelist.test.js
+++ b/protocol/test/Whitelist.test.js
@@ -125,45 +125,6 @@ describe('Whitelist', function () {
           '0')).to.be.revertedWith("Whitelist: Token already whitelisted");
     })
 
-    it('reverts on whitelisting a token not in the whitelistTokenArray', async function() {
-      await expect(this.whitelist.connect(owner).whitelistToken(
-          this.siloToken.address, 
-          this.silo.interface.getSighash("mockBDV(uint256 amount)"), 
-          '10000',
-          '1',
-          this.gaugePoint.interface.getSighash("defaultGaugePointFunction(uint256,uint256,uint256)"),
-          this.liquidityWeight.interface.getSighash("maxWeight()"),
-          '0',
-          '0')).to.be.revertedWith("Whitelist: Token not in whitelisted token array");
-    });
-
-    it('reverts on whitelisting a well not in the whitelistTokenArray', async function() {
-      // create a mockWellToken 
-      this.mockWellToken = await deployMockWell();
-      
-      await expect(this.whitelist.connect(owner).whitelistToken(
-          this.mockWellToken.address, 
-          this.silo.interface.getSighash("mockBDV(uint256 amount)"), 
-          '10000',
-          '1',
-          this.gaugePoint.interface.getSighash("defaultGaugePointFunction(uint256,uint256,uint256)"),
-          this.liquidityWeight.interface.getSighash("maxWeight()"),
-          '0',
-          '0')).to.be.revertedWith("Whitelist: Token not in whitelisted token array");
-    });
-
-    it('reverts on whitelisting a token in a array incorrectly', async function(){
-      await expect(this.whitelist.connect(owner).whitelistToken(
-        this.well.address, 
-        this.silo.interface.getSighash("mockBDV(uint256 amount)"), 
-        '10000',
-        '1',
-        this.gaugePoint.interface.getSighash("defaultGaugePointFunction(uint256,uint256,uint256)"),
-        this.liquidityWeight.interface.getSighash("maxWeight()"),
-        '0',
-        '0')).to.be.revertedWith("Whitelist: Token in incorrect whitelisted token array");
-    })
-
     it('reverts on updating stalk per bdv per season for token that is not whitelisted', async function () {
       await expect(this.whitelist.connect(owner).updateStalkPerBdvPerSeasonForToken(this.well.address, 1)).to.be.revertedWith("Token not whitelisted");
     });


### PR DESCRIPTION
Introduce a list of Whitelist Statuses in `AppStorage.sol`. This list is managed by `LibWhitelistedTokens.sol`. A token's Whitelist Status is set when it is whitelisted. A token's status is changed when dewhitelisted. Removing a token from the Whitelist Status must be manual. `WhitelistFacet` now inherits `WhitelistedTokens.sol`, which contain `view` functions to read the lists provided by `LibWhitelistedTokens.sol`.