### PR TITLE
UI: silo cosmetic updates

### DIFF
--- a/projects/ui/src/components/Silo/SiloAssetOverviewCard.tsx
+++ b/projects/ui/src/components/Silo/SiloAssetOverviewCard.tsx
@@ -40,11 +40,12 @@ const DepositRewards: FC<{ token: ERC20Token }> = ({ token }) => (
       </Row>
       {/* This vAPY chip is only shown on larger screens */}
       <Row sx={{ display: { xs: 'none', sm: 'block' } }}>
-        <SiloAssetApyChip
-          token={token as Token}
-          metric="bean"
-          variant="labeled"
-        />
+        {token.symbol === 'BEAN3CRV' ? null : 
+          <SiloAssetApyChip
+            token={token as Token}
+            metric="bean"
+            variant="labeled"
+          />}
       </Row>
     </Row>
   </Box>
@@ -118,14 +119,15 @@ const SiloAssetOverviewCard: FC<{ token: ERC20Token }> = ({ token }) => {
             justifyContent="center"
             sx={{ display: { xs: 'flex', sm: 'none' } }}
           >
-            <SiloAssetApyChip
-              token={token as Token}
-              metric="bean"
-              variant="labeled"
-            />
+            {token.symbol === 'BEAN3CRV' ? null : 
+              <SiloAssetApyChip
+                token={token as Token}
+                metric="bean"
+                variant="labeled"
+              />}
           </Row>
           {/* Card Carousel */}
-          <SiloCarousel token={token} />
+          {token.symbol === 'BEAN3CRV' ? null : <SiloCarousel token={token} />}
         </Stack>
       </ModuleContent>
     </Module>

--- a/projects/ui/src/components/Silo/SiloCarousel.tsx
+++ b/projects/ui/src/components/Silo/SiloCarousel.tsx
@@ -64,6 +64,7 @@ const useCardContentWithToken = (token: ERC20Token) => [
     title: `Receive Stalk ${!token.isUnripe ? 'and Seeds' : ''} for your Deposit`,
     texts: [
       'Stalk entitles holders to participate in Beanstalk governance and earn a portion of Bean mints.',
+      `${token.isUnripe ? '' : 'Seeds yield 1/10000 new Stalk every Season.'}`,
     ],
     imageSrc: token.isUnripe ? earnStalkImg : earnStalkAndSeedsImg,
   },

--- a/projects/ui/src/pages/silo/token.tsx
+++ b/projects/ui/src/pages/silo/token.tsx
@@ -9,7 +9,6 @@ import usePools from '~/hooks/beanstalk/usePools';
 import useWhitelist from '~/hooks/beanstalk/useWhitelist';
 import GuideButton from '~/components/Common/Guide/GuideButton';
 import {
-  HOW_TO_CLAIM_WITHDRAWALS,
   HOW_TO_CONVERT_DEPOSITS,
   HOW_TO_DEPOSIT_IN_THE_SILO,
   HOW_TO_TRANSFER_DEPOSITS,
@@ -27,7 +26,6 @@ const guides = [
   HOW_TO_CONVERT_DEPOSITS,
   HOW_TO_TRANSFER_DEPOSITS,
   HOW_TO_WITHDRAW_FROM_THE_SILO,
-  HOW_TO_CLAIM_WITHDRAWALS,
 ];
 
 const SILO_ACTIONS_MAX_WIDTH = '480px';

--- a/projects/ui/src/util/Guides.ts
+++ b/projects/ui/src/util/Guides.ts
@@ -24,10 +24,6 @@ export const HOW_TO_WITHDRAW_FROM_THE_SILO: Guide = {
   title: 'How to Withdraw from the Silo',
   url: 'https://docs.bean.money/almanac/guides/silo/withdraw',
 };
-export const HOW_TO_CLAIM_WITHDRAWALS: Guide = {
-  title: 'How to Claim Withdrawals',
-  url: 'https://docs.bean.money/almanac/guides/silo/claim-assets',
-};
 export const HOW_TO_TRANSFER_DEPOSITS: Guide = {
   title: 'How to Transfer Deposits',
   url: 'https://docs.bean.money/almanac/guides/silo/transfer',


### PR DESCRIPTION
<img width="500" alt="image" src="https://github.com/BeanstalkFarms/Beanstalk/assets/28496268/524d7c52-9713-4e65-ad46-c159fdd7dbb1">

* add note on carousel about seeds on non-unripe whitelisted assets
* remove carousel altogether for dewhitelisted bean3crv

***

<img width="300" alt="Screenshot 2024-05-27 at 1 21 41 PM" src="https://github.com/BeanstalkFarms/Beanstalk/assets/28496268/c8dee196-d8db-4eca-b1a6-f861cf52d3f0">

* remove vAPY card on bean3crv

***

<img width="500" alt="image" src="https://github.com/BeanstalkFarms/Beanstalk/assets/28496268/deb5060f-b215-4f45-b195-eb66383cb138">

* remove How to Claim Withdrawals card with broken link
