### PR TITLE
wstETH Migration Remediations

### DIFF
--- a/protocol/contracts/libraries/Convert/LibUnripeConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibUnripeConvert.sol
@@ -135,7 +135,7 @@ library LibUnripeConvert {
         uint256 lp = LibUnripe.unripeToUnderlying(
             C.UNRIPE_LP,
             amountIn,
-            IBean(C.UNRIPE_BEAN).totalSupply()
+            IBean(C.UNRIPE_LP).totalSupply()
         );
         bean = LibWellConvert.getBeanAmountOut(LibBarnRaise.getBarnRaiseWell(), lp);
         bean = LibUnripe

--- a/protocol/contracts/libraries/LibBarnRaise.sol
+++ b/protocol/contracts/libraries/LibBarnRaise.sol
@@ -25,7 +25,7 @@ library LibBarnRaise {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return
             s.u[C.UNRIPE_LP].underlyingToken == address(0)
-                ? C.BEAN_ETH_WELL
+                ? C.BEAN_WSTETH_WELL
                 : s.u[C.UNRIPE_LP].underlyingToken;
     }
 }

--- a/protocol/contracts/libraries/LibFertilizer.sol
+++ b/protocol/contracts/libraries/LibFertilizer.sol
@@ -185,10 +185,7 @@ library LibFertilizer {
         returns (uint256 remaining)
     {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        uint256 totalDollars = C
-            .dollarPerUnripeLP()
-            .mul(C.unripeLP().totalSupply())
-            .div(DECIMALS);
+        uint256 totalDollars = uint256(1e12).mul(C.unripeLP().totalSupply()).div(C.unripeLPPerDollar()).div(DECIMALS);
         totalDollars = totalDollars / 1e6 * 1e6; // round down to nearest USDC
         if (s.recapitalized >= totalDollars) return 0;
         return totalDollars.sub(s.recapitalized);

--- a/protocol/contracts/libraries/Oracle/LibOracleHelpers.sol
+++ b/protocol/contracts/libraries/Oracle/LibOracleHelpers.sol
@@ -25,7 +25,15 @@ library LibOracleHelpers {
         uint x,
         uint y
     ) internal pure returns (uint256 percentDifference) {
-        percentDifference = x.mul(ONE).div(y);
-        percentDifference = x > y ? percentDifference - ONE : ONE - percentDifference; // SafeMath unnecessary due to conditional check
+        if (x == y) {
+            percentDifference = 0;
+        } else if (x < y) {
+            percentDifference = x.mul(ONE).div(y);
+            percentDifference = ONE - percentDifference;
+        } else {
+            percentDifference = y.mul(ONE).div(x);
+            percentDifference = ONE - percentDifference;
+        }
+        return percentDifference;
     }
 }

--- a/protocol/contracts/libraries/Oracle/LibOracleHelpers.sol
+++ b/protocol/contracts/libraries/Oracle/LibOracleHelpers.sol
@@ -20,6 +20,8 @@ library LibOracleHelpers {
     /**
      * Gets the percent difference between two values with 18 decimal precision.
      * @dev If x == 0 (Such as in the case of Uniswap Oracle failure), then the percent difference is calculated as 100%.
+     * Always use the bigger price as the denominator, thereby making sure that in whichever of the two cases explained in audit report (M-03),
+     * i.e if x > y or not a fixed percentDifference is provided and this can then be accurately checked against protocol's set MAX_DIFFERENCE value.
      */
     function getPercentDifference(
         uint x,

--- a/protocol/contracts/libraries/Oracle/LibUsdOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibUsdOracle.sol
@@ -61,7 +61,7 @@ library LibUsdOracle {
             return ethUsdPrice;
         }
         if (token == C.WSTETH) {
-            uint256 wstethUsdPrice = LibWstethUsdOracle.getWstethUsdPrice(0);
+            uint256 wstethUsdPrice = LibWstethUsdOracle.getWstethUsdPrice(lookback);
             if (wstethUsdPrice == 0) return 0;
             return wstethUsdPrice;
         }

--- a/protocol/contracts/libraries/Oracle/LibWstethEthOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibWstethEthOracle.sol
@@ -92,8 +92,10 @@ library LibWstethEthOracle {
 
         if (LibOracleHelpers.getPercentDifference(chainlinkPrice, uniswapPrice) < MAX_DIFFERENCE) {
             wstethEthPrice = chainlinkPrice.add(uniswapPrice).div(AVERAGE_DENOMINATOR);
-            if (wstethEthPrice > stethPerWsteth) wstethEthPrice = stethPerWsteth;
-            wstethEthPrice = wstethEthPrice.div(PRECISION_DENOMINATOR);
+        } else {
+            wstethEthPrice = chainlinkPrice;
         }
+        if (wstethEthPrice > stethPerWsteth) wstethEthPrice = stethPerWsteth;
+        wstethEthPrice = wstethEthPrice.div(PRECISION_DENOMINATOR);
     }
 }

--- a/protocol/test/WstethOracle.test.js
+++ b/protocol/test/WstethOracle.test.js
@@ -85,8 +85,8 @@ describe('wStEth Oracle', function () {
                 await setWstethStethRedemptionPrice('1.01')
                 await setStethEthChainlinkPrice('1.02') // The Uniswap Oracle cannot be exactly 2 
                 await setWstethEthUniswapPrice('1.005')
-                expect(await season.getWstethEthPrice()).to.be.equal('0')
-                expect(await season.getWstethEthTwap('900')).to.be.equal('0')
+                expect(await season.getWstethEthPrice()).to.be.equal('1010000') // after M-2 remediation, should not be zero
+                expect(await season.getWstethEthTwap('900')).to.be.equal('1010000') // after M-2 remediation, should not be zero
             })
         })
 
