### PR TITLE
Sow - plot index

### DIFF
--- a/protocol/contracts/libraries/LibDibbler.sol
+++ b/protocol/contracts/libraries/LibDibbler.sol
@@ -88,6 +88,8 @@ library LibDibbler {
             pods = beansToPods(beans, _morningTemperature);
         }
 
+        require(pods > 0, "Pods must be greater than 0");
+
         // In the case of an overflow, its equivalent to having no soil left.
         if (s.sys.soil < beans) {
             s.sys.soil = 0;


### PR DESCRIPTION
Fixes:
[L-17](https://codehawks.cyfrin.io/c/2024-05-beanstalk-the-finale/s/485)

Adds a requirement that the pods sown must be greater than 0. Given that sowing 0 soil should not do anything, this change loses no utility.
