### PR TITLE
[Subgraph-Basin] Add field for cumulative trade reserves of both tokens

### DIFF
--- a/projects/subgraph-basin/schema.graphql
+++ b/projects/subgraph-basin/schema.graphql
@@ -122,6 +122,9 @@ type Well @entity {
   " All trade volume occurred in this well, in USD. This includes any net trading activity as a result of add/remove liquidity. Should be equal to the sum of all entries in cumulativeTradeVolumeReservesUSD "
   cumulativeTradeVolumeUSD: BigDecimal!
 
+  " All trade volume occurred for a specific token, in native amount. This includes absolute tokens on both sides of the trade unlike cumulativeTradeVolumeReserves. This includes any net trading activity as a result of add/remove liquidity. The ordering should be the same as the well's `tokens` field. "
+  cumulativeBiTradeVolumeReserves: [BigInt!]!
+
   " All transfer volume occurred for a specific token, in native amount. This includes the full amount of tokens transferred in ad/remove liquidity. The ordering should be the same as the well's `tokens` field. "
   cumulativeTransferVolumeReserves: [BigInt!]!
 
@@ -149,6 +152,9 @@ type Well @entity {
   " Current rolling 24h trade volume in USD "
   rollingDailyTradeVolumeUSD: BigDecimal!
 
+  " Current rolling 24h reserve trade volume in token amounts, including absolute tokens on both side of the trade unlike rollingDailyTradeVolumeReserves. "
+  rollingDailyBiTradeVolumeReserves: [BigInt!]!
+
   " Current rolling 24h reserve transfer volume in token amounts "
   rollingDailyTransferVolumeReserves: [BigInt!]!
 
@@ -166,6 +172,9 @@ type Well @entity {
 
   " Current rolling weekly trade volume in USD "
   rollingWeeklyTradeVolumeUSD: BigDecimal!
+
+  " Current rolling weekly reserve trade volume in token amounts, including absolute tokens on both side of the trade unlike rollingWeeklyTradeVolumeReserves. "
+  rollingWeeklyBiTradeVolumeReserves: [BigInt!]!
 
   " Current rolling weekly reserve transfer volume in token amounts "
   rollingWeeklyTransferVolumeReserves: [BigInt!]!
@@ -235,6 +244,9 @@ type WellDailySnapshot @entity {
   " All trade volume occurred in this well, in USD. This includes any net trading activity as a result of add/remove liquidity. Should be equal to the sum of all entries in cumulativeTradeVolumeReservesUSD "
   cumulativeTradeVolumeUSD: BigDecimal!
 
+  " All trade volume occurred for a specific token, in native amount. This includes absolute tokens on both sides of the trade unlike cumulativeTradeVolumeReserves. This includes any net trading activity as a result of add/remove liquidity. The ordering should be the same as the well's `tokens` field. "
+  cumulativeBiTradeVolumeReserves: [BigInt!]!
+
   " All transfer volume occurred for a specific token, in native amount. This includes the full amount of tokens transferred in ad/remove liquidity. The ordering should be the same as the well's `tokens` field. "
   cumulativeTransferVolumeReserves: [BigInt!]!
 
@@ -269,6 +281,9 @@ type WellDailySnapshot @entity {
 
   " Delta of cumulativeTradeVolumeUSD "
   deltaTradeVolumeUSD: BigDecimal!
+
+  " Delta of cumulativeBiTradeVolumeReserves "
+  deltaBiTradeVolumeReserves: [BigInt!]!
 
   " Delta of cumulativeTransferVolumeReserves "
   deltaTransferVolumeReserves: [BigInt!]!
@@ -322,6 +337,9 @@ type WellHourlySnapshot @entity {
   " All trade volume occurred in this well, in USD. This includes any net trading activity as a result of add/remove liquidity. Should be equal to the sum of all entries in cumulativeTradeVolumeReservesUSD "
   cumulativeTradeVolumeUSD: BigDecimal!
 
+  " All trade volume occurred for a specific token, in native amount. This includes absolute tokens on both sides of the trade unlike cumulativeTradeVolumeReserves. This includes any net trading activity as a result of add/remove liquidity. The ordering should be the same as the well's `tokens` field. "
+  cumulativeBiTradeVolumeReserves: [BigInt!]!
+
   " All transfer volume occurred for a specific token, in native amount. This includes the full amount of tokens transferred in ad/remove liquidity. The ordering should be the same as the well's `tokens` field. "
   cumulativeTransferVolumeReserves: [BigInt!]!
 
@@ -356,6 +374,9 @@ type WellHourlySnapshot @entity {
 
   " Delta of cumulativeTradeVolumeUSD "
   deltaTradeVolumeUSD: BigDecimal!
+
+  " Delta of cumulativeBiTradeVolumeReserves "
+  deltaBiTradeVolumeReserves: [BigInt!]!
 
   " Delta of cumulativeTransferVolumeReserves "
   deltaTransferVolumeReserves: [BigInt!]!

--- a/projects/subgraph-basin/src/utils/VolumeCP.ts
+++ b/projects/subgraph-basin/src/utils/VolumeCP.ts
@@ -21,7 +21,8 @@ export function updateWellVolumesAfterSwap(
   const deltaTradeVolumeReserves = emptyBigIntArray(well.tokens.length);
   const deltaTransferVolumeReserves = emptyBigIntArray(well.tokens.length);
 
-  // Trade volume is considered on the buying end of the trade
+  // Trade volume is will ignore the selling end (negative)
+  deltaTradeVolumeReserves[well.tokens.indexOf(fromToken)] = amountIn.neg();
   deltaTradeVolumeReserves[well.tokens.indexOf(toToken)] = amountOut;
   // Transfer volume is considered on both ends of the trade
   deltaTransferVolumeReserves[well.tokens.indexOf(fromToken)] = amountIn;

--- a/projects/subgraph-basin/src/utils/VolumeCP.ts
+++ b/projects/subgraph-basin/src/utils/VolumeCP.ts
@@ -118,10 +118,13 @@ export function calcLiquidityVolume(currentReserves: BigInt[], addedReserves: Bi
 function updateVolumeStats(well: Well, deltaTradeVolumeReserves: BigInt[], deltaTransferVolumeReserves: BigInt[]): void {
   let tradeVolumeReserves = well.cumulativeTradeVolumeReserves;
   let tradeVolumeReservesUSD = well.cumulativeTradeVolumeReservesUSD;
+  let biTradeVolumeReserves = well.cumulativeBiTradeVolumeReserves;
   let rollingDailyTradeVolumeReserves = well.rollingDailyTradeVolumeReserves;
   let rollingDailyTradeVolumeReservesUSD = well.rollingDailyTradeVolumeReservesUSD;
+  let rollingDailyBiTradeVolumeReserves = well.rollingDailyBiTradeVolumeReserves;
   let rollingWeeklyTradeVolumeReserves = well.rollingWeeklyTradeVolumeReserves;
   let rollingWeeklyTradeVolumeReservesUSD = well.rollingWeeklyTradeVolumeReservesUSD;
+  let rollingWeeklyBiTradeVolumeReserves = well.rollingWeeklyBiTradeVolumeReserves;
 
   let transferVolumeReserves = well.cumulativeTransferVolumeReserves;
   let transferVolumeReservesUSD = well.cumulativeTransferVolumeReservesUSD;
@@ -141,6 +144,9 @@ function updateVolumeStats(well: Well, deltaTradeVolumeReserves: BigInt[], delta
       rollingWeeklyTradeVolumeReserves[i] = rollingWeeklyTradeVolumeReserves[i].plus(deltaTradeVolumeReserves[i]);
       usdTradeAmount = toDecimal(deltaTradeVolumeReserves[i], tokenInfo.decimals).times(tokenInfo.lastPriceUSD);
     }
+    biTradeVolumeReserves[i] = biTradeVolumeReserves[i].plus(deltaTradeVolumeReserves[i].abs());
+    rollingDailyBiTradeVolumeReserves[i] = rollingDailyBiTradeVolumeReserves[i].plus(deltaTradeVolumeReserves[i].abs());
+    rollingWeeklyBiTradeVolumeReserves[i] = rollingWeeklyBiTradeVolumeReserves[i].plus(deltaTradeVolumeReserves[i].abs());
 
     transferVolumeReserves[i] = transferVolumeReserves[i].plus(deltaTransferVolumeReserves[i].abs());
     rollingDailyTransferVolumeReserves[i] = rollingDailyTransferVolumeReserves[i].plus(deltaTransferVolumeReserves[i].abs());
@@ -162,6 +168,7 @@ function updateVolumeStats(well: Well, deltaTradeVolumeReserves: BigInt[], delta
   well.cumulativeTradeVolumeReserves = tradeVolumeReserves;
   well.cumulativeTradeVolumeReservesUSD = tradeVolumeReservesUSD;
   well.cumulativeTradeVolumeUSD = well.cumulativeTradeVolumeUSD.plus(totalTradeUSD);
+  well.cumulativeBiTradeVolumeReserves = biTradeVolumeReserves;
 
   well.cumulativeTransferVolumeReserves = transferVolumeReserves;
   well.cumulativeTransferVolumeReservesUSD = transferVolumeReservesUSD;
@@ -173,6 +180,7 @@ function updateVolumeStats(well: Well, deltaTradeVolumeReserves: BigInt[], delta
   well.rollingDailyTradeVolumeReserves = rollingDailyTradeVolumeReserves;
   well.rollingDailyTradeVolumeReservesUSD = rollingDailyTradeVolumeReservesUSD;
   well.rollingDailyTradeVolumeUSD = well.rollingDailyTradeVolumeUSD.plus(totalTradeUSD);
+  well.rollingDailyBiTradeVolumeReserves = rollingDailyBiTradeVolumeReserves;
   well.rollingDailyTransferVolumeReserves = rollingDailyTransferVolumeReserves;
   well.rollingDailyTransferVolumeReservesUSD = rollingDailyTransferVolumeReservesUSD;
   well.rollingDailyTransferVolumeUSD = well.rollingDailyTransferVolumeUSD.plus(totalTransferUSD);
@@ -180,6 +188,7 @@ function updateVolumeStats(well: Well, deltaTradeVolumeReserves: BigInt[], delta
   well.rollingWeeklyTradeVolumeReserves = rollingWeeklyTradeVolumeReserves;
   well.rollingWeeklyTradeVolumeReservesUSD = rollingWeeklyTradeVolumeReservesUSD;
   well.rollingWeeklyTradeVolumeUSD = well.rollingWeeklyTradeVolumeUSD.plus(totalTradeUSD);
+  well.rollingWeeklyBiTradeVolumeReserves = rollingWeeklyBiTradeVolumeReserves;
   well.rollingWeeklyTransferVolumeReserves = rollingWeeklyTransferVolumeReserves;
   well.rollingWeeklyTransferVolumeReservesUSD = rollingWeeklyTransferVolumeReservesUSD;
   well.rollingWeeklyTransferVolumeUSD = well.rollingWeeklyTransferVolumeUSD.plus(totalTransferUSD);

--- a/projects/subgraph-basin/src/utils/Well.ts
+++ b/projects/subgraph-basin/src/utils/Well.ts
@@ -52,6 +52,7 @@ export function createWell(wellAddress: Address, implementation: Address, inputT
   well.cumulativeTradeVolumeReserves = emptyBigIntArray(inputTokens.length);
   well.cumulativeTradeVolumeReservesUSD = emptyBigDecimalArray(inputTokens.length);
   well.cumulativeTradeVolumeUSD = ZERO_BD;
+  well.cumulativeBiTradeVolumeReserves = emptyBigIntArray(inputTokens.length);
   well.cumulativeTransferVolumeReserves = emptyBigIntArray(inputTokens.length);
   well.cumulativeTransferVolumeReservesUSD = emptyBigDecimalArray(inputTokens.length);
   well.cumulativeTransferVolumeUSD = ZERO_BD;
@@ -61,12 +62,14 @@ export function createWell(wellAddress: Address, implementation: Address, inputT
   well.rollingDailyTradeVolumeReserves = emptyBigIntArray(inputTokens.length);
   well.rollingDailyTradeVolumeReservesUSD = emptyBigDecimalArray(inputTokens.length);
   well.rollingDailyTradeVolumeUSD = ZERO_BD;
+  well.rollingDailyBiTradeVolumeReserves = emptyBigIntArray(inputTokens.length);
   well.rollingDailyTransferVolumeReserves = emptyBigIntArray(inputTokens.length);
   well.rollingDailyTransferVolumeReservesUSD = emptyBigDecimalArray(inputTokens.length);
   well.rollingDailyTransferVolumeUSD = ZERO_BD;
   well.rollingWeeklyTradeVolumeReserves = emptyBigIntArray(inputTokens.length);
   well.rollingWeeklyTradeVolumeReservesUSD = emptyBigDecimalArray(inputTokens.length);
   well.rollingWeeklyTradeVolumeUSD = ZERO_BD;
+  well.rollingWeeklyBiTradeVolumeReserves = emptyBigIntArray(inputTokens.length);
   well.rollingWeeklyTransferVolumeReserves = emptyBigIntArray(inputTokens.length);
   well.rollingWeeklyTransferVolumeReservesUSD = emptyBigDecimalArray(inputTokens.length);
   well.rollingWeeklyTransferVolumeUSD = ZERO_BD;
@@ -218,6 +221,10 @@ export function takeWellDailySnapshot(wellAddress: Address, dayID: i32, timestam
     priorSnapshot.cumulativeTradeVolumeReservesUSD
   );
   newSnapshot.deltaTradeVolumeUSD = newSnapshot.cumulativeTradeVolumeUSD.minus(priorSnapshot.cumulativeTradeVolumeUSD);
+  newSnapshot.deltaBiTradeVolumeReserves = deltaBigIntArray(
+    newSnapshot.cumulativeBiTradeVolumeReserves,
+    priorSnapshot.cumulativeBiTradeVolumeReserves
+  );
   newSnapshot.deltaTransferVolumeReserves = deltaBigIntArray(
     newSnapshot.cumulativeTransferVolumeReserves,
     priorSnapshot.cumulativeTransferVolumeReserves
@@ -249,6 +256,7 @@ export function loadOrCreateWellDailySnapshot(wellAddress: Address, dayID: i32, 
     snapshot.cumulativeTradeVolumeReserves = well.cumulativeTradeVolumeReserves;
     snapshot.cumulativeTradeVolumeReservesUSD = well.cumulativeTradeVolumeReservesUSD;
     snapshot.cumulativeTradeVolumeUSD = well.cumulativeTradeVolumeUSD;
+    snapshot.cumulativeBiTradeVolumeReserves = well.cumulativeBiTradeVolumeReserves;
     snapshot.cumulativeTransferVolumeReserves = well.cumulativeTransferVolumeReserves;
     snapshot.cumulativeTransferVolumeReservesUSD = well.cumulativeTransferVolumeReservesUSD;
     snapshot.cumulativeTransferVolumeUSD = well.cumulativeTransferVolumeUSD;
@@ -260,6 +268,7 @@ export function loadOrCreateWellDailySnapshot(wellAddress: Address, dayID: i32, 
     snapshot.deltaTradeVolumeReserves = emptyBigIntArray(well.tokens.length);
     snapshot.deltaTradeVolumeReservesUSD = emptyBigDecimalArray(well.tokens.length);
     snapshot.deltaTradeVolumeUSD = ZERO_BD;
+    snapshot.deltaBiTradeVolumeReserves = emptyBigIntArray(well.tokens.length);
     snapshot.deltaTransferVolumeReserves = emptyBigIntArray(well.tokens.length);
     snapshot.deltaTransferVolumeReservesUSD = emptyBigDecimalArray(well.tokens.length);
     snapshot.deltaTransferVolumeUSD = ZERO_BD;
@@ -295,6 +304,10 @@ export function takeWellHourlySnapshot(wellAddress: Address, hourID: i32, timest
     priorSnapshot.cumulativeTradeVolumeReservesUSD
   );
   newSnapshot.deltaTradeVolumeUSD = newSnapshot.cumulativeTradeVolumeUSD.minus(priorSnapshot.cumulativeTradeVolumeUSD);
+  newSnapshot.deltaBiTradeVolumeReserves = deltaBigIntArray(
+    newSnapshot.cumulativeBiTradeVolumeReserves,
+    priorSnapshot.cumulativeBiTradeVolumeReserves
+  );
   newSnapshot.deltaTransferVolumeReserves = deltaBigIntArray(
     newSnapshot.cumulativeTransferVolumeReserves,
     priorSnapshot.cumulativeTransferVolumeReserves
@@ -323,6 +336,7 @@ export function takeWellHourlySnapshot(wellAddress: Address, hourID: i32, timest
       oldest24h.deltaTradeVolumeReservesUSD
     );
     well.rollingDailyTradeVolumeUSD = well.rollingDailyTradeVolumeUSD.minus(oldest24h.deltaTradeVolumeUSD);
+    well.rollingDailyBiTradeVolumeReserves = deltaBigIntArray(well.rollingDailyBiTradeVolumeReserves, oldest24h.deltaBiTradeVolumeReserves);
     well.rollingDailyTransferVolumeReserves = deltaBigIntArray(
       well.rollingDailyTransferVolumeReserves,
       oldest24h.deltaTransferVolumeReserves
@@ -339,6 +353,10 @@ export function takeWellHourlySnapshot(wellAddress: Address, hourID: i32, timest
         oldest7d.deltaTradeVolumeReservesUSD
       );
       well.rollingWeeklyTradeVolumeUSD = well.rollingWeeklyTradeVolumeUSD.minus(oldest7d.deltaTradeVolumeUSD);
+      well.rollingWeeklyBiTradeVolumeReserves = deltaBigIntArray(
+        well.rollingWeeklyBiTradeVolumeReserves,
+        oldest7d.deltaBiTradeVolumeReserves
+      );
       well.rollingWeeklyTransferVolumeReserves = deltaBigIntArray(
         well.rollingWeeklyTransferVolumeReserves,
         oldest7d.deltaTransferVolumeReserves
@@ -370,6 +388,7 @@ export function loadOrCreateWellHourlySnapshot(
     snapshot.cumulativeTradeVolumeReserves = well.cumulativeTradeVolumeReserves;
     snapshot.cumulativeTradeVolumeReservesUSD = well.cumulativeTradeVolumeReservesUSD;
     snapshot.cumulativeTradeVolumeUSD = well.cumulativeTradeVolumeUSD;
+    snapshot.cumulativeBiTradeVolumeReserves = well.cumulativeBiTradeVolumeReserves;
     snapshot.cumulativeTransferVolumeReserves = well.cumulativeTransferVolumeReserves;
     snapshot.cumulativeTransferVolumeReservesUSD = well.cumulativeTransferVolumeReservesUSD;
     snapshot.cumulativeTransferVolumeUSD = well.cumulativeTransferVolumeUSD;
@@ -381,6 +400,7 @@ export function loadOrCreateWellHourlySnapshot(
     snapshot.deltaTradeVolumeReserves = emptyBigIntArray(well.tokens.length);
     snapshot.deltaTradeVolumeReservesUSD = emptyBigDecimalArray(well.tokens.length);
     snapshot.deltaTradeVolumeUSD = ZERO_BD;
+    snapshot.deltaBiTradeVolumeReserves = emptyBigIntArray(well.tokens.length);
     snapshot.deltaTransferVolumeReserves = emptyBigIntArray(well.tokens.length);
     snapshot.deltaTransferVolumeReservesUSD = emptyBigDecimalArray(well.tokens.length);
     snapshot.deltaTransferVolumeUSD = ZERO_BD;

--- a/projects/subgraph-basin/tests/Liquidity.test.ts
+++ b/projects/subgraph-basin/tests/Liquidity.test.ts
@@ -31,6 +31,10 @@ const BD_2 = BigDecimal.fromString("2");
 const BD_3 = BigDecimal.fromString("3");
 const BD_4 = BigDecimal.fromString("4");
 
+function zeroNegative(tokenAmounts: BigInt[]): BigInt[] {
+  return [tokenAmounts[0] < ZERO_BI ? ZERO_BI : tokenAmounts[0], tokenAmounts[1] < ZERO_BI ? ZERO_BI : tokenAmounts[1]];
+}
+
 function assignUSD(tokenAmounts: BigInt[]): BigDecimal[] {
   const bean = loadToken(BEAN_ERC20);
   const weth = loadToken(WETH);
@@ -81,7 +85,9 @@ describe("Well Entity: Liquidity Event Tests", () => {
       const tradeReservesUSD = updatedStore.cumulativeTradeVolumeReservesUSD;
       const transferReservesUSD = updatedStore.cumulativeTransferVolumeReservesUSD;
 
-      const expectedTradeVolume = calcLiquidityVolume([BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT], [BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT]);
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT], [BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT])
+      );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
 
       assert.bigIntEquals(expectedTradeVolume[0], tradeReserves[0]);
@@ -95,7 +101,9 @@ describe("Well Entity: Liquidity Event Tests", () => {
     });
     test("Cumulative volume updated (CP)", () => {
       let updatedStore = loadWell(WELL);
-      const expectedTradeVolume = calcLiquidityVolume([BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT], [BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT]);
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT], [BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT])
+      );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
       assert.stringEquals(BigDecimal_max(expectedTradeVolumeUSD).toString(), updatedStore.cumulativeTradeVolumeUSD.toString());
       assert.stringEquals(BEAN_USD_AMOUNT.plus(WETH_USD_AMOUNT).toString(), updatedStore.cumulativeTransferVolumeUSD.toString());
@@ -136,7 +144,9 @@ describe("Well Entity: Liquidity Event Tests", () => {
       const tradeReservesUSD = updatedStore.cumulativeTradeVolumeReservesUSD;
       const transferReservesUSD = updatedStore.cumulativeTransferVolumeReservesUSD;
 
-      const expectedTradeVolume = calcLiquidityVolume([BEAN_SWAP_AMOUNT.times(BI_2), WETH_SWAP_AMOUNT], [BEAN_SWAP_AMOUNT, ZERO_BI]);
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT.times(BI_2), WETH_SWAP_AMOUNT], [BEAN_SWAP_AMOUNT, ZERO_BI])
+      );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
 
       assert.bigIntEquals(expectedTradeVolume[0], tradeReserves[0]);
@@ -150,7 +160,9 @@ describe("Well Entity: Liquidity Event Tests", () => {
     });
     test("Cumulative volume updated (CP)", () => {
       let updatedStore = loadWell(WELL);
-      const expectedTradeVolume = calcLiquidityVolume([BEAN_SWAP_AMOUNT.times(BI_2), WETH_SWAP_AMOUNT], [BEAN_SWAP_AMOUNT, ZERO_BI]);
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT.times(BI_2), WETH_SWAP_AMOUNT], [BEAN_SWAP_AMOUNT, ZERO_BI])
+      );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
       assert.stringEquals(BigDecimal_max(expectedTradeVolumeUSD).toString(), updatedStore.cumulativeTradeVolumeUSD.toString());
       assert.stringEquals(
@@ -193,9 +205,8 @@ describe("Well Entity: Liquidity Event Tests", () => {
       const tradeReservesUSD = updatedStore.cumulativeTradeVolumeReservesUSD;
       const transferReservesUSD = updatedStore.cumulativeTransferVolumeReservesUSD;
 
-      const expectedTradeVolume = calcLiquidityVolume(
-        [BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT],
-        [BEAN_SWAP_AMOUNT.div(BI_2), WETH_SWAP_AMOUNT.div(BI_2)]
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT], [BEAN_SWAP_AMOUNT.div(BI_2), WETH_SWAP_AMOUNT.div(BI_2)])
       );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
 
@@ -210,9 +221,8 @@ describe("Well Entity: Liquidity Event Tests", () => {
     });
     test("Cumulative volume updated (CP)", () => {
       let updatedStore = loadWell(WELL);
-      const expectedTradeVolume = calcLiquidityVolume(
-        [BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT],
-        [BEAN_SWAP_AMOUNT.div(BI_2), WETH_SWAP_AMOUNT.div(BI_2)]
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT], [BEAN_SWAP_AMOUNT.div(BI_2), WETH_SWAP_AMOUNT.div(BI_2)])
       );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
       assert.stringEquals(BigDecimal_max(expectedTradeVolumeUSD).toString(), updatedStore.cumulativeTradeVolumeUSD.toString());
@@ -255,9 +265,8 @@ describe("Well Entity: Liquidity Event Tests", () => {
       const tradeReservesUSD = updatedStore.cumulativeTradeVolumeReservesUSD;
       const transferReservesUSD = updatedStore.cumulativeTransferVolumeReservesUSD;
 
-      const expectedTradeVolume = calcLiquidityVolume(
-        [BEAN_SWAP_AMOUNT.div(BI_2), WETH_SWAP_AMOUNT],
-        [ZERO_BI, WETH_SWAP_AMOUNT.div(BI_2)]
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT.div(BI_2), WETH_SWAP_AMOUNT], [ZERO_BI, WETH_SWAP_AMOUNT.div(BI_2)])
       );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
 
@@ -272,9 +281,8 @@ describe("Well Entity: Liquidity Event Tests", () => {
     });
     test("Cumulative volume updated (CP)", () => {
       let updatedStore = loadWell(WELL);
-      const expectedTradeVolume = calcLiquidityVolume(
-        [BEAN_SWAP_AMOUNT.div(BI_2), WETH_SWAP_AMOUNT],
-        [ZERO_BI, WETH_SWAP_AMOUNT.div(BI_2)]
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT.div(BI_2), WETH_SWAP_AMOUNT], [ZERO_BI, WETH_SWAP_AMOUNT.div(BI_2)])
       );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
       assert.stringEquals(BigDecimal_max(expectedTradeVolumeUSD).toString(), updatedStore.cumulativeTradeVolumeUSD.toString());
@@ -307,7 +315,7 @@ describe("Well Entity: Liquidity Event Tests", () => {
       const tradeReservesUSD = updatedStore.cumulativeTradeVolumeReservesUSD;
       const transferReservesUSD = updatedStore.cumulativeTransferVolumeReservesUSD;
 
-      const expectedTradeVolume = calcLiquidityVolume([ZERO_BI, ZERO_BI], [BEAN_SWAP_AMOUNT.neg(), WETH_SWAP_AMOUNT.neg()]);
+      const expectedTradeVolume = zeroNegative(calcLiquidityVolume([ZERO_BI, ZERO_BI], [BEAN_SWAP_AMOUNT.neg(), WETH_SWAP_AMOUNT.neg()]));
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
 
       assert.bigIntEquals(expectedTradeVolume[0], tradeReserves[0]);
@@ -321,7 +329,7 @@ describe("Well Entity: Liquidity Event Tests", () => {
     });
     test("Cumulative volume updated (CP)", () => {
       let updatedStore = loadWell(WELL);
-      const expectedTradeVolume = calcLiquidityVolume([ZERO_BI, ZERO_BI], [BEAN_SWAP_AMOUNT.neg(), WETH_SWAP_AMOUNT.neg()]);
+      const expectedTradeVolume = zeroNegative(calcLiquidityVolume([ZERO_BI, ZERO_BI], [BEAN_SWAP_AMOUNT.neg(), WETH_SWAP_AMOUNT.neg()]));
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
       assert.stringEquals(BigDecimal_max(expectedTradeVolumeUSD).toString(), updatedStore.cumulativeTradeVolumeUSD.toString());
       assert.stringEquals(
@@ -357,7 +365,9 @@ describe("Well Entity: Liquidity Event Tests", () => {
       const tradeReservesUSD = updatedStore.cumulativeTradeVolumeReservesUSD;
       const transferReservesUSD = updatedStore.cumulativeTransferVolumeReservesUSD;
 
-      const expectedTradeVolume = calcLiquidityVolume([BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT.times(BI_2)], [BEAN_SWAP_AMOUNT.neg(), ZERO_BI]);
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT.times(BI_2)], [BEAN_SWAP_AMOUNT.neg(), ZERO_BI])
+      );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
 
       assert.bigIntEquals(expectedTradeVolume[0], tradeReserves[0]);
@@ -371,7 +381,9 @@ describe("Well Entity: Liquidity Event Tests", () => {
     });
     test("Cumulative volume updated (CP)", () => {
       let updatedStore = loadWell(WELL);
-      const expectedTradeVolume = calcLiquidityVolume([BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT.times(BI_2)], [BEAN_SWAP_AMOUNT.neg(), ZERO_BI]);
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT, WETH_SWAP_AMOUNT.times(BI_2)], [BEAN_SWAP_AMOUNT.neg(), ZERO_BI])
+      );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
       assert.stringEquals(BigDecimal_max(expectedTradeVolumeUSD).toString(), updatedStore.cumulativeTradeVolumeUSD.toString());
       assert.stringEquals(
@@ -407,7 +419,9 @@ describe("Well Entity: Liquidity Event Tests", () => {
       const tradeReservesUSD = updatedStore.cumulativeTradeVolumeReservesUSD;
       const transferReservesUSD = updatedStore.cumulativeTransferVolumeReservesUSD;
 
-      const expectedTradeVolume = calcLiquidityVolume([BEAN_SWAP_AMOUNT.times(BI_2), WETH_SWAP_AMOUNT], [ZERO_BI, WETH_SWAP_AMOUNT.neg()]);
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT.times(BI_2), WETH_SWAP_AMOUNT], [ZERO_BI, WETH_SWAP_AMOUNT.neg()])
+      );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
 
       assert.bigIntEquals(expectedTradeVolume[0], tradeReserves[0]);
@@ -421,7 +435,9 @@ describe("Well Entity: Liquidity Event Tests", () => {
     });
     test("Cumulative volume updated (CP)", () => {
       let updatedStore = loadWell(WELL);
-      const expectedTradeVolume = calcLiquidityVolume([BEAN_SWAP_AMOUNT.times(BI_2), WETH_SWAP_AMOUNT], [ZERO_BI, WETH_SWAP_AMOUNT.neg()]);
+      const expectedTradeVolume = zeroNegative(
+        calcLiquidityVolume([BEAN_SWAP_AMOUNT.times(BI_2), WETH_SWAP_AMOUNT], [ZERO_BI, WETH_SWAP_AMOUNT.neg()])
+      );
       const expectedTradeVolumeUSD = assignUSD(expectedTradeVolume);
       assert.stringEquals(BigDecimal_max(expectedTradeVolumeUSD).toString(), updatedStore.cumulativeTradeVolumeUSD.toString());
       assert.stringEquals(


### PR DESCRIPTION
Adds a new field that tracks trade reserves in terms of both tokens, not just the bought token. This information is required for coingecko integration, and being able to use this field directly is cleaner than the prior implementation and more generalizable for wells having tokens with unknown prices