### PR TITLE
Misc Improvements (Codehawks Part 3) Remediations

### DIFF
--- a/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
@@ -248,7 +248,12 @@ contract Sun is Oracle {
         }
 
         // Set new soil.
-        setSoil(Math.min(uint256(-twaDeltaB), uint256(-instDeltaB)));
+        if (instDeltaB < 0) {
+            setSoil(Math.min(uint256(-twaDeltaB), uint256(-instDeltaB)));
+        } else {
+            setSoil(uint256(-twaDeltaB));
+        }
+        
     }
 
     /**

--- a/protocol/contracts/libraries/LibUnripe.sol
+++ b/protocol/contracts/libraries/LibUnripe.sol
@@ -164,7 +164,13 @@ library LibUnripe {
         // But totalRipeUnderlying = CurrentUnderlying * totalUsdNeeded/usdValueRaised to get the total underlying
         // redeem = currentRipeUnderlying * (usdValueRaised/totalUsdNeeded) * UnripeAmountIn/UnripeSupply
         uint256 underlyingAmount = s.u[unripeToken].balanceOfUnderlying;
-        redeem = underlyingAmount.mul(s.recapitalized).div(totalUsdNeeded).mul(amount).div(supply);
+        if(totalUsdNeeded == 0) {
+            // when totalUsdNeeded == 0, the barnraise has been fully recapitalized.
+            redeem = underlyingAmount.mul(amount).div(supply);
+        } else {
+            redeem = underlyingAmount.mul(s.recapitalized).div(totalUsdNeeded).mul(amount).div(supply);
+        }
+        
         // cap `redeem to `balanceOfUnderlying in the case that `s.recapitalized` exceeds `totalUsdNeeded`.
         // this can occur due to unripe LP chops.
         if(redeem > underlyingAmount) redeem = underlyingAmount;

--- a/protocol/contracts/libraries/LibUnripe.sol
+++ b/protocol/contracts/libraries/LibUnripe.sol
@@ -178,7 +178,9 @@ library LibUnripe {
     function getTotalRecapitalizedPercent() internal view returns (uint256 recapitalizedPercent) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         uint256 totalUsdNeeded = LibFertilizer.getTotalRecapDollarsNeeded();
-        if(totalUsdNeeded == 0) return 0;
+        if (totalUsdNeeded == 0) {
+            return 1e6; // if zero usd needed, full recap has happened
+        }
         return s.recapitalized.mul(DECIMALS).div(totalUsdNeeded);
     }
 

--- a/protocol/test/Sun.test.js
+++ b/protocol/test/Sun.test.js
@@ -131,7 +131,31 @@ describe('Sun', function () {
       value: 0
     })
 
-    // twaDeltaB = -100000000000000000
+    // twaDeltaB = -100000000
+    // instantaneousDeltaB = -585786437627
+                                            // twaDeltaB, case ID
+    this.result = await this.season.sunSunrise('-585786437627', 8);
+    await expect(this.result).to.emit(this.season, 'Soil').withArgs(3, '585786437627');
+    await expect(await this.field.totalSoil()).to.be.equal('585786437627');
+  })
+
+  it("twaDeltaB < 0, -instDeltaB > 0. (uses twaDeltaB)", async function () {
+    // go forward 1800 blocks
+    await advanceTime(1800)
+    // whitelist well to be included in the instantaneous deltaB calculation
+    await this.silo.mockWhitelistToken(BEAN_ETH_WELL, this.silo.interface.getSighash("mockBDV(uint256 amount)"), "10000", "1");
+    // set reserves to 0.5M Beans and 1000 Eth
+    await await this.well.setReserves([to6('500000'), to18('1000')]);
+    await await this.well.setReserves([to6('500000'), to18('1000')]);
+    // go forward 1800 blocks
+    await advanceTime(1800)
+    // send 0 eth to beanstalk
+    await user.sendTransaction({
+      to: this.diamond.address,
+      value: 0
+    })
+
+    // twaDeltaB = +500_000
     // instantaneousDeltaB = -585786437627
                                             // twaDeltaB, case ID
     this.result = await this.season.sunSunrise('-585786437627', 8);

--- a/protocol/test/Unripe.test.js
+++ b/protocol/test/Unripe.test.js
@@ -418,6 +418,40 @@ describe('Unripe', function () {
       )
     })
   })
+
+  describe('LP chop all of supply', async function () {
+    beforeEach(async function () {
+      // totalDollarsneeded = 47
+      await this.unripeLP.mint(userAddress, to6('189'))
+      await this.unripe.connect(owner).addUnderlying(
+        UNRIPE_LP,
+        to6('100') // balanceOfUnderlying is 25
+      )            
+                                                      // s.recapitalized=25
+      await this.fertilizer.connect(user).setPenaltyParams(to6('100'), to6('100'))
+
+      // remaining recapitalization = totalDollarsNeeded - s.recapitalized = 100 - 100 = 0
+      expect(await this.fertilizer.remainingRecapitalization()).to.be.equal(to6('0'))
+      // s.recapitalized = 100
+      expect(await this.unripe.getRecapitalized()).to.be.equal(to6('100'))
+      
+      // 100000000*100000000/100000000*1000000/189000000 = 529100
+      expect(await this.unripe.getPenalty(UNRIPE_LP)).to.be.equal(to6('0.529100'))
+      // user chops ~ all the unripe LP supply
+      this.result = await this.unripe.connect(user).chop(UNRIPE_LP, to6('189'), EXTERNAL, EXTERNAL)
+    })
+
+    it('emits an event, and chopping unripe bean works', async function () {
+      await expect(this.result).to.emit(this.unripe, 'Chop').withArgs(
+        user.address,
+        UNRIPE_LP,
+        to6('189'),
+        to6('100.000000') // 100%
+      )
+
+      // attempt to chop unripe bean
+    })
+  })
   
   // Same as above but with different transfer modes used
   describe('chop, different transfer modes, half the supply, balanceOfUnderlying Max ≠ Unripe Total Supply, TotalSupply > 100, fert 25% sold', async function () {


### PR DESCRIPTION
# Misc Improvements (Codehawks Part 3) Remediations

Audit results: https://www.codehawks.com/report/clvo5kwin00078k6jhhjobn22

## Codehawks Remediations

### [ L-01. LibUnripe::getTotalRecapitalizedPercent returns wrong recapitalizedPercent if totalUsdNeeded is 0](https://www.codehawks.com/report/clvo5kwin00078k6jhhjobn22#L-01) 

Remediation: Set `getTotalRecapitalizedPercent` to 1e6 when beanstalk is fully recapitalized. 00ad54a03c151c722043e8118084beb3cbd401d5

Original finding: https://www.codehawks.com/report/clvo5kwin00078k6jhhjobn22#L-01

### [L-02. Missing validation for totalUsdNeeded in LibUnripe::getPenalizedUnderlying can lead to the urBean chopping block](https://www.codehawks.com/report/clvo5kwin00078k6jhhjobn22#L-02) 

Remediation: Modified `getPenalizedUnderlying ` to return `underlyingAmount.mul(s.recapitalized).div(totalUsdNeeded).mul(amount).div(supply)` (given at 100% recapitalization, s.recapitalized/totalUsdNeeded == 1) fae3d9733ee91980aa96f55eda53f99fb316cc02


Original finding:https://www.codehawks.com/report/clvo5kwin00078k6jhhjobn22#L-02

### [L-03. Soil issuance is computed incorrectly if twaDeltaB is negative while instDeltaB is positive.](https://www.codehawks.com/report/clvo5kwin00078k6jhhjobn22#L-03)

Remediation: check that instDeltaB is negative prior to taking the minimum between instDeltaB and twaDeltaB 77427749c58ab000162e0921ccd4cbd229a12fc2

Original finding: https://www.codehawks.com/report/clvo5kwin00078k6jhhjobn22#L-03

# Accepted Risks from Codehawks Findings

### L-04. Ignoring caseIdvalue when season is below peg

The finding states that during reasonably low and excessively low debt levels, Beanstalk does not need to take the minimum between the TWA and instantaneous DeltaB given beanstalk has too little debt. However, the goal of taking the minimum between the two is to issue the correct amount of soil to return beanstalk back to peg. Overissuing Soil even during times of low debt can lead to inorganic demand (which is something Beanstalk aims to minimize).

https://www.codehawks.com/report/clvo5kwin00078k6jhhjobn22#L-04