### PR TITLE
seedGauge-remediation-fix

### DIFF
--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -164,6 +164,9 @@ contract ConvertFacet is ReentrancyGuard {
                 ));
                 i++;
             }
+
+            // if the loop is exited early, set the remaining amounts to 0.
+            // `i` is not reinitalized and uses the value from the loop.
             for (i; i < stems.length; ++i) amounts[i] = 0;
             
             emit RemoveDeposits(

--- a/protocol/contracts/beanstalk/silo/ConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertFacet.sol
@@ -234,8 +234,7 @@ contract ConvertFacet is ReentrancyGuard {
             );
         } else {
             LibTokenSilo.incrementTotalGerminating(token, amount, bdv, germ);
-            // safeCast not needed as stalk is <= max(uint128)
-            LibSilo.mintGerminatingStalk(msg.sender, uint128(bdv.mul(LibTokenSilo.stalkIssuedPerBdv(token))), germ);   
+            LibSilo.mintGerminatingStalk(msg.sender, bdv.mul(LibTokenSilo.stalkIssuedPerBdv(token)).toUint128(), germ);   
             LibSilo.mintActiveStalk(msg.sender, grownStalk);
         }
         LibTokenSilo.addDepositToAccount(

--- a/protocol/contracts/beanstalk/silo/EnrootFacet.sol
+++ b/protocol/contracts/beanstalk/silo/EnrootFacet.sol
@@ -255,7 +255,7 @@ contract EnrootFacet is ReentrancyGuard {
             LibSilo.stalkReward(
                 stem,
                 stemTip,
-                uint128(bdv) // safeCast not needed because bdv is already uint128.
+                bdv.toUint128()
             )
         );
     }

--- a/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/TokenSilo.sol
@@ -146,7 +146,7 @@ contract TokenSilo is Silo {
             stem = LibTokenSilo.stemTipForToken(token),
             amount
         );
-        LibSilo.mintGerminatingStalk(account, uint128(stalk), germ);
+        LibSilo.mintGerminatingStalk(account, stalk.toUint128(), germ);
     }
 
     //////////////////////// WITHDRAW ////////////////////////
@@ -297,7 +297,7 @@ contract TokenSilo is Silo {
     ) private {
         // Decrement from total germinating.
         LibTokenSilo.decrementTotalGerminating(token, amount, bdv, germinateState); // Decrement total Germinating in the silo.
-        LibSilo.burnGerminatingStalk(account, uint128(stalk), germinateState); // Burn stalk and roots associated with the stalk.
+        LibSilo.burnGerminatingStalk(account, stalk.toUint128(), germinateState); // Burn stalk and roots associated with the stalk.
     }
 
     //////////////////////// TRANSFER ////////////////////////

