### PR TITLE
Update readme to include known working node/npm versions

### DIFF
--- a/protocol/README.md
+++ b/protocol/README.md
@@ -39,6 +39,10 @@ The Beanstalk contract is a multi-facet proxy that implements [EIP-2535](https:/
 - [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/)
   - You'll know you've installed yarn right if you can run `yarn --version` And get an output like: `x.x.x`
 
+## Node and NPM compatibility
+
+The latest Node.js and NPM versions are known to be incompatible with some parts of the Foundry toolchain. We recommend using Node.js `v16.20.2` and npm `v8.19.2`.
+
 ## Installation
 
 _Note: The Beanstalk repo is a monorepo with induvidual projects inside it. See the `DEVELOPER.md` in the root directory for more information._
@@ -62,6 +66,7 @@ yarn hardhat compile
 ### Testing
 
 #### Hardhat
+
 1. Ensure you are in the `protocol` directory
 2. Have a [FORKING_RPC](https://hardhat.org/hardhat-network/docs/guides/forking-other-networks) as an [environment variable](https://www.npmjs.com/package/dotenv) pointing to ETH Mainnet.
    1. _We fork ETH Mainnet to run our test suite locally. Note, this will make a large number of API calls to your `FORKING_RPC`_
@@ -78,6 +83,7 @@ yarn hardhat coverage
 ```
 
 #### Foundry
+
 1. Ensure you are in the `protocol` directory
 2. Install foundry with `foundryup` - instructions [here](https://book.getfoundry.sh/getting-started/installation)
 3. `forge install foundry-rs/forge-std --no-commit`

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -41,7 +41,7 @@ The Beanstalk contract is a multi-facet proxy that implements [EIP-2535](https:/
 
 ## Node and NPM compatibility
 
-The latest Node.js and NPM versions are known to be incompatible with some parts of the Foundry toolchain. We recommend using Node.js `v16.20.2` and npm `v8.19.2`.
+The latest Node.js and NPM versions are known to be incompatible with some parts of the Foundry toolchain. We recommend using Node.js `v18.12.0` and npm `v8.19.2`.
 
 ## Installation
 


### PR DESCRIPTION
Adds note in `protocol/README.md` about compatible node/npm versions.

The other spacing modifications appear to be from auto-format.