### PR TITLE
remediations 2.

### DIFF
--- a/protocol/abi/Beanstalk.json
+++ b/protocol/abi/Beanstalk.json
@@ -375,6 +375,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "getRecapitalized",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -938,6 +951,19 @@
         "internalType": "uint128",
         "name": "",
         "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTotalRecapDollarsNeeded",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/protocol/contracts/beanstalk/barn/UnripeFacet.sol
+++ b/protocol/contracts/beanstalk/barn/UnripeFacet.sol
@@ -228,9 +228,22 @@ contract UnripeFacet is ReentrancyGuard {
      * @notice Returns the % penalty of Chopping an Unripe Token into its Ripe Token.
      * @param unripeToken The address of the Unripe Token.
      * @return penalty The penalty % of Chopping derived from %Recapitalized^2.
+     * @dev `address` parameter retained for backwards compatiability.
      */
     function getPercentPenalty(address unripeToken) external view returns (uint256 penalty) {
-        return LibUnripe.getPenalizedUnderlying(unripeToken, LibUnripe.DECIMALS, IERC20(unripeToken).totalSupply());
+        if (unripeToken == C.UNRIPE_BEAN) { 
+            return LibUnripe.getPenalizedUnderlying(
+                unripeToken,
+                LibUnripe.DECIMALS,
+                IERC20(unripeToken).totalSupply()
+            );
+        }
+        
+        if (unripeToken == C.UNRIPE_LP) { 
+            return LibUnripe.getTotalRecapitalizedPercent()
+                .mul(LibUnripe.getTotalRecapitalizedPercent())
+                .div(LibUnripe.DECIMALS);
+        }
     }
 
     /**
@@ -356,7 +369,7 @@ contract UnripeFacet is ReentrancyGuard {
     function getLockedBeansUnderlyingUnripeBean() external view returns (uint256) {
         return LibLockedUnderlying.getLockedUnderlying(
             C.UNRIPE_BEAN,
-            LibUnripe.getRecapPaidPercentAmount(1e6)
+            LibUnripe.getTotalRecapitalizedPercent()
         );
     }
 
@@ -366,5 +379,12 @@ contract UnripeFacet is ReentrancyGuard {
     function getLockedBeansUnderlyingUnripeLP() external view returns (uint256) {
         uint256[] memory twaReserves = LibWell.getTwaReservesFromBeanstalkPump(LibBarnRaise.getBarnRaiseWell());
         return LibUnripe.getLockedBeansFromLP(twaReserves);
+    }
+
+    /**
+     * @notice returns the amount of dollars recapitalized in the barn raise.
+     */
+    function getRecapitalized() external view returns (uint256) {
+        return s.recapitalized;
     }
 }

--- a/protocol/contracts/libraries/LibFertilizer.sol
+++ b/protocol/contracts/libraries/LibFertilizer.sol
@@ -19,6 +19,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import {LibWell} from "contracts/libraries/Well/LibWell.sol";
 import {LibUsdOracle} from "contracts/libraries/Oracle/LibUsdOracle.sol";
 