--- a/protocol/contracts/beanstalk/sun/SeasonFacet/SeasonFacet.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/SeasonFacet.sol
@@ -98,7 +98,7 @@ contract SeasonFacet is Weather {
             .div(C.BLOCK_LENGTH_SECONDS);
 
         // Read the Bean / Eth price calculated by the Minting Well.
-        uint256 beanEthPrice = LibWell.getBeanTknPriceFromTwaReserves(C.BEAN_ETH_WELL);
+        uint256 beanEthPrice = LibWell.getBeanTokenPriceFromTwaReserves(C.BEAN_ETH_WELL);
 
         // reset USD Token prices and TWA reserves in storage for all whitelisted Well LP Tokens.
         address[] memory whitelistedWells = LibWhitelistedTokens.getWhitelistedWellLpTokens();

--- a/protocol/contracts/libraries/LibEvaluate.sol
+++ b/protocol/contracts/libraries/LibEvaluate.sol
@@ -234,8 +234,9 @@ library LibEvaluate {
             // if the liquidity is the largest, update `largestLiqWell`,  
             // and add the liquidity to the total.
             // `largestLiqWell` is only used to initalize `s.sopWell` upon a sop,
-            // but a hot storage load to skip the block below 
-            // is significantly more expensive than performing the logic on every sunrise.
+            // if it has not been initalized.
+            // A hot storage load to skip the block below is significantly more expensive
+            //  than performing the logic on every sunrise.
             if (wellLiquidity > largestLiq) {
                 largestLiq = wellLiquidity;
                 largestLiqWell = pools[i];

--- a/protocol/contracts/libraries/LibEvaluate.sol
+++ b/protocol/contracts/libraries/LibEvaluate.sol
@@ -92,12 +92,12 @@ library LibEvaluate {
             // and thus will skip the p > EXCESSIVE_PRICE_THRESHOLD check if the well oracle fails to
             // compute a valid price this Season.
             // deltaB > 0 implies that address(well) != address(0).
-            uint256 beanTknPrice = LibWell.getBeanTknPriceFromTwaReserves(well);
-            if (beanTknPrice > 1) {
-                // USD/TKN * TKN/BEAN = USD/BEAN 
+            uint256 beanTokenPrice = LibWell.getBeanTokenPriceFromTwaReserves(well);
+            if (beanTokenPrice > 1) {
+                // USD/TOKEN * TOKEN/BEAN = USD/BEAN 
                 // 1/USD/BEAN = BEAN/USD
                 uint256 beanUsdPrice = uint256(1e30).div(
-                    LibWell.getUsdTokenPriceForWell(well).mul(beanTknPrice)
+                    LibWell.getUsdTokenPriceForWell(well).mul(beanTokenPrice)
                 );
                 if (beanUsdPrice > EXCESSIVE_PRICE_THRESHOLD) {
                     // p > EXCESSIVE_PRICE_THRESHOLD

--- a/protocol/contracts/libraries/Silo/LibGerminate.sol
+++ b/protocol/contracts/libraries/Silo/LibGerminate.sol
@@ -161,7 +161,7 @@ library LibGerminate {
         uint128 germinatingStalk;
 
         // check to end germination for first stalk.
-        // if last mowed season is not equal to current season - 1,
+        // if last mowed season is greater or equal than (currentSeason - 1),,
         if (firstStalk > 0 && lastMowedSeason < currentSeason.sub(1)) {
             germinatingStalk = firstStalk;
             roots = claimGerminatingRoots(account, lastMowedSeason, firstStalk, lastUpdateOdd);

--- a/protocol/contracts/libraries/Silo/LibGerminate.sol
+++ b/protocol/contracts/libraries/Silo/LibGerminate.sol
@@ -281,7 +281,7 @@ library LibGerminate {
         // check to end germination for first stalk.
         // if last mowed season is the greater or equal than (currentSeason - 1),
         // then the first stalk is still germinating.
-        if (firstStalk > 0 && lastMowedSeason < currentSeason.sub(1)) {
+        if (firstStalk > 0 && lastMowedSeason != currentSeason.sub(1)) {
             germinatingStalk = firstStalk;
             germinatingRoots = calculateGerminatingRoots(lastMowedSeason, firstStalk);
         }

--- a/protocol/contracts/libraries/Silo/LibGerminate.sol
+++ b/protocol/contracts/libraries/Silo/LibGerminate.sol
@@ -162,7 +162,7 @@ library LibGerminate {
 
         // check to end germination for first stalk.
         // if last mowed season is not equal to current season - 1,
-        if (firstStalk > 0 && lastMowedSeason != currentSeason.sub(1)) {
+        if (firstStalk > 0 && lastMowedSeason < currentSeason.sub(1)) {
             germinatingStalk = firstStalk;
             roots = claimGerminatingRoots(account, lastMowedSeason, firstStalk, lastUpdateOdd);
         }
@@ -281,7 +281,7 @@ library LibGerminate {
         // check to end germination for first stalk.
         // if last mowed season is the greater or equal than (currentSeason - 1),
         // then the first stalk is still germinating.
-        if (firstStalk > 0 && lastMowedSeason != currentSeason.sub(1)) {
+        if (firstStalk > 0 && lastMowedSeason < currentSeason.sub(1)) {
             germinatingStalk = firstStalk;
             germinatingRoots = calculateGerminatingRoots(lastMowedSeason, firstStalk);
         }

--- a/protocol/contracts/libraries/Silo/LibGerminate.sol
+++ b/protocol/contracts/libraries/Silo/LibGerminate.sol
@@ -381,6 +381,9 @@ library LibGerminate {
      *
      * @dev use when the stemTip and germinatingStem have already been calculated.
      * Assumes the same token is used.
+     * prevStalkEarnedPerSeason is the stalkEarnedPerSeason of the previous season.
+     * since `lastStemTip` + `prevStalkEarnedPerSeason` is the current stemTip, 
+     * safeMath is not needed.
      */
     function __getGerminatingStem(
         int96 stemTip,

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -405,11 +405,11 @@ library LibTokenSilo {
 
             // SafeCast unnecessary b/c updatedAmount <= crateAmount and updatedBDV <= crateBDV, 
             // which are both <= type(uint128).max
-            s.a[account].deposits[depositId].amount = uint128(updatedAmount);
-            s.a[account].deposits[depositId].bdv = uint128(updatedBDV);
+            s.a[account].deposits[depositId].amount = updatedAmount.toUint128();
+            s.a[account].deposits[depositId].bdv = updatedBDV.toUint128();
             
             s.a[account].mowStatuses[token].bdv = s.a[account].mowStatuses[token].bdv.sub(
-                uint128(removedBDV)
+                removedBDV.toUint128()
             );
 
             return removedBDV;
@@ -419,7 +419,7 @@ library LibTokenSilo {
 
         // SafeMath unnecessary b/c crateBDV <= type(uint128).max
         s.a[account].mowStatuses[token].bdv = s.a[account].mowStatuses[token].bdv.sub(
-            uint128(crateBDV)
+            crateBDV.toUint128()
         );
     }
 

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -609,7 +609,7 @@ library LibTokenSilo {
         // divide the newStem by 1e6 to get the legacy stem.
         uint256 legacyDepositId = LibBytes.packAddressAndStem(token, newStem.div(1e6));
         uint256 legacyAmount = s.a[account].legacyV3Deposits[legacyDepositId].amount;
-    uint256 legacyBdv = s.a[account].legacyV3Deposits[legacyDepositId].bdv;
+        uint256 legacyBdv = s.a[account].legacyV3Deposits[legacyDepositId].bdv;
         crateAmount = crateAmount.add(legacyAmount);
         crateBdv = crateBdv.add(legacyBdv);
         delete s.a[account].legacyV3Deposits[legacyDepositId];

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -156,7 +156,7 @@ library LibTokenSilo {
             amount.toUint128()
         );
         germinate.deposited[token].bdv = germinate.deposited[token].bdv.sub(bdv.toUint128());
-
+    
         emit LibGerminate.TotalGerminatingBalanceChanged(
             LibGerminate.getSeasonGerminationState() == germ ? 
                 s.season.current : 
@@ -303,9 +303,6 @@ library LibTokenSilo {
      *
      * Unlike {removeDepositFromAccount}, this function DOES EMIT an
      * {AddDeposit} event. See {removeDepositFromAccount} for more details.
-     *
-     * If a deposit is 'germinating', increment the germinating bdv for a user.
-     * Otherwise, increment the mow status bdv for a user.
      */
     function addDepositToAccount(
         address account,
@@ -612,7 +609,7 @@ library LibTokenSilo {
         // divide the newStem by 1e6 to get the legacy stem.
         uint256 legacyDepositId = LibBytes.packAddressAndStem(token, newStem.div(1e6));
         uint256 legacyAmount = s.a[account].legacyV3Deposits[legacyDepositId].amount;
-        uint256 legacyBdv = s.a[account].legacyV3Deposits[legacyDepositId].bdv;
+    uint256 legacyBdv = s.a[account].legacyV3Deposits[legacyDepositId].bdv;
         crateAmount = crateAmount.add(legacyAmount);
         crateBdv = crateBdv.add(legacyBdv);
         delete s.a[account].legacyV3Deposits[legacyDepositId];

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -182,6 +182,9 @@ library LibWhitelist {
         s.ss[token].milestoneSeason = s.season.current;
        
         // stalkEarnedPerSeason is set to int32 before casting down.
+        // will overflow if s.ss[token].stalkEarnedPerSeason or 
+        // stalkEarnedPerSeason > 2^31 - 1. 
+        // or if the difference is greater than 2^23 - 1.
         s.ss[token].deltaStalkEarnedPerSeason = int24(int32(stalkEarnedPerSeason) - int32(s.ss[token].stalkEarnedPerSeason)); // calculate delta
         s.ss[token].stalkEarnedPerSeason = stalkEarnedPerSeason;
 

--- a/protocol/contracts/libraries/Well/LibWell.sol
+++ b/protocol/contracts/libraries/Well/LibWell.sol
@@ -223,14 +223,14 @@ library LibWell {
      * @notice returns the price in terms of TKN/BEAN. 
      * (if eth is 1000 beans, this function will return 1000e6);
      */
-    function getBeanTknPriceFromTwaReserves(address well) internal view returns (uint256 price) {
+    function getBeanTokenPriceFromTwaReserves(address well) internal view returns (uint256 price) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         // s.twaReserve[well] should be set prior to this function being called.
         if (s.twaReserves[well].reserve0 == 0 || s.twaReserves[well].reserve1 == 0) {
             price = 0;
         } else {
             // fetch the bean index from the well in order to properly return the bean price.
-            if(getBeanIndexFromWell(well) == 0) { 
+            if (getBeanIndexFromWell(well) == 0) { 
                 price = uint256(s.twaReserves[well].reserve0).mul(1e18).div(s.twaReserves[well].reserve1);
             } else { 
                 price = uint256(s.twaReserves[well].reserve1).mul(1e18).div(s.twaReserves[well].reserve0);

--- a/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -300,8 +300,6 @@ contract MockSeasonFacet is SeasonFacet  {
         IMockPump(C.BEANSTALK_PUMP).update(reserves, new bytes(0));
         s.twaReserves[C.BEAN_ETH_WELL].reserve0 = uint128(reserves[0]);
         s.twaReserves[C.BEAN_ETH_WELL].reserve1 = uint128(reserves[1]);
-        console.log("twa reserves 0:", s.twaReserves[C.BEAN_ETH_WELL].reserve0);
-        console.log("twa reserves 1:", s.twaReserves[C.BEAN_ETH_WELL].reserve1);
         s.usdTokenPrice[C.BEAN_ETH_WELL] = 0.001e18;
         if(aboveQ) {
             // increase bean price
@@ -310,8 +308,6 @@ contract MockSeasonFacet is SeasonFacet  {
             // decrease bean price
             s.twaReserves[C.BEAN_ETH_WELL].reserve0 = uint128(reserves[0]);
         }
-        console.log("twa reserves 0:", s.twaReserves[C.BEAN_ETH_WELL].reserve0);
-        console.log("twa reserves 1:", s.twaReserves[C.BEAN_ETH_WELL].reserve1);
 
         /// FIELD ///
         s.season.raining = raining;
@@ -556,9 +552,9 @@ contract MockSeasonFacet is SeasonFacet  {
     }
 
     function mockTestBeanPrice(address well) external view returns (uint256 beanUsdPrice) {
-        uint256 beanTknPrice = LibWell.getBeanTknPriceFromTwaReserves(well);
+        uint256 beanTokenPrice = LibWell.getBeanTokenPriceFromTwaReserves(well);
         beanUsdPrice = uint256(1e30).div(
-            LibWell.getUsdTokenPriceForWell(well).mul(beanTknPrice)
+            LibWell.getUsdTokenPriceForWell(well).mul(beanTokenPrice)
         );
     }
 }

--- a/protocol/test/Sun.test.js
+++ b/protocol/test/Sun.test.js
@@ -357,7 +357,7 @@ describe('Sun', function () {
     
     await expect(this.result).to.emit(this.silo, 'TotalGerminatingBalanceChanged')
       .withArgs(
-        '6',
+        '4',
         BEAN, 
         to6('-1000'), 
         to6('-1000')


### PR DESCRIPTION
Adds recommended remediations based on Cyfrin review. 

- Updated LibGerminate.EndTotalGermination to emit the proper season: https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/1f29edda1d63a00231ff80a45d7284f6d81d1b02#diff-d2261445685829aad9421eae03f9644ae9d11be5713ccc0870497a0be1e58d8aL121 

- Updated NatSpec of LibTokenSilo::addDepositToAccount: https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/6429ce199ea3b60f9b43d6072a59689912abbf15#diff-a0abb2f4046ee1f0caff2716c2c0a21755aa0eac99ab5e6519fcb77d989a196cL307 (Ignore the tab, fixed in a later commit). 

- Downcasted bdv in convertFacet, line 238: https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/2914b1984d934e188f5d8f60f115fff855505a81#diff-80dee2bf35b86cb246d17e5c125566d999c1c76f695851906d62df8db8930950R237

- Downcasted bdv in enrootFacet, line 252: https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/2914b1984d934e188f5d8f60f115fff855505a81#diff-8ff408c03f8e572c65d42e361bf068086db153e502b17f12145a388a57209aafR258 

- Downcasted bdv in TokenSilo, lines 149 and 299: https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/2914b1984d934e188f5d8f60f115fff855505a81#diff-1133daa7cab8c89b53a1fc34e51195e138f499112abfdf198b280fc03eb77ecfR149 
https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/2914b1984d934e188f5d8f60f115fff855505a81#diff-1133daa7cab8c89b53a1fc34e51195e138f499112abfdf198b280fc03eb77ecfR300 

- Downcasted updatedAmount, updatedBDV, removedBDV, and crateBDV here: https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/2914b1984d934e188f5d8f60f115fff855505a81#diff-a0abb2f4046ee1f0caff2716c2c0a21755aa0eac99ab5e6519fcb77d989a196cR408 

- Updated comment in LibEvaluate regarding the sop well:https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/15f92503886446a4cb3f67c41772e7e1f70d7f9d#diff-03d6d7beb3b1e19c35746b1fef4b4b5f28b5d8d1470e834d4ed939eb8b0fa177R237-R239 

- Updated conditional to match in libGerminate: https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/71ea4c97b637243d8797037a9432555af1cb607f#diff-d2261445685829aad9421eae03f9644ae9d11be5713ccc0870497a0be1e58d8aR165

- Added rationale for safe logic in LibGerminate, L383: https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/a1f1d8c8d107a300930bb203fee7f71e99ed9e11#diff-d2261445685829aad9421eae03f9644ae9d11be5713ccc0870497a0be1e58d8aR384-R386 

- Added documentation for safe logic in LibWhitelist, L188: https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/490d2d0f63796b5d41052c36577f30617442a48a#diff-dc7f60cc6e63597b30e6d00ab9e69f139cdc59411ff3113e7a54d7b331b3d1ebR185-R187

- Replaced `TKN` for `TOKEN` for readability. https://github.com/BeanstalkFarms/Beanstalk/pull/829/commits/d2a52383fcdf8985fb1ce59aeee0b04cbb5dadc1
