### PR TITLE
Lib locked underlying fix

### DIFF
--- a/protocol/contracts/libraries/LibLockedUnderlying.sol
+++ b/protocol/contracts/libraries/LibLockedUnderlying.sol
@@ -16,6 +16,8 @@ import {AppStorage, LibAppStorage} from "./LibAppStorage.sol";
 library LibLockedUnderlying {
     using SafeMath for uint256;
 
+    uint256 constant DECIMALS = 1e6; 
+
     /**
      * @notice Return the amount of Underlying Tokens that would be locked if all of the Unripe Tokens
      * were chopped.
@@ -52,12 +54,15 @@ library LibLockedUnderlying {
      * The equation is solved by using a lookup table of N_{⌈U/i⌉} values for different values of
      * U and R (The solution is independent of N) as solving iteratively is too computationally
      * expensive and there is no more efficient way to solve the equation.
+     * 
+     * The lookup threshold assumes no decimal precision. This library only supports 
+     * unripe tokens with 6 decimals.
      */
     function getPercentLockedUnderlying(
         address unripeToken,
         uint256 recapPercentPaid
     ) private view returns (uint256 percentLockedUnderlying) {
-        uint256 unripeSupply = IERC20(unripeToken).totalSupply();
+        uint256 unripeSupply = IERC20(unripeToken).totalSupply().div(DECIMALS);
         if (unripeSupply < 1_000_000) return 0; // If < 1,000,000 Assume all supply is unlocked.
         if (unripeSupply > 5_000_000) {
             if (unripeSupply > 10_000_000) {

--- a/protocol/test/Gauge.test.js
+++ b/protocol/test/Gauge.test.js
@@ -328,23 +328,25 @@ describe('Gauge', function () {
       it('< 1m unripe lockedBeans calculation:', async function () {
         // current unripe LP and unripe Bean supply each: 10,000. 
         // under 1m unripe bean and LP, all supply is unlocked:
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('0'))
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('0'))
-        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('0'))
-        expect(
-          await this.seasonGetters.getLiquidityToSupplyRatio()
-          ).to.be.eq(to18('1'))
+        const getLockedBeansUnderlyingUnripeBean = await this.unripe.getLockedBeansUnderlyingUnripeBean()
+        const getLockedBeansUnderlyingUrLP = await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()
+        const lockedBeans = await this.unripe.getLockedBeans()
+        const L2SR = await this.seasonGetters.getLiquidityToSupplyRatio()
+
+        expect(getLockedBeansUnderlyingUnripeBean).to.be.eq('0')
+        expect(getLockedBeansUnderlyingUrLP).to.be.eq('0')
+        expect(lockedBeans).to.be.eq('0')
+        expect(L2SR).to.be.eq(to18('1'))
 
         //  set urBean and urLP to 1m and verify values do not change:
-        await this.unripeLP.mint(ownerAddress, to6('990000'))
-        await this.unripeBean.mint(ownerAddress, to6('990000'))
+        await this.unripeLP.mint(ownerAddress, to6('989999'))
+        await this.unripeBean.mint(ownerAddress, to6('989999'))
 
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('0'))
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('0'))
-        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('0'))
-        expect(
-          await this.seasonGetters.getLiquidityToSupplyRatio()
-          ).to.be.eq(to18('1'))
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(getLockedBeansUnderlyingUnripeBean)
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(getLockedBeansUnderlyingUrLP)
+        expect(await this.unripe.getLockedBeans()).to.be.eq(lockedBeans)
+        expect(await this.seasonGetters.getLiquidityToSupplyRatio()
+          ).to.be.eq(L2SR)
       })
 
       it('< 5m unripe lockedBeans calculation:', async function () {
@@ -353,26 +355,26 @@ describe('Gauge', function () {
         await this.unripeBean.mint(ownerAddress, to6('1000000'))
 
         // verify locked beans amount changed: 
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('579.500817'))
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('579.500817'))
-        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('1159.001634'))
+        const getLockedBeansUnderlyingUnripeBean = await this.unripe.getLockedBeansUnderlyingUnripeBean()
+        const getLockedBeansUnderlyingUrLP = await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()
+        const lockedBeans = await this.unripe.getLockedBeans()
+        const L2SR = await this.seasonGetters.getLiquidityToSupplyRatio()
+        expect(getLockedBeansUnderlyingUnripeBean).to.be.eq(to6('579.500817'))
+        expect(getLockedBeansUnderlyingUrLP).to.be.eq(to6('579.500817'))
+        expect(lockedBeans).to.be.eq(to6('1159.001634'))
 
         // verify L2SR increased:
-        expect(
-          await this.seasonGetters.getLiquidityToSupplyRatio()
-          ).to.be.eq(to18('1.001160346477463386'))
+        expect(L2SR).to.be.eq(to18('1.001160346477463386'))
         
         //  set urBean and urLP to 5m and verify values do not change:
         await this.unripeLP.mint(ownerAddress, to6('3990000'))
         await this.unripeBean.mint(ownerAddress, to6('3990000'))
 
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('579.500817'))
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('579.500817'))
-        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('1159.001634'))
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(getLockedBeansUnderlyingUnripeBean)
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(getLockedBeansUnderlyingUrLP)
+        expect(await this.unripe.getLockedBeans()).to.be.eq(lockedBeans)
 
-        expect(
-          await this.seasonGetters.getLiquidityToSupplyRatio()
-          ).to.be.eq(to18('1.001160346477463386'))
+        expect(await this.seasonGetters.getLiquidityToSupplyRatio()).to.be.eq(L2SR)
       })
 
       it('< 10m unripe lockedBeans calculation:', async function () {
@@ -381,26 +383,26 @@ describe('Gauge', function () {
         await this.unripeBean.mint(ownerAddress, to6('5000000'))
 
         // verify locked beans amount changed: 
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('515.604791'))
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('515.604791'))
-        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('1031.209582'))
+        const getLockedBeansUnderlyingUnripeBean = await this.unripe.getLockedBeansUnderlyingUnripeBean()
+        const getLockedBeansUnderlyingUrLP = await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()
+        const lockedBeans = await this.unripe.getLockedBeans()
+        const L2SR = await this.seasonGetters.getLiquidityToSupplyRatio()
+        expect(getLockedBeansUnderlyingUnripeBean).to.be.eq(to6('515.604791'))
+        expect(getLockedBeansUnderlyingUrLP).to.be.eq(to6('515.604791'))
+        expect(lockedBeans).to.be.eq(to6('1031.209582'))
 
         // verify L2SR increased:
-        expect(
-          await this.seasonGetters.getLiquidityToSupplyRatio()
-          ).to.be.eq(to18('1.001032274072915240'))
+        expect(L2SR).to.be.eq(to18('1.001032274072915240'))
 
         //  set urBean and urLP to 10m and verify values do not change:
         await this.unripeLP.mint(ownerAddress, to6('4990000'))
         await this.unripeBean.mint(ownerAddress, to6('4990000'))
 
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('579.500817'))
-        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('579.500817'))
-        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('1159.001634'))
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(getLockedBeansUnderlyingUnripeBean)
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(getLockedBeansUnderlyingUrLP)
+        expect(await this.unripe.getLockedBeans()).to.be.eq(lockedBeans)
 
-        expect(
-          await this.seasonGetters.getLiquidityToSupplyRatio()
-          ).to.be.eq(to18('1.001160346477463386'))
+        expect(await this.seasonGetters.getLiquidityToSupplyRatio()).to.be.eq(L2SR)
       })
 
       it('< 10m unripe lockedBeans calculation:', async function () {

--- a/protocol/test/Gauge.test.js
+++ b/protocol/test/Gauge.test.js
@@ -58,7 +58,7 @@ describe('Gauge', function () {
     // add unripe
     this.unripeBean = await ethers.getContractAt('MockToken', UNRIPE_BEAN)
     this.unripeLP = await ethers.getContractAt('MockToken', UNRIPE_LP)
-    await this.unripeLP.mint(ownerAddress, to18('10000'))
+    await this.unripeLP.mint(ownerAddress, to6('10000'))
     await this.unripeBean.mint(ownerAddress, to6('10000'))
     await this.unripeLP.connect(owner).approve(this.diamond.address, to6('100000000'))
     await this.unripeBean.connect(owner).approve(this.diamond.address, to6('100000000'))
@@ -307,6 +307,9 @@ describe('Gauge', function () {
       })
 
       it('getters', async function () {
+        // issue unripe such that unripe supply > 10m. 
+        await this.unripeLP.mint(ownerAddress, to6('10000000'))
+        await this.unripeBean.mint(ownerAddress, to6('10000000'))
         // urBean supply * 10% recapitalization (underlyingBean/UrBean) * 10% (fertilizerIndex/totalFertilizer)
         // = 10000 urBEAN * 10% = 1000 BEAN * (100-10%) = 900 beans locked.
         // urBEANETH supply * 0.1% recapitalization (underlyingBEANETH/UrBEANETH) * 10% (fertilizerIndex/totalFertilizer)
@@ -319,9 +322,107 @@ describe('Gauge', function () {
         expect(
           await this.seasonGetters.getLiquidityToSupplyRatio()
           ).to.be.eq(to18('1.000873426417975035'))
+
+      })
+      
+      it('< 1m unripe lockedBeans calculation:', async function () {
+        // current unripe LP and unripe Bean supply each: 10,000. 
+        // under 1m unripe bean and LP, all supply is unlocked:
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('0'))
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('0'))
+        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('0'))
+        expect(
+          await this.seasonGetters.getLiquidityToSupplyRatio()
+          ).to.be.eq(to18('1'))
+
+        //  set urBean and urLP to 1m and verify values do not change:
+        await this.unripeLP.mint(ownerAddress, to6('990000'))
+        await this.unripeBean.mint(ownerAddress, to6('990000'))
+
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('0'))
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('0'))
+        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('0'))
+        expect(
+          await this.seasonGetters.getLiquidityToSupplyRatio()
+          ).to.be.eq(to18('1'))
+      })
+
+      it('< 5m unripe lockedBeans calculation:', async function () {
+        // mint unripe bean and LP such that 5m > supply > 1m.
+        await this.unripeLP.mint(ownerAddress, to6('1000000'))
+        await this.unripeBean.mint(ownerAddress, to6('1000000'))
+
+        // verify locked beans amount changed: 
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('579.500817'))
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('579.500817'))
+        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('1159.001634'))
+
+        // verify L2SR increased:
+        expect(
+          await this.seasonGetters.getLiquidityToSupplyRatio()
+          ).to.be.eq(to18('1.001160346477463386'))
+        
+        //  set urBean and urLP to 5m and verify values do not change:
+        await this.unripeLP.mint(ownerAddress, to6('3990000'))
+        await this.unripeBean.mint(ownerAddress, to6('3990000'))
+
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('579.500817'))
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('579.500817'))
+        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('1159.001634'))
+
+        expect(
+          await this.seasonGetters.getLiquidityToSupplyRatio()
+          ).to.be.eq(to18('1.001160346477463386'))
+      })
+
+      it('< 10m unripe lockedBeans calculation:', async function () {
+        // mint unripe bean and LP such that 10m > supply > 5m.
+        await this.unripeLP.mint(ownerAddress, to6('5000000'))
+        await this.unripeBean.mint(ownerAddress, to6('5000000'))
+
+        // verify locked beans amount changed: 
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('515.604791'))
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('515.604791'))
+        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('1031.209582'))
+
+        // verify L2SR increased:
+        expect(
+          await this.seasonGetters.getLiquidityToSupplyRatio()
+          ).to.be.eq(to18('1.001032274072915240'))
+
+        //  set urBean and urLP to 10m and verify values do not change:
+        await this.unripeLP.mint(ownerAddress, to6('4990000'))
+        await this.unripeBean.mint(ownerAddress, to6('4990000'))
+
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('579.500817'))
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('579.500817'))
+        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('1159.001634'))
+
+        expect(
+          await this.seasonGetters.getLiquidityToSupplyRatio()
+          ).to.be.eq(to18('1.001160346477463386'))
+      })
+
+      it('< 10m unripe lockedBeans calculation:', async function () {
+        // mint unripe bean and LP such that supply > 10m.
+        await this.unripeLP.mint(ownerAddress, to6('10000000'))
+        await this.unripeBean.mint(ownerAddress, to6('10000000'))
+
+        // verify locked beans amount changed: 
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBean()).to.be.eq(to6('436.332105'))
+        expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('436.332105'))
+        expect(await this.unripe.getLockedBeans()).to.be.eq(to6('872.664210'))
+
+        // verify L2SR increased:
+        expect(
+          await this.seasonGetters.getLiquidityToSupplyRatio()
+          ).to.be.eq(to18('1.000873426417975035'))
       })
 
       it('is MEV resistant', async function () {
+        // issue unripe such that unripe supply > 10m. 
+        await this.unripeLP.mint(ownerAddress, to6('10000000'))
+        await this.unripeBean.mint(ownerAddress, to6('10000000'))
         expect(await this.unripe.getLockedBeansUnderlyingUnripeBeanEth()).to.be.eq(to6('436.332105'))
 
         await this.well.mint(ownerAddress, to18('1000'))


### PR DESCRIPTION
The current seed gauge implementation incorrectly calculates the locked beans underlying an unripe bean(how Beanstalk accounts for Unripe in the L2SR calculation). The issue occurs when the Unripe supply is <10M and in these instances Beanstalk would've calculated a lower L2SR than intended.