+
 /**
  * @author Publius
  * @title Fertilizer

--- a/protocol/contracts/libraries/LibLockedUnderlying.sol
+++ b/protocol/contracts/libraries/LibLockedUnderlying.sol
@@ -6,7 +6,7 @@ pragma experimental ABIEncoderV2;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
 import {AppStorage, LibAppStorage} from "./LibAppStorage.sol";
-
+// import "hardhat/console.sol";
 /**
  * @title LibLockedUnderlying
  * @author Brendan
@@ -15,6 +15,8 @@ import {AppStorage, LibAppStorage} from "./LibAppStorage.sol";
  */
 library LibLockedUnderlying {
     using SafeMath for uint256;
+
+    uint256 constant DECIMALS = 1e6; 
 
     /**
      * @notice Return the amount of Underlying Tokens that would be locked if all of the Unripe Tokens
@@ -25,6 +27,9 @@ library LibLockedUnderlying {
         uint256 recapPercentPaid
     ) external view returns (uint256 lockedUnderlying) {
         AppStorage storage s = LibAppStorage.diamondStorage();
+        // console.log("token:", unripeToken);
+        // console.log("balance of underlying:", s.u[unripeToken].balanceOfUnderlying);
+        // console.log("get percent locked underlying:", getPercentLockedUnderlying(unripeToken, recapPercentPaid));
         return
             s
                 .u[unripeToken]
@@ -52,12 +57,15 @@ library LibLockedUnderlying {
      * The equation is solved by using a lookup table of N_{⌈U/i⌉} values for different values of
      * U and R (The solution is independent of N) as solving iteratively is too computationally
      * expensive and there is no more efficient way to solve the equation.
+     * 
+     * The lookup threshold assumes no decimal precision. This library only supports 
+     * unripe tokens with 6 decimals.
      */
     function getPercentLockedUnderlying(
         address unripeToken,
         uint256 recapPercentPaid
     ) private view returns (uint256 percentLockedUnderlying) {
-        uint256 unripeSupply = IERC20(unripeToken).totalSupply();
+        uint256 unripeSupply = IERC20(unripeToken).totalSupply().div(DECIMALS);
         if (unripeSupply < 1_000_000) return 0; // If < 1,000,000 Assume all supply is unlocked.
         if (unripeSupply > 5_000_000) {
             if (unripeSupply > 10_000_000) {

--- a/protocol/contracts/libraries/LibLockedUnderlying.sol
+++ b/protocol/contracts/libraries/LibLockedUnderlying.sol
@@ -6,7 +6,7 @@ pragma experimental ABIEncoderV2;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
 import {AppStorage, LibAppStorage} from "./LibAppStorage.sol";
-// import "hardhat/console.sol";
+
 /**
  * @title LibLockedUnderlying
  * @author Brendan
@@ -27,9 +27,6 @@ library LibLockedUnderlying {
         uint256 recapPercentPaid
     ) external view returns (uint256 lockedUnderlying) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        // console.log("token:", unripeToken);
-        // console.log("balance of underlying:", s.u[unripeToken].balanceOfUnderlying);
-        // console.log("get percent locked underlying:", getPercentLockedUnderlying(unripeToken, recapPercentPaid));
         return
             s
                 .u[unripeToken]

--- a/protocol/contracts/libraries/LibUnripe.sol
+++ b/protocol/contracts/libraries/LibUnripe.sol
@@ -14,7 +14,6 @@ import {IWellFunction} from "contracts/interfaces/basin/IWellFunction.sol";
 import {LibLockedUnderlying} from "./LibLockedUnderlying.sol";
 import {LibFertilizer} from "./LibFertilizer.sol";
 
-
 /**
  * @title LibUnripe
  * @author Publius

--- a/protocol/contracts/libraries/LibUnripe.sol
+++ b/protocol/contracts/libraries/LibUnripe.sol
@@ -14,6 +14,7 @@ import {IWellFunction} from "contracts/interfaces/basin/IWellFunction.sol";
 import {LibLockedUnderlying} from "./LibLockedUnderlying.sol";
 import {LibFertilizer} from "./LibFertilizer.sol";
 
+
 /**
  * @title LibUnripe
  * @author Publius
@@ -171,6 +172,18 @@ library LibUnripe {
     }
 
     /**
+     * @notice returns the total percentage that beanstalk has recapitalized.
+     * @dev this is calculated by the ratio of s.recapitalized and the total dollars the barnraise needs to raise.
+     * returns the same precision as `getRecapPaidPercentAmount` (100% recapitalized = 1e6).
+     */
+    function getTotalRecapitalizedPercent() internal view returns (uint256 recapitalizedPercent) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        uint256 totalUsdNeeded = LibFertilizer.getTotalRecapDollarsNeeded();
+        if(totalUsdNeeded == 0) return 0;
+        return s.recapitalized.mul(DECIMALS).div(totalUsdNeeded);
+    }
+
+    /**
      * @notice Returns the amount of beans that are locked in the unripe token.
      * @dev Locked beans are the beans that are forfeited if the unripe token is chopped.
      * @param reserves the reserves of the LP that underly the unripe token.
@@ -180,7 +193,7 @@ library LibUnripe {
         uint256[] memory reserves
     ) internal view returns (uint256 lockedAmount) {
         lockedAmount = LibLockedUnderlying
-            .getLockedUnderlying(C.UNRIPE_BEAN, getRecapPaidPercentAmount(1e6))
+            .getLockedUnderlying(C.UNRIPE_BEAN, getTotalRecapitalizedPercent())
             .add(getLockedBeansFromLP(reserves));
     }
 
@@ -195,10 +208,9 @@ library LibUnripe {
         
         // if reserves return 0, then skip calculations.
         if (reserves[0] == 0) return 0;
-        
         uint256 lockedLpAmount = LibLockedUnderlying.getLockedUnderlying(
             C.UNRIPE_LP,
-            getRecapPaidPercentAmount(1e6)
+            getTotalRecapitalizedPercent()
         );
         address underlying = s.u[C.UNRIPE_LP].underlyingToken;
         uint256 beanIndex = LibWell.getBeanIndexFromWell(underlying);

--- a/protocol/contracts/mocks/mockFacets/MockUnripeFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockUnripeFacet.sol
@@ -20,10 +20,6 @@ contract MockUnripeFacet is UnripeFacet {
         s.u[unripeToken].merkleRoot = root;
     }
 
-    function getRecapitalized() external view returns (uint256) {
-        return s.recapitalized;
-    }
-
     function addUnderlying(address unripeToken, uint256 amount)
         external
         payable

--- a/protocol/contracts/mocks/mockFacets/MockUnripeFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockUnripeFacet.sol
@@ -50,4 +50,18 @@ contract MockUnripeFacet is UnripeFacet {
         );
         LibUnripe.addUnderlying(unripeToken, amount);
     }
+
+    function getLegacyLockedUnderlyingBean() public view returns (uint256) {
+        return LibLockedUnderlying.getLockedUnderlying(
+            C.UNRIPE_BEAN,
+            LibUnripe.getRecapPaidPercentAmount(1e6)
+        );
+    }
+
+    function getLegacyLockedUnderlyingLP() public view returns (uint256) {
+        return LibLockedUnderlying.getLockedUnderlying(
+            C.UNRIPE_LP,
+            LibUnripe.getRecapPaidPercentAmount(1e6)
+        );
+    }
 }

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -250,6 +250,34 @@ task("ebip9", async function () {
   await ebip9();
 })
 
+task("check", async function () {
+  const owner = await impersonateBeanstalkOwner();
+  await mintEth(owner.address);
+  await upgradeWithNewFacets({
+    diamondAddress: BEANSTALK,
+    facetNames: [
+      "UnripeFacet",
+      "FertilizerFacet"
+    ],
+    libraryNames: [
+      'LibLockedUnderlying'
+    ],
+    facetLibraries: {
+      'UnripeFacet': [
+        'LibLockedUnderlying'
+      ]
+    },
+    initArgs: [],
+    bip: false,
+    verbose: true,
+    account: owner
+  });
+  beanstalk = await getBeanstalk()
+  console.log("s.recapitalized:", await beanstalk.getRecapitalized())
+  console.log("remaining recapitalization :",await beanstalk.remainingRecapitalization())
+  console.log("total dollars needed to be raised:" , await beanstalk.getTotalRecapDollarsNeeded())
+})
+
 //////////////////////// SUBTASK CONFIGURATION ////////////////////////
 
 // Add a subtask that sets the action for the TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS task
@@ -337,7 +365,7 @@ module.exports = {
     }
   },
   gasReporter: {
-    enabled: true
+    enabled: false
   },
   mocha: {
     timeout: 100000000

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -250,34 +250,6 @@ task("ebip9", async function () {
   await ebip9();
 })
 
-task("check", async function () {
-  const owner = await impersonateBeanstalkOwner();
-  await mintEth(owner.address);
-  await upgradeWithNewFacets({
-    diamondAddress: BEANSTALK,
-    facetNames: [
-      "UnripeFacet",
-      "FertilizerFacet"
-    ],
-    libraryNames: [
-      'LibLockedUnderlying'
-    ],
-    facetLibraries: {
-      'UnripeFacet': [
-        'LibLockedUnderlying'
-      ]
-    },
-    initArgs: [],
-    bip: false,
-    verbose: true,
-    account: owner
-  });
-  beanstalk = await getBeanstalk()
-  console.log("s.recapitalized:", await beanstalk.getRecapitalized())
-  console.log("remaining recapitalization :",await beanstalk.remainingRecapitalization())
-  console.log("total dollars needed to be raised:" , await beanstalk.getTotalRecapDollarsNeeded())
-})
-
 //////////////////////// SUBTASK CONFIGURATION ////////////////////////
 
 // Add a subtask that sets the action for the TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS task

--- a/protocol/scripts/bips.js
+++ b/protocol/scripts/bips.js
@@ -327,30 +327,35 @@ async function bipMiscellaneousImprovements(mock = true, account = undefined, ve
       "UnripeFacet",
       "ConvertFacet",
       "SeasonFacet",
+      "SeasonGettersFacet",
       "FertilizerFacet"
     ],
     libraryNames: [
-      'LibChopConvert',
-      'LibConvert',
-      'LibConvertData',
-      'LibLambdaConvert',
-      'LibChop',
-      'LibFertilizer',
-      'LibStrings',
-      'LibUnripe',
+      'LibGauge',
+      'LibIncentive',
+      'LibLockedUnderlying',
       'LibWellMinting',
+      'LibGerminate',
+      'LibConvert'
     ],
     facetLibraries: {
       'UnripeFacet': [
-        'LibUnripe',
-        'LibChop'
+        'LibLockedUnderlying'
       ],
       'ConvertFacet': [
         'LibConvert',
       ],
       'SeasonFacet': [
+        'LibGauge',
+        'LibIncentive',
+        'LibLockedUnderlying',
         'LibWellMinting',
-      ]
+        'LibGerminate'
+      ],
+      'SeasonGettersFacet': [
+        'LibLockedUnderlying',
+        'LibWellMinting',
+      ],
     },
     selectorsToRemove: [],
     bip: false,

--- a/protocol/test/BeanEthToBeanWstethMigration.test.js
+++ b/protocol/test/BeanEthToBeanWstethMigration.test.js
@@ -32,7 +32,7 @@ async function fastForwardHour() {
 }
 
 // Skipping because this migration already occured.
-testIfRpcSet('Bean:Eth to Bean:Wsteth Migration', function () {
+describe.skip('Bean:Eth to Bean:Wsteth Migration', function () {
   before(async function () {
 
     [user, user2] = await ethers.getSigners()

--- a/protocol/test/LockedBeansMainnet.test.js
+++ b/protocol/test/LockedBeansMainnet.test.js
@@ -1,11 +1,12 @@
-const { BEAN, BEAN_3_CURVE, STABLE_FACTORY, UNRIPE_BEAN, UNRIPE_LP, BEANSTALK, BEAN_ETH_WELL } = require('./utils/constants.js');
+const { BEAN, UNRIPE_BEAN, UNRIPE_LP, BEAN_ETH_WELL, BEANSTALK } = require('./utils/constants.js');
 const { EXTERNAL, INTERNAL } = require('./utils/balances.js')
-const { impersonateBeanstalkOwner, impersonateSigner } = require('../utils/signer.js');
-const { time, mine } = require("@nomicfoundation/hardhat-network-helpers");
+const { impersonateSigner, impersonateBeanstalkOwner } = require('../utils/signer.js');
 const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot.js");
 const { getBeanstalk } = require('../utils/contracts.js');
+const { upgradeWithNewFacets } = require("../scripts/diamond");
 const { bipSeedGauge, bipMiscellaneousImprovements } = require('../scripts/bips.js');
 const { to6, to18 } = require('./utils/helpers.js');
+const { mintEth } = require('../utils')
 const { ethers } = require('hardhat');
 const { expect } = require('chai');
 
@@ -137,23 +138,45 @@ describe('LockedBeansMainnet', function () {
       let newBeanEthBal = await this.beanstalk.getExternalBalance(address.address, BEAN_ETH_WELL)
       // beanEthBal should increase by ~4.94x the original chop rate.
       expect(newBeanEthBal-initialBeanEthBal).to.eq(to18('0.000624219026576969'))
-      await revertToSnapshot(snapshotId)
     })
   })
 
   describe("lockedBeans change", async function() {
     it("correctly updates locked beans", async function () {
-       // deploy seed gauge
-      await bipSeedGauge(true, undefined, false)
-
-      // check locked beans:
-      expect(await this.beanstalk.getLockedBeans()).to.eq(to6('5553152.377928'))
+      // deploy mockUnripeFacet, as `getLockedBeans()` was updated: 
+      account = await impersonateBeanstalkOwner();
+      await mintEth(account.address);
+      await upgradeWithNewFacets({
+        diamondAddress: BEANSTALK,
+        facetNames: [
+          'MockUnripeFacet'
+        ],
+        libraryNames: [
+          'LibLockedUnderlying'
+        ],
+        facetLibraries: {
+          'MockUnripeFacet': [
+            'LibLockedUnderlying'
+          ]
+        },
+        selectorsToRemove: [],
+        bip: false,
+        object: false,
+        verbose: false,
+        account: account,
+        verify: false
+      })
+      // check underlying locked beans and locked LP:
+      this.unripe = await ethers.getContractAt('MockUnripeFacet', BEANSTALK)
+      expect(await this.unripe.getLegacyLockedUnderlyingBean()).to.eq(to6('16778637.205350'))
+      expect(await this.unripe.getLegacyLockedUnderlyingLP()).to.be.within(to18('158853'),to18('158855'))
 
       // deploy misc. improvements bip
       await bipMiscellaneousImprovements(true, undefined, false)
 
-      // check locked beans:
-      expect(await this.beanstalk.getLockedBeans()).to.eq(to6('5553152.377928'))
+      // check underlying locked beans and locked LP:
+      expect(await this.beanstalk.getLockedBeansUnderlyingUnripeBean()).to.eq(to6('3650664.793864'))
+      expect(await this.beanstalk.getLockedBeansUnderlyingUnripeLP()).to.be.within(to18('0.000001810930253916'),to18('0.000002010930253916'))
     })
   })
 })

--- a/protocol/test/LockedBeansMainnet.test.js
+++ b/protocol/test/LockedBeansMainnet.test.js
@@ -1,0 +1,159 @@
+const { BEAN, BEAN_3_CURVE, STABLE_FACTORY, UNRIPE_BEAN, UNRIPE_LP, BEANSTALK, BEAN_ETH_WELL } = require('./utils/constants.js');
+const { EXTERNAL, INTERNAL } = require('./utils/balances.js')
+const { impersonateBeanstalkOwner, impersonateSigner } = require('../utils/signer.js');
+const { time, mine } = require("@nomicfoundation/hardhat-network-helpers");
+const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot.js");
+const { getBeanstalk } = require('../utils/contracts.js');
+const { bipSeedGauge, bipMiscellaneousImprovements } = require('../scripts/bips.js');
+const { to6, to18 } = require('./utils/helpers.js');
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+
+let user,user2, owner;
+
+let snapshotId
+
+
+describe('LockedBeansMainnet', function () {
+  before(async function () {
+
+    [user, user2] = await ethers.getSigners()
+    
+
+    try {
+      await network.provider.request({
+        method: "hardhat_reset",
+        params: [
+          {
+            forking: {
+              jsonRpcUrl: process.env.FORKING_RPC,
+              blockNumber: 19785088 //a random semi-recent block close to Grown Stalk Per Bdv pre-deployment
+            },
+          },
+        ],
+      });
+    } catch(error) {
+      console.log('forking error in seed Gauge');
+      console.log(error);
+      return
+    }
+
+    this.beanstalk = await getBeanstalk()
+  });
+
+  beforeEach(async function () {
+    snapshotId = await takeSnapshot()
+  });
+
+  afterEach(async function () {
+    await revertToSnapshot(snapshotId)
+  });
+
+  /**
+   * the following tests are performed prior to the seed gauge deployment.
+   * upon the bips passing, the tests should be updated to the latest block and omit the seed gauge update.
+   */
+  describe("chopRate change:", async function() {
+    it("correctly updates chop", async function () {
+      // check chop rate:
+      expect(await this.beanstalk.getPercentPenalty(UNRIPE_BEAN)).to.eq(to6('0.010227'))
+      expect(await this.beanstalk.getPercentPenalty(UNRIPE_LP)).to.eq(to6('0.010215'))
+
+      // simulate a urBean chop: 
+      address = await impersonateSigner('0xef764bac8a438e7e498c2e5fccf0f174c3e3f8db')
+      snapshotId = await takeSnapshot()
+      await this.beanstalk.connect(address).withdrawDeposit(
+        UNRIPE_BEAN,
+        '-28418',
+        to6('1'),
+        INTERNAL
+      );
+      await this.beanstalk.connect(address).chop(
+        UNRIPE_BEAN,
+        to6('1'),
+        INTERNAL,
+        EXTERNAL
+      )
+      expect(await this.beanstalk.getExternalBalance(address.address, BEAN)).to.eq(to6('0.010226'))
+      await revertToSnapshot(snapshotId)
+
+      // simulate a urLP chop: 
+      await this.beanstalk.connect(address).withdrawDeposit(
+        UNRIPE_LP,
+        '-33292',
+        to6('1'),
+        INTERNAL
+      );
+      await this.beanstalk.connect(address).chop(
+        UNRIPE_LP,
+        to6('1'),
+        INTERNAL,
+        EXTERNAL
+      )
+      expect(await this.beanstalk.getExternalBalance(address.address, BEAN_ETH_WELL)).to.eq(to18('0.000126330680297571'))
+      await revertToSnapshot(snapshotId)
+
+      // deploy seed gauge
+      await bipSeedGauge(true, undefined, false)
+
+      // // deploy misc. improvements bip
+      await bipMiscellaneousImprovements(true, undefined, false)
+
+      // check chop rate:
+      expect(await this.beanstalk.getPercentPenalty(UNRIPE_BEAN)).to.eq(to6('0.050532'))
+      expect(await this.beanstalk.getPercentPenalty(UNRIPE_LP)).to.eq(to6('0.050473'))
+
+      // simulate a urBean chop: 
+      snapshotId = await takeSnapshot()
+      await this.beanstalk.connect(address).withdrawDeposit(
+        UNRIPE_BEAN,
+        '-28418000000', // scaled by 1e6 due to silo v3.1.
+        to6('1'),
+        INTERNAL
+      );
+      await this.beanstalk.connect(address).chop(
+        UNRIPE_BEAN,
+        to6('1'),
+        INTERNAL,
+        EXTERNAL
+      )
+      expect(await this.beanstalk.getExternalBalance(address.address, BEAN)).to.eq(to6('0.050532'))
+      await revertToSnapshot(snapshotId)
+
+      // // simulate a urLP chop:
+      let initialBeanEthBal = await this.beanstalk.getExternalBalance(address.address, BEAN_ETH_WELL)
+      await this.beanstalk.connect(address).withdrawDeposit(
+        UNRIPE_LP,
+        '-33292000000',
+        to6('1'),
+        INTERNAL
+      );
+      await this.beanstalk.connect(address).chop(
+        UNRIPE_LP,
+        to6('1'),
+        INTERNAL,
+        EXTERNAL
+      )
+      let newBeanEthBal = await this.beanstalk.getExternalBalance(address.address, BEAN_ETH_WELL)
+      // beanEthBal should increase by ~4.94x the original chop rate.
+      expect(newBeanEthBal-initialBeanEthBal).to.eq(to18('0.000624219026576969'))
+      await revertToSnapshot(snapshotId)
+    })
+  })
+
+  describe("lockedBeans change", async function() {
+    it("correctly updates locked beans", async function () {
+       // deploy seed gauge
+      await bipSeedGauge(true, undefined, false)
+
+      // check locked beans:
+      expect(await this.beanstalk.getLockedBeans()).to.eq(to6('5553152.377928'))
+
+      // deploy misc. improvements bip
+      await bipMiscellaneousImprovements(true, undefined, false)
+
+      // check locked beans:
+      expect(await this.beanstalk.getLockedBeans()).to.eq(to6('5553152.377928'))
+    })
+  })
+})

--- a/protocol/test/SeedGaugeMainnet.test.js
+++ b/protocol/test/SeedGaugeMainnet.test.js
@@ -107,12 +107,12 @@ testIfRpcSet('SeedGauge Init Test', function () {
       expect(await this.beanstalk.getBeanToMaxLpGpPerBdvRatioScaled()).to.be.equal(to18('66.666666666666666666'));
     })
 
-    it('lockedBeans', async function () {
+    it.skip('lockedBeans', async function () {
       // ~25.5m locked beans, ~35.8m total beans
       expect(await this.beanstalk.getLockedBeans()).to.be.within(to6('25900000.000000'), to6('26000000.000000'));
     })
 
-    it('usd Liquidity', async function () {
+    it.skip('usd Liquidity', async function () {
       // ~13.2m usd liquidity in Bean:Eth
       expect(await this.beanstalk.getTwaLiquidityForWell(BEAN_ETH_WELL)).to.be.within(to18('13100000'), to18('13300000'));
       // ~13.2m usd liquidity in Bean:Eth

--- a/protocol/test/SeedGaugeMainnet.test.js
+++ b/protocol/test/SeedGaugeMainnet.test.js
@@ -95,7 +95,7 @@ testIfRpcSet('SeedGauge Init Test', function () {
       expect(await this.beanstalk.getTotalBdv()).to.be.within(to6('43000000'), to6('44000000'));
     })
 
-    it('L2SR', async function () {
+    it.skip('L2SR', async function () {
       // the L2SR may differ during testing, due to the fact 
       // that the L2SR is calculated on twa reserves, and thus may slightly differ due to 
       // timestamp differences.

--- a/protocol/test/Unripe.test.js
+++ b/protocol/test/Unripe.test.js
@@ -106,7 +106,7 @@ describe('Unripe', function () {
       expect(await this.unripe.getRecapFundedPercent(UNRIPE_BEAN)).to.be.equal(to6('1'))
       expect(await this.unripe.getRecapFundedPercent(UNRIPE_LP)).to.be.equal(to6('0.498569'))
       expect(await this.unripe.getPercentPenalty(UNRIPE_BEAN)).to.be.equal(to6('0.5'))
-      expect(await this.unripe.getPercentPenalty(UNRIPE_LP)).to.be.equal(to6('0.264550'))
+      expect(await this.unripe.getPercentPenalty(UNRIPE_LP)).to.be.equal(to6('0.25'))
     })
   })
 
@@ -148,7 +148,7 @@ describe('Unripe', function () {
       expect(await this.unripe.getRecapFundedPercent(UNRIPE_BEAN)).to.be.equal(to6('0.1'))
       expect(await this.unripe.getRecapFundedPercent(UNRIPE_LP)).to.be.equal(to6('0.997138'))
       expect(await this.unripe.getPercentPenalty(UNRIPE_BEAN)).to.be.equal(to6('0.1'))
-      expect(await this.unripe.getPercentPenalty(UNRIPE_LP)).to.be.equal(to6('0.529100'))
+      expect(await this.unripe.getPercentPenalty(UNRIPE_LP)).to.be.equal(to6('1'))
     })
   })
 
@@ -379,7 +379,7 @@ describe('Unripe', function () {
     it('getters', async function () {
       // 21.875 / 94.5
       expect(await this.unripe.getUnderlyingPerUnripeToken(UNRIPE_LP)).to.be.equal(to6('0.231481'))
-      // 21.876 * 0.43752 * 1/94.5 ~= 0.03306878307
+      // 21.876 * 0.43752 * 1/94.5 ~= 0.1012824076
       expect(await this.unripe.getPenalty(UNRIPE_LP)).to.be.equal(to6('0.101273'))
 
       expect(await this.unripe.getPenalizedUnderlying(UNRIPE_LP, to6('1'))).to.be.equal(to6('0.101273'))


### PR DESCRIPTION
Update liblockedUnderlying.
Uses `LibUnripe.getTotalRecapitalizedPercent()` instead of `LibUnripe.getRecapPaidPercentAmount`.

- fixes various view functions
- skipped legacy tests
- fixed various tests
- added mainnet tests.