### PR TITLE
Basin subgraph - add token order field

### DIFF
--- a/projects/subgraph-basin/schema.graphql
+++ b/projects/subgraph-basin/schema.graphql
@@ -81,8 +81,10 @@ type Well @entity {
   symbol: String
 
   " Tokens that need to be deposited to take a position in protocol. e.g. WETH and USDC to deposit into the WETH-USDC well. Array to account for multi-asset wells like Curve and Balancer "
-  # Check for forced indexing of tokens
   tokens: [Token!]!
+
+  " The order of the tokens in the Well. The above `tokens` association will be sorted by id on any retrieval. "
+  tokenOrder: [Bytes!]!
 
   " Pricing function contract used with this well "
   wellFunction: WellFunction! @derivedFrom(field: "well")

--- a/projects/subgraph-basin/src/templates/AquiferHandler.ts
+++ b/projects/subgraph-basin/src/templates/AquiferHandler.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, Bytes, log } from "@graphprotocol/graph-ts";
 import { BoreWell } from "../../generated/Aquifer/Aquifer";
 import { ERC20 } from "../../generated/Aquifer/ERC20";
 import { Well } from "../../generated/templates";
@@ -17,22 +17,14 @@ export function handleBoreWell(event: BoreWell): void {
   Well.create(event.params.well);
 
   let well = createWell(event.params.well, event.params.implementation, event.params.tokens);
-
   well.aquifer = event.address;
 
-  // A bit crude, but it works
-
+  const tokens: Bytes[] = [];
   for (let i = 0; i < event.params.tokens.length; i++) {
-    loadOrCreateToken(event.params.tokens[i]);
+    tokens.push(loadOrCreateToken(event.params.tokens[i]).id);
   }
-
-  if (event.params.tokens.length == 2) {
-    well.tokens = [event.params.tokens[0], event.params.tokens[1]];
-  } else if (event.params.tokens.length == 3) {
-    well.tokens = [event.params.tokens[0], event.params.tokens[1], event.params.tokens[2]];
-  } else if (event.params.tokens.length == 4) {
-    well.tokens = [event.params.tokens[0], event.params.tokens[1], event.params.tokens[2], event.params.tokens[3]];
-  }
+  well.tokens = tokens;
+  well.tokensOrdered = tokens;
 
   for (let i = 0; i < event.params.pumps.length; i++) {
     loadOrCreatePump(event.params.pumps[i], event.params.well);

--- a/projects/subgraph-basin/src/templates/AquiferHandler.ts
+++ b/projects/subgraph-basin/src/templates/AquiferHandler.ts
@@ -24,7 +24,7 @@ export function handleBoreWell(event: BoreWell): void {
     tokens.push(loadOrCreateToken(event.params.tokens[i]).id);
   }
   well.tokens = tokens;
-  well.tokensOrdered = tokens;
+  well.tokenOrder = tokens;
 
   for (let i = 0; i < event.params.pumps.length; i++) {
     loadOrCreatePump(event.params.pumps[i], event.params.well);

--- a/projects/subgraph-basin/src/utils/Well.ts
+++ b/projects/subgraph-basin/src/utils/Well.ts
@@ -43,6 +43,7 @@ export function createWell(wellAddress: Address, implementation: Address, inputT
   well.aquifer = Bytes.empty();
   well.implementation = implementation;
   well.tokens = []; // This is currently set in the `handleBoreWell` function
+  well.tokenOrder = [];
   well.createdTimestamp = ZERO_BI;
   well.createdBlockNumber = ZERO_BI;
   well.lpTokenSupply = ZERO_BI;

--- a/projects/subgraph-basin/subgraph.yaml
+++ b/projects/subgraph-basin/subgraph.yaml
@@ -79,3 +79,8 @@ templates:
         - event: Sync(uint256[],uint256,address)
           handler: handleSync
       file: ./src/WellHandler.ts
+# features:
+#   - grafting
+# graft:
+#   base: QmWHi6hu2wXnyxBHHmQHwCQLoq5KkoTX2qLm8MdyVXTyTu
+#   block: 20216425


### PR DESCRIPTION
The `tokens` field on the `Well` entity is sorted by token id when queried via the graphql api. This is a problem because the caller can't determine what is the order of tokens in the well. An additional field `tokenOrder` is added here.