### PR TITLE
add mapping.

### DIFF
--- a/protocol/contracts/beanstalk/field/FieldFacet.sol
+++ b/protocol/contracts/beanstalk/field/FieldFacet.sol
@@ -217,6 +217,9 @@ contract FieldFacet is Invariable, ReentrancyGuard {
         uint256 newIndex = index.add(harvestablePods);
         s.accts[account].fields[fieldId].plots[newIndex] = pods.sub(harvestablePods);
         s.accts[account].fields[fieldId].plotIndexes.push(newIndex);
+        s.accts[account].fields[fieldId].piIndex[newIndex] =
+            s.accts[account].fields[fieldId].plotIndexes.length -
+            1;
     }
 
     //////////////////// CONFIG /////////////////////

--- a/protocol/contracts/beanstalk/init/reseed/L2/ReseedSilo.sol
+++ b/protocol/contracts/beanstalk/init/reseed/L2/ReseedSilo.sol
@@ -123,7 +123,9 @@ contract ReseedSilo {
                 // add deposit to account. Add to depositIdList.
                 s.accts[deposits.accounts].deposits[depositId].amount = deposits.dd[j].amount;
                 s.accts[deposits.accounts].deposits[depositId].bdv = deposits.dd[j].bdv;
-                s.accts[deposits.accounts].depositIdList[siloDeposit.token].push(depositId);
+                s.accts[deposits.accounts].depositIdList[siloDeposit.token].depositIds.push(
+                    depositId
+                );
 
                 // increment totalBdvForAccount by bdv of deposit:
                 totalBdvForAccount += deposits.dd[j].bdv;

--- a/protocol/contracts/beanstalk/market/MarketplaceFacet/PodTransfer.sol
+++ b/protocol/contracts/beanstalk/market/MarketplaceFacet/PodTransfer.sol
@@ -61,6 +61,9 @@ contract PodTransfer is ReentrancyGuard {
     function insertPlot(address account, uint256 fieldId, uint256 index, uint256 amount) internal {
         s.accts[account].fields[fieldId].plots[index] = amount;
         s.accts[account].fields[fieldId].plotIndexes.push(index);
+        s.accts[account].fields[fieldId].piIndex[index] =
+            s.accts[account].fields[fieldId].plotIndexes.length -
+            1;
     }
 
     function removePlot(
@@ -83,6 +86,9 @@ contract PodTransfer is ReentrancyGuard {
             uint256 newIndex = index + end;
             s.accts[account].fields[fieldId].plots[newIndex] = amountAfterEnd;
             s.accts[account].fields[fieldId].plotIndexes.push(newIndex);
+            s.accts[account].fields[fieldId].piIndex[newIndex] =
+                s.accts[account].fields[fieldId].plotIndexes.length -
+                1;
         }
     }
 

--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloGettersFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloGettersFacet.sol
@@ -577,7 +577,7 @@ contract SiloGettersFacet is ReentrancyGuard {
         address account,
         address token
     ) public view returns (TokenDepositId memory deposits) {
-        uint256[] memory depositIds = s.accts[account].depositIdList[token];
+        uint256[] memory depositIds = s.accts[account].depositIdList[token].depositIds;
         if (depositIds.length == 0) return TokenDepositId(token, depositIds, new Deposit[](0));
         deposits.token = token;
         deposits.depositIds = depositIds;
@@ -594,6 +594,14 @@ contract SiloGettersFacet is ReentrancyGuard {
         address account,
         address token
     ) public view returns (uint256[] memory depositIds) {
-        return s.accts[account].depositIdList[token];
+        return s.accts[account].depositIdList[token].depositIds;
+    }
+
+    function getIndexForDepositId(
+        address account,
+        address token,
+        uint256 depositId
+    ) external view returns (uint256) {
+        return s.accts[account].depositIdList[token].idIndex[depositId];
     }
 }

--- a/protocol/contracts/beanstalk/storage/Account.sol
+++ b/protocol/contracts/beanstalk/storage/Account.sol
@@ -17,7 +17,7 @@ import {GerminationSide} from "./System.sol";
  * @param lastRain The last Season that it started Raining at the time the Farmer last updated their Silo.
  * @param _buffer_0 Reserved storage for future additions.
  * @param deposits SiloV3.1 deposits. A mapping from depositId to Deposit. SiloV3.1 introduces greater precision for deposits.
- * @param depositIdList A list of depositIds for each token owned by the account.
+ * @param depositIdList DepositListData for each token owned by the account.
  * @param field A mapping from FieldId to a Farmer's Field storage.
  * @param depositAllowances A mapping of `spender => Silo token address => amount`.
  * @param tokenAllowances Internal balance token allowances.
@@ -39,7 +39,7 @@ struct Account {
     uint32 lastRain;
     bytes32[16] _buffer_0;
     mapping(uint256 => Deposit) deposits;
-    mapping(address => uint256[]) depositIdList;
+    mapping(address => DepositListData) depositIdList;
     mapping(uint256 => Field) fields;
     mapping(address => mapping(address => uint256)) depositAllowances;
     mapping(address => mapping(IERC20 => uint256)) tokenAllowances;
@@ -56,12 +56,14 @@ struct Account {
  * @param plots A Farmer's Plots. Maps from Plot index to Pod amount.
  * @param podAllowances An allowance mapping for Pods similar to that of the ERC-20 standard. Maps from spender address to allowance amount.
  * @param plotIndexes An array of Plot indexes. Used to return the farm plots of a Farmer.
+ * @param piIndex A mapping from Plot index to the index in plotIndexes.
  * @param _buffer Reserved storage for future additions.
  */
 struct Field {
     mapping(uint256 => uint256) plots;
     mapping(address => uint256) podAllowances;
     uint256[] plotIndexes;
+    mapping(uint256 => uint256) piIndex;
     bytes32[4] _buffer;
 }
 
@@ -122,4 +124,15 @@ struct GerminatingStalk {
 struct MowStatus {
     int96 lastStem;
     uint128 bdv;
+}
+
+/**
+ * @notice This struct stores data for a deposit list for a given token.
+ * a mapping from id to index was created to allow for O(1) retrevial of a deposit from the list.
+ * @param depositIds An array of depositIds for a given token.
+ * @param idIndex A mapping from depositId to index in depositIds.
+ */
+struct DepositListData {
+    uint256[] depositIds;
+    mapping(uint256 => uint256) idIndex;
 }

--- a/protocol/contracts/interfaces/IMockFBeanstalk.sol
+++ b/protocol/contracts/interfaces/IMockFBeanstalk.sol
@@ -1885,4 +1885,10 @@ interface IMockFBeanstalk {
         address token,
         uint256 lookback
     ) external view returns (uint256 tokenPrice);
+
+    function getIndexForDepositId(
+        address account,
+        address token,
+        uint256 depositId
+    ) external view returns (uint256);
 }

--- a/protocol/contracts/libraries/LibDibbler.sol
+++ b/protocol/contracts/libraries/LibDibbler.sol
@@ -399,6 +399,7 @@ library LibDibbler {
         Field storage field = s.accts[account].fields[fieldId];
         field.plotIndexes[i] = field.plotIndexes[field.plotIndexes.length - 1];
         field.piIndex[field.plotIndexes[i]] = i;
+        field.piIndex[plotIndex] = type(uint256).max;
         field.plotIndexes.pop();
     }
 
@@ -411,8 +412,6 @@ library LibDibbler {
         uint256 plotIndex
     ) internal view returns (uint256 i) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        console.log("i", i);
-        console.log("plotIndex", plotIndex);
         return s.accts[account].fields[fieldId].piIndex[plotIndex];
     }
 }

--- a/protocol/contracts/libraries/Silo/LibTokenSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibTokenSilo.sol
@@ -599,6 +599,7 @@ library LibTokenSilo {
         uint256 i = findDepositIdForAccount(account, token, depositId);
         list.depositIds[i] = list.depositIds[list.depositIds.length - 1];
         list.idIndex[list.depositIds[i]] = i;
+        list.idIndex[depositId] = type(uint256).max;
         list.depositIds.pop();
     }
 

--- a/protocol/test/foundry/silo/Silo.t.sol
+++ b/protocol/test/foundry/silo/Silo.t.sol
@@ -67,6 +67,7 @@ contract SiloTest is TestHelper {
         IMockFBeanstalk.TokenDepositId[] memory allDeposits = bs.getDepositsForAccount(farmers[0]);
 
         verifyDepositIdLengths(depositIds, deposit, C.BEAN, 1);
+        assertEq(bs.getIndexForDepositId(farmers[0], C.BEAN, depositIds[0]), 0);
         (address token, int96 stem) = LibBytes.unpackAddressAndStem(depositIds[0]);
         assertEq(token, deposit.token);
         assertEq(stem, bs.stemTipForToken(token));
@@ -101,12 +102,14 @@ contract SiloTest is TestHelper {
         depositIds = bs.getTokenDepositIdsForAccount(farmers[0], C.BEAN);
         deposit = bs.getTokenDepositsForAccount(farmers[0], C.BEAN);
         verifyDepositIdLengths(depositIds, deposit, C.BEAN, 1);
+        assertEq(bs.getIndexForDepositId(farmers[0], C.BEAN, depositIds[0]), 0);
         assertEq(deposit.tokenDeposits[0].amount, amount - portion);
 
         // verify depositList for recipient.
         depositIds = bs.getTokenDepositIdsForAccount(farmers[1], C.BEAN);
         deposit = bs.getTokenDepositsForAccount(farmers[1], C.BEAN);
         verifyDepositIdLengths(depositIds, deposit, C.BEAN, 1);
+        assertEq(bs.getIndexForDepositId(farmers[1], C.BEAN, depositIds[0]), 0);
         assertEq(deposit.tokenDeposits[0].amount, portion);
 
         vm.revertTo(snapshot);


### PR DESCRIPTION
Fixes 
- [M-14](https://codehawks.cyfrin.io/c/2024-05-beanstalk-the-finale/s/379)
- [M-03](https://codehawks.cyfrin.io/c/2024-05-beanstalk-the-finale/s/491)

by adding a mapping for the silo and field, that allows for O(1) lookup in the depositIdList and plotIndex array.
- `mapping(uint256 => uint256) idIndex;` 
- `mapping(uint256 => uint256) piIndex;`

When a new entry is added to the list, the mapping stores the index. When an entry is removed, the index is set to max (as it should not exist).