### PR TITLE
`gpPerBdv = 0` when 0 Deposited Bdv

### DIFF
--- a/protocol/contracts/libraries/LibGauge.sol
+++ b/protocol/contracts/libraries/LibGauge.sol
@@ -164,7 +164,7 @@ library LibGauge {
 
             // Gauge points has 18 decimal precision (GP_PRECISION = 1%)
             // Deposited BDV has 6 decimal precision (1e6 = 1 unit of BDV)
-            uint256 gpPerBdv = newGaugePoints.mul(BDV_PRECISION).div(depositedBdv);
+            uint256 gpPerBdv = depositedBdv > 0 ? newGaugePoints.mul(BDV_PRECISION).div(depositedBdv) : 0;
 
             // gpPerBdv has 18 decimal precision.
             if (gpPerBdv > maxLpGpPerBdv) maxLpGpPerBdv = gpPerBdv;


### PR DESCRIPTION
- use `gpPerBdv = 0` when there is 0 Deposited Bdv.