@@ -102,8 +102,8 @@ describe('wStEth Oracle', function () {
                 await setWstethStethRedemptionPrice('1')
                 await setStethEthChainlinkPrice('1.02') // The Uniswap Oracle cannot be exactly 2 
                 await setWstethEthUniswapPrice('1')
-                expect(await season.getWstethEthPrice()).to.be.equal('0')
-                expect(await season.getWstethEthTwap('900')).to.be.equal('0')
+                expect(await season.getWstethEthPrice()).to.be.equal('1000000') // after M-2 remediation, should not be zero
+                expect(await season.getWstethEthTwap('900')).to.be.equal('1000000') // after M-2 remediation, should not be zero
             })
         })
 


### PR DESCRIPTION
# wstETH Migration Remediations

Audit results: https://www.codehawks.com/report/clu7665bs0001fmt5yahc8tyh

## Codehawks Remediations

### M-02. LibWstethEthOracle::getWstethEthPrice returns wrong wstETH/ETH price in some conditions impacting system operations

Remediation: Modified `getWstethEthPrice` function to include explicit logic for handling the case where the percent difference between the Chainlink and Uniswap prices is greater then `MAX_DIFFERENCE`. 4a7ad83345027ac4622748cf05aab43aa9006bea

Original finding: https://www.codehawks.com/report/clu7665bs0001fmt5yahc8tyh#M-02

### M-03. Protocol unintentionally implements an asymmetric method of calculating the price difference

Remediation: Modified `getPercentDifference` to ensure divisor is always lower so that percent differences calculated are consistent no matter the input order. f453c547c29600c77b92f6abe329f4e7d175a023

Original finding: https://www.codehawks.com/report/clu7665bs0001fmt5yahc8tyh#M-03

### L-01. Because of devision before multiplication in LibFertilizer:remainingRecapitalization() less fertilizers is mintable than is needed to fully recapitalize the lost LP token value

Remediation: Modified totalDollars variable calculation as suggested: 0c7fe76cea1f8f0e0f712d1dcdaba8f3f683f720

Original finding: https://www.codehawks.com/report/clu7665bs0001fmt5yahc8tyh#L-01

### L-02. Deprecated pool BEAN:WETH on LibBarnRaise used as fallback

Remediation: Added the `C.BEAN_WSTETH_WELL` as a fallback for the underlying token on `LibBarnRaise` as suggested.

Original finding: https://www.codehawks.com/report/clu7665bs0001fmt5yahc8tyh#L-02

### L-04. LibUnripeConvert.sol :: getBeanAmountOut() incorrectly calculates the amount of BEAN.

Remediation: Replace `IBean(C.UNRIPE_BEAN).totalSupply()` with `IBean(C.UNRIPE_LP).totalSupply()` as suggested. a9342444fc6b8d29afe2ecfc5fb0c377cedd51ab

Original finding: https://www.codehawks.com/report/clu7665bs0001fmt5yahc8tyh#L-04

### L-05. Missing the lookback parameter when invoking the getWstethUsdPrice() in the getTokenPrice function

Remediation: Use lookback parameter of 0. 3bf4755ead0f39bee6523ab691ea806d935b9d12

Original finding: https://www.codehawks.com/report/clu7665bs0001fmt5yahc8tyh#L-05


# Accepted Risks from Codehawks Findings

### M-01. Calling `init()` will fail because the well that should be whitelisted has no liquidity

M-01 will be solved by simply adding enough liquidity to the well before migrating the liquidity within Beanstalk.

https://www.codehawks.com/report/clu7665bs0001fmt5yahc8tyh#M-01

### L-03. There is a more efficient and secure way to compute wstETH:ETH price using Chainlink

We disagree with the heartbeat here given that the worst deviation would be 0.5% for a day, and is averaged by the Uniswap oracle. This means that the oracles would need to be 1% off for manipulation to occur. The other factor is that using the WSTETH/ETH + ETH/USD chainlink setup gives the trust assumption of the ETH/USD chainlink oracle, which is much more widely used than the steth:usd oracle. Additionally, this change would require using a wsteth:usd uniswap oracle, which has significantly less liquidity than the wsteth:eth uniswap pool

https://www.codehawks.com/report/clu7665bs0001fmt5yahc8tyh#L-03