### PR TITLE
implement stalk scale increase

### DIFF
--- a/protocol/abi/MockBeanstalk.json
+++ b/protocol/abi/MockBeanstalk.json
@@ -6551,9 +6551,9 @@
         "type": "bytes4"
       },
       {
-        "internalType": "uint32",
+        "internalType": "uint48",
         "name": "stalkIssuedPerBdv",
-        "type": "uint32"
+        "type": "uint48"
       },
       {
         "internalType": "uint32",
@@ -6621,9 +6621,9 @@
         "type": "bytes4"
       },
       {
-        "internalType": "uint32",
+        "internalType": "uint48",
         "name": "stalkIssuedPerBdv",
-        "type": "uint32"
+        "type": "uint48"
       },
       {
         "internalType": "uint32",
@@ -6696,9 +6696,9 @@
         "type": "bytes4"
       },
       {
-        "internalType": "uint32",
+        "internalType": "uint48",
         "name": "stalkIssuedPerBdv",
-        "type": "uint32"
+        "type": "uint48"
       },
       {
         "internalType": "uint32",
@@ -7845,9 +7845,9 @@
             "type": "uint32"
           },
           {
-            "internalType": "uint32",
+            "internalType": "uint48",
             "name": "stalkIssuedPerBdv",
-            "type": "uint32"
+            "type": "uint48"
           },
           {
             "internalType": "uint32",
@@ -12003,14 +12003,14 @@
         "type": "bytes4"
       },
       {
-        "internalType": "uint16",
+        "internalType": "uint48",
         "name": "stalkIssuedPerBdv",
-        "type": "uint16"
+        "type": "uint48"
       },
       {
-        "internalType": "uint24",
+        "internalType": "uint32",
         "name": "stalkEarnedPerSeason",
-        "type": "uint24"
+        "type": "uint32"
       }
     ],
     "name": "mockWhitelistToken",

--- a/protocol/contracts/C.sol
+++ b/protocol/contracts/C.sol
@@ -25,10 +25,10 @@ library C {
 
     /// @dev The length of a Season meaured in seconds.
     uint256 private constant CURRENT_SEASON_PERIOD = 3600; // 1 hour
-    uint256 internal constant SOP_PRECISION = 1e24;
+    uint256 internal constant SOP_PRECISION = 1e30;
 
     //////////////////// Silo ////////////////////
-    uint256 internal constant STALK_PER_BEAN = 10000;
+    uint256 internal constant STALK_PER_BEAN = 1e10;
     uint256 private constant ROOTS_BASE = 1e12;
 
     //////////////////// Exploit Migration ////////////////////

--- a/protocol/contracts/beanstalk/init/InitalizeDiamond.sol
+++ b/protocol/contracts/beanstalk/init/InitalizeDiamond.sol
@@ -32,7 +32,7 @@ contract InitalizeDiamond {
     uint128 constant INIT_AVG_GSPBDV = 3e6;
     uint32 constant INIT_BEAN_STALK_EARNED_PER_SEASON = 2e6;
     uint32 constant INIT_BEAN_TOKEN_WELL_STALK_EARNED_PER_SEASON = 4e6;
-    uint32 constant INIT_STALK_ISSUED_PER_BDV = 1e4;
+    uint48 constant INIT_STALK_ISSUED_PER_BDV = 1e10;
     uint128 constant INIT_TOKEN_G_POINTS = 100e18;
     uint32 constant INIT_BEAN_TOKEN_WELL_PERCENT_TARGET = 100e6;
 

--- a/protocol/contracts/beanstalk/migration/L1AppStorage.sol
+++ b/protocol/contracts/beanstalk/migration/L1AppStorage.sol
@@ -428,7 +428,7 @@ contract Storage {
     struct SiloSettings {
         bytes4 selector; // ────────────────────┐ 4
         uint32 stalkEarnedPerSeason; //         │ 4  (8)
-        uint48 stalkIssuedPerBdv; //            │ 4  (12)
+        uint32 stalkIssuedPerBdv; //            │ 4  (12)
         uint32 milestoneSeason; //              │ 4  (16)
         int96 milestoneStem; //                 │ 12 (28)
         bytes1 encodeType; //                   │ 1  (29)

--- a/protocol/contracts/beanstalk/migration/L1AppStorage.sol
+++ b/protocol/contracts/beanstalk/migration/L1AppStorage.sol
@@ -428,7 +428,7 @@ contract Storage {
     struct SiloSettings {
         bytes4 selector; // ────────────────────┐ 4
         uint32 stalkEarnedPerSeason; //         │ 4  (8)
-        uint32 stalkIssuedPerBdv; //            │ 4  (12)
+        uint48 stalkIssuedPerBdv; //            │ 4  (12)
         uint32 milestoneSeason; //              │ 4  (16)
         int96 milestoneStem; //                 │ 12 (28)
         bytes1 encodeType; //                   │ 1  (29)

--- a/protocol/contracts/beanstalk/silo/EnrootFacet.sol
+++ b/protocol/contracts/beanstalk/silo/EnrootFacet.sol
@@ -45,7 +45,7 @@ contract EnrootFacet is Invariable, ReentrancyGuard {
         uint256 stalkAdded;
         uint256 bdvAdded;
         int96 stemTip;
-        uint32 stalkPerBdv;
+        uint48 stalkPerBdv;
     }
 
     modifier mowSender(address token) {
@@ -119,7 +119,7 @@ contract EnrootFacet is Invariable, ReentrancyGuard {
             LibSilo.stalkReward(stem, LibTokenSilo.stemTipForToken(token), uint128(deltaBDV))
         );
 
-        LibSilo.mintActiveStalk(LibTractor._user(), deltaStalk.toUint128());
+        LibSilo.mintActiveStalk(LibTractor._user(), deltaStalk);
     }
 
     /**
@@ -237,7 +237,7 @@ contract EnrootFacet is Invariable, ReentrancyGuard {
         uint256 amount,
         uint256 bdv,
         int96 stemTip,
-        uint32 stalkPerBdv
+        uint48 stalkPerBdv
     ) private returns (uint256 stalkAdded) {
         LibTokenSilo.addDepositToAccount(
             LibTractor._user(),

--- a/protocol/contracts/beanstalk/silo/WhitelistFacet/WhitelistFacet.sol
+++ b/protocol/contracts/beanstalk/silo/WhitelistFacet/WhitelistFacet.sol
@@ -56,7 +56,7 @@ contract WhitelistFacet is Invariable, WhitelistedTokens, ReentrancyGuard {
     function whitelistToken(
         address token,
         bytes4 selector,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint32 stalkEarnedPerSeason,
         bytes4 gaugePointSelector,
         bytes4 liquidityWeightSelector,
@@ -98,7 +98,7 @@ contract WhitelistFacet is Invariable, WhitelistedTokens, ReentrancyGuard {
     function whitelistTokenWithEncodeType(
         address token,
         bytes4 selector,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint32 stalkEarnedPerSeason,
         bytes1 encodeType,
         bytes4 gaugePointSelector,
@@ -149,7 +149,7 @@ contract WhitelistFacet is Invariable, WhitelistedTokens, ReentrancyGuard {
     function whitelistTokenWithExternalImplementation(
         address token,
         bytes4 selector,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint32 stalkEarnedPerSeason,
         bytes1 encodeType,
         uint128 gaugePoints,

--- a/protocol/contracts/beanstalk/storage/System.sol
+++ b/protocol/contracts/beanstalk/storage/System.sol
@@ -269,8 +269,7 @@ struct WhitelistStatus {
  * It is called by `LibTokenSilo` through the use of `delegatecall`
  * to calculate a token's BDV at the time of Deposit.
  * @param stalkEarnedPerSeason represents how much Stalk one BDV of the underlying deposited token
- * grows each season. In the past, this was represented by seeds. This is stored as 1e6, plus stalk is stored
- * as 1e10, so 1 legacy seed would be 1e6 * 1e10.
+ * grows each season. In the past, this was represented by seeds. 6 decimal precision.
  * @param stalkIssuedPerBdv The Stalk Per BDV that the Silo grants in exchange for Depositing this Token.
  * previously called stalk.
  * @param milestoneSeason The last season in which the stalkEarnedPerSeason for this token was updated.
@@ -299,13 +298,15 @@ struct WhitelistStatus {
 struct AssetSettings {
     bytes4 selector; // ────────────────────┐ 4
     uint32 stalkEarnedPerSeason; //         │ 4  (8)
-    uint32 stalkIssuedPerBdv; //            │ 4  (12)
-    uint32 milestoneSeason; //              │ 4  (16)
-    int96 milestoneStem; //                 │ 12 (28)
-    bytes1 encodeType; //                   │ 1  (29)
-    int24 deltaStalkEarnedPerSeason; // ────┘ 3  (32)
-    uint128 gaugePoints; // ─────────-───────┐ 16
-    uint64 optimalPercentDepositedBdv; //  ──┘ 8
+    uint48 stalkIssuedPerBdv; //            │ 6  (14)
+    uint32 milestoneSeason; //              │ 4  (18)
+    int96 milestoneStem; //                 │ 12 (30)
+    bytes1 encodeType; //                   │ 1  (31)
+    // one byte is left here.             ──┘ 1  (32)
+    int24 deltaStalkEarnedPerSeason; // ────┐ 3
+    uint128 gaugePoints; //                 │ 16 (19)
+    uint64 optimalPercentDepositedBdv; //   │ 8  (27)
+    // 5 bytes are left here.             ──┘ 5  (32)
     Implementation gaugePointImplementation;
     Implementation liquidityWeightImplementation;
 }
@@ -356,8 +357,8 @@ struct ConvertCapacity {
  * @notice Stores the system level germination Silo data.
  */
 struct GerminatingSilo {
-    uint128 stalk;
-    uint128 roots;
+    uint256 stalk;
+    uint256 roots;
 }
 
 /**

--- a/protocol/contracts/interfaces/IMockFBeanstalk.sol
+++ b/protocol/contracts/interfaces/IMockFBeanstalk.sol
@@ -90,7 +90,7 @@ interface IMockFBeanstalk {
     struct AssetSettings {
         bytes4 selector; // ────────────────────┐ 4
         uint32 stalkEarnedPerSeason; //         │ 4  (8)
-        uint32 stalkIssuedPerBdv; //            │ 4  (12)
+        uint48 stalkIssuedPerBdv; //            │ 4  (12)
         uint32 milestoneSeason; //              │ 4  (16)
         int96 milestoneStem; //                 │ 12 (28)
         bytes1 encodeType; //                   │ 1  (29)
@@ -1801,7 +1801,7 @@ interface IMockFBeanstalk {
     function whitelistToken(
         address token,
         bytes4 selector,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint32 stalkEarnedPerSeason,
         bytes4 gaugePointSelector,
         bytes4 liquidityWeightSelector,
@@ -1813,7 +1813,7 @@ interface IMockFBeanstalk {
     function whitelistTokenWithEncodeType(
         address token,
         bytes4 selector,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint32 stalkEarnedPerSeason,
         bytes1 encodeType,
         bytes4 gaugePointSelector,
@@ -1826,7 +1826,7 @@ interface IMockFBeanstalk {
     function whitelistTokenWithExternalImplementation(
         address token,
         bytes4 selector,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint32 stalkEarnedPerSeason,
         bytes1 encodeType,
         uint128 gaugePoints,

--- a/protocol/contracts/libraries/Silo/LibGerminate.sol
+++ b/protocol/contracts/libraries/Silo/LibGerminate.sol
@@ -95,18 +95,14 @@ library LibGerminate {
         // base roots are used if there are no roots in the silo.
         // root calculation is skipped if no deposits have been made
         // in the season.
-        uint128 finishedGerminatingStalk = s.sys.silo.unclaimedGerminating[germinationSeason].stalk;
-        uint128 rootsFromGerminatingStalk;
+        uint256 finishedGerminatingStalk = s.sys.silo.unclaimedGerminating[germinationSeason].stalk;
+        uint256 rootsFromGerminatingStalk;
         if (s.sys.silo.roots == 0) {
-            rootsFromGerminatingStalk = finishedGerminatingStalk.mul(uint128(C.getRootsBase()));
+            rootsFromGerminatingStalk = finishedGerminatingStalk.mul(C.getRootsBase());
         } else if (s.sys.silo.unclaimedGerminating[germinationSeason].stalk > 0) {
-            rootsFromGerminatingStalk = s
-                .sys
-                .silo
-                .roots
-                .mul(finishedGerminatingStalk)
-                .div(s.sys.silo.stalk)
-                .toUint128();
+            rootsFromGerminatingStalk = s.sys.silo.roots.mul(finishedGerminatingStalk).div(
+                s.sys.silo.stalk
+            );
         }
         s.sys.silo.unclaimedGerminating[germinationSeason].roots = rootsFromGerminatingStalk;
         // increment total stalk and roots based on unclaimed values.
@@ -139,7 +135,6 @@ library LibGerminate {
         }
 
         // emit change in total germinating stalk.
-        // safecast not needed as finishedGerminatingStalk is initially a uint128.
         emit TotalGerminatingStalkChanged(
             germinationSeason,
             -int256(uint256(finishedGerminatingStalk))
@@ -171,15 +166,15 @@ library LibGerminate {
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         bool lastUpdateOdd = isSeasonOdd(lastMowedSeason);
-        (uint128 firstStalk, uint128 secondStalk) = getGerminatingStalk(account, lastUpdateOdd);
-        uint128 totalRootsFromGermination;
-        uint128 germinatingStalk;
+        (uint256 firstStalk, uint256 secondStalk) = getGerminatingStalk(account, lastUpdateOdd);
+        uint256 totalRootsFromGermination;
+        uint256 germinatingStalk;
 
         // check to end germination for first stalk.
         // if last mowed season is greater or equal than (currentSeason - 1),
         // then the first stalk is still germinating.
         if (firstStalk > 0 && lastMowedSeason < currentSeason.sub(1)) {
-            (uint128 roots, GerminationSide germState) = claimGerminatingRoots(
+            (uint256 roots, GerminationSide germState) = claimGerminatingRoots(
                 account,
                 lastMowedSeason,
                 firstStalk,
@@ -196,7 +191,7 @@ library LibGerminate {
 
         // check to end germination for second stalk.
         if (secondStalk > 0) {
-            (uint128 roots, GerminationSide germState) = claimGerminatingRoots(
+            (uint256 roots, GerminationSide germState) = claimGerminatingRoots(
                 account,
                 lastMowedSeason.sub(1),
                 secondStalk,
@@ -237,9 +232,9 @@ library LibGerminate {
     function claimGerminatingRoots(
         address account,
         uint32 season,
-        uint128 stalk,
+        uint256 stalk,
         bool clearOdd
-    ) private returns (uint128 roots, GerminationSide germState) {
+    ) private returns (uint256 roots, GerminationSide germState) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         roots = calculateGerminatingRoots(season, stalk);
@@ -275,7 +270,7 @@ library LibGerminate {
     function calculateGerminatingRoots(
         uint32 season,
         uint256 stalk
-    ) private view returns (uint128 roots) {
+    ) private view returns (uint256 roots) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         // if the stalk is equal to the remaining unclaimed germinating stalk,
@@ -284,10 +279,9 @@ library LibGerminate {
             roots = s.sys.silo.unclaimedGerminating[season].roots;
         } else {
             // calculate the roots:
-            roots = uint256(stalk)
-                .mul(s.sys.silo.unclaimedGerminating[season].roots)
-                .div(s.sys.silo.unclaimedGerminating[season].stalk)
-                .toUint128();
+            roots = uint256(stalk).mul(s.sys.silo.unclaimedGerminating[season].roots).div(
+                s.sys.silo.unclaimedGerminating[season].stalk
+            );
         }
     }
 

--- a/protocol/contracts/libraries/Silo/LibLegacyWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibLegacyWhitelist.sol
@@ -40,7 +40,7 @@ library LibLegacyWhitelist {
     function whitelistToken(
         address token,
         bytes4 selector,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint32 stalkEarnedPerSeason
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();

--- a/protocol/contracts/libraries/Silo/LibSilo.sol
+++ b/protocol/contracts/libraries/Silo/LibSilo.sol
@@ -665,9 +665,7 @@ library LibSilo {
         int96 endStem,
         uint128 bdv
     ) internal pure returns (uint256) {
-        uint128 reward = uint128(uint96(endStem.sub(startStem))).mul(bdv).div(PRECISION);
-
-        return reward;
+        return uint256(uint96(endStem.sub(startStem))).mul(bdv);
     }
 
     /**

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -121,7 +121,7 @@ library LibWhitelist {
     function whitelistToken(
         address token,
         bytes4 selector,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint32 stalkEarnedPerSeason,
         bytes1 encodeType,
         bytes4 gaugePointSelector,
@@ -191,7 +191,7 @@ library LibWhitelist {
     function whitelistTokenWithExternalImplementation(
         address token,
         bytes4 selector,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint32 stalkEarnedPerSeason,
         bytes1 encodeType,
         uint128 gaugePoints,
@@ -510,7 +510,7 @@ library LibWhitelist {
     function verifyWhitelistStatus(
         address token,
         bytes4 selector,
-        uint32 stalkIssuedPerBdv
+        uint48 stalkIssuedPerBdv
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 

--- a/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -381,21 +381,22 @@ contract MockSeasonFacet is SeasonFacet {
 
         ds.supportedInterfaces[type(IERC1155).interfaceId] = true;
         ds.supportedInterfaces[0x0e89341c] = true;
+        uint48 stalk = 1e10;
 
         uint24 currentSeason = uint24(s.sys.season.current);
 
         s.sys.silo.assetSettings[C.BEAN].stalkEarnedPerSeason = 2 * 1e6;
-        s.sys.silo.assetSettings[C.BEAN].stalkIssuedPerBdv = 10000;
+        s.sys.silo.assetSettings[C.BEAN].stalkIssuedPerBdv = stalk;
         s.sys.silo.assetSettings[C.BEAN].milestoneSeason = currentSeason;
         s.sys.silo.assetSettings[C.BEAN].milestoneStem = 0;
 
         s.sys.silo.assetSettings[C.UNRIPE_BEAN].stalkEarnedPerSeason = 2 * 1e6;
-        s.sys.silo.assetSettings[C.UNRIPE_BEAN].stalkIssuedPerBdv = 10000;
+        s.sys.silo.assetSettings[C.UNRIPE_BEAN].stalkIssuedPerBdv = stalk;
         s.sys.silo.assetSettings[C.UNRIPE_BEAN].milestoneSeason = currentSeason;
         s.sys.silo.assetSettings[C.UNRIPE_BEAN].milestoneStem = 0;
 
         s.sys.silo.assetSettings[address(C.unripeLP())].stalkEarnedPerSeason = 2 * 1e6;
-        s.sys.silo.assetSettings[address(C.unripeLP())].stalkIssuedPerBdv = 10000;
+        s.sys.silo.assetSettings[address(C.unripeLP())].stalkIssuedPerBdv = stalk;
         s.sys.silo.assetSettings[address(C.unripeLP())].milestoneSeason = currentSeason;
         s.sys.silo.assetSettings[address(C.unripeLP())].milestoneStem = 0;
 

--- a/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSiloFacet.sol
@@ -205,8 +205,8 @@ contract MockSiloFacet is SiloFacet {
     function mockWhitelistToken(
         address token,
         bytes4 selector,
-        uint16 stalkIssuedPerBdv,
-        uint24 stalkEarnedPerSeason
+        uint48 stalkIssuedPerBdv,
+        uint32 stalkEarnedPerSeason
     ) external {
         s.sys.silo.assetSettings[token].selector = selector;
         s.sys.silo.assetSettings[token].stalkIssuedPerBdv = stalkIssuedPerBdv; //previously just called "stalk"

--- a/protocol/test/foundry/farm/PipelineConvert.t.sol
+++ b/protocol/test/foundry/farm/PipelineConvert.t.sol
@@ -58,7 +58,7 @@ contract PipelineConvertTest is TestHelper {
     address[] farmers;
 
     uint256 constant MAX_UINT256 = type(uint256).max;
-    uint256 constant BDV_TO_STALK = 1e4;
+    uint256 constant BDV_TO_STALK = 1e10;
     address constant EXTRACT_VALUE_ADDRESS = 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045;
 
     bytes constant noData = abi.encode(0);

--- a/protocol/test/foundry/invariantTesting/BeanstalkHandler.sol
+++ b/protocol/test/foundry/invariantTesting/BeanstalkHandler.sol
@@ -43,13 +43,17 @@ contract BeanstalkHandler is Test {
         // tokens.push(C.BEAN_WSTETH_WELL); // is not mock erc20
     }
 
-    function deposit(uint16 userSeed, uint16 tokenSeed, uint256 amount) public useUser(userSeed) useToken(tokenSeed) {
-        amount = bound(amount, 1, type(uint96).max);
+    function deposit(
+        uint16 userSeed,
+        uint16 tokenSeed,
+        uint256 amount
+    ) public useUser(userSeed) useToken(tokenSeed) {
+        amount = bound(amount, 1, type(uint88).max);
 
         MockToken(token).mint(user, amount);
         bean.approve(address(bs), type(uint256).max);
 
-        (,, int96 stem) = bs.deposit(token, amount, 0);
+        (, , int96 stem) = bs.deposit(token, amount, 0);
 
         depositSumsTotal[token] += amount;
         depositSumsUser[user][token] += amount;
@@ -61,18 +65,25 @@ contract BeanstalkHandler is Test {
         userDeposits[user][token].push(stem);
     }
 
-    function withdraw(uint16 userSeed, uint16 tokenSeed, uint256 stemSeed, uint256 amount) public useUser(userSeed) useToken(tokenSeed) {
+    function withdraw(
+        uint16 userSeed,
+        uint16 tokenSeed,
+        uint256 stemSeed,
+        uint256 amount
+    ) public useUser(userSeed) useToken(tokenSeed) {
         // vm.assume(userDeposits[user][token].length > 0);
         if (userDeposits[user][token].length == 0) return;
         uint256 stemIndex = bound(stemSeed, 0, userDeposits[user][token].length - 1);
         int96 stem = userDeposits[user][token][stemIndex];
-        (uint256 depositAmount,) = bs.getDeposit(user, token, stem);
+        (uint256 depositAmount, ) = bs.getDeposit(user, token, stem);
         amount = bound(amount, 1, depositAmount);
 
         bs.withdrawDeposit(token, stem, amount, 0);
 
         if (amount == depositAmount) {
-            userDeposits[user][token][stemIndex] = userDeposits[user][token][userDeposits[user][token].length - 1];
+            userDeposits[user][token][stemIndex] = userDeposits[user][token][
+                userDeposits[user][token].length - 1
+            ];
             userDeposits[user][token].pop();
         }
 

--- a/protocol/test/foundry/silo/Whitelist.t.sol
+++ b/protocol/test/foundry/silo/Whitelist.t.sol
@@ -180,7 +180,7 @@ contract WhitelistTest is TestHelper {
      */
     function test_whitelistTokenBasic(
         uint32 stalkEarnedPerSeason,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint128 gaugePoints,
         uint64 optimalPercentDepositedBdv
     ) public prank(BEANSTALK) {
@@ -234,7 +234,7 @@ contract WhitelistTest is TestHelper {
      */
     function test_whitelistTokenWithEncodeType(
         uint32 stalkEarnedPerSeason,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint8 encodeType,
         uint128 gaugePoints,
         uint64 optimalPercentDepositedBdv
@@ -299,7 +299,7 @@ contract WhitelistTest is TestHelper {
         emit DewhitelistToken(token);
         bs.dewhitelistToken(token);
 
-        verifyWhitelistState(token, 0, 1, 10000, 0, 0, 0, 0, false, false, false);
+        verifyWhitelistState(token, 0, 1, 1e10, 0, 0, 0, 0, false, false, false);
         // verify that the milestone stem and season are updated and are kept, as
         // existing deposits are still valid.
         IMockFBeanstalk.AssetSettings memory newSS = bs.tokenSettings(token);
@@ -309,7 +309,7 @@ contract WhitelistTest is TestHelper {
 
     function test_whitelistTokenWithExternalImplementation(
         uint32 stalkEarnedPerSeason,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         uint128 gaugePoints,
         uint64 optimalPercentDepositedBdv
     ) public prank(BEANSTALK) {
@@ -362,7 +362,7 @@ contract WhitelistTest is TestHelper {
         address token,
         bytes4 bdvSelector,
         uint32 stalkEarnedPerSeason,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         bytes4 gaugePointSelector,
         bytes4 liquidityWeightSelector,
         uint128 gaugePoints,
@@ -388,7 +388,7 @@ contract WhitelistTest is TestHelper {
         address token,
         bytes4 bdvSelector,
         uint32 stalkEarnedPerSeason,
-        uint32 stalkIssuedPerBdv,
+        uint48 stalkIssuedPerBdv,
         bytes4 gaugePointSelector,
         bytes4 liquidityWeightSelector,
         uint128 gaugePoints,

--- a/protocol/test/foundry/sun/Flood.t.sol
+++ b/protocol/test/foundry/sun/Flood.t.sol
@@ -81,12 +81,12 @@ contract FloodTest is TestHelper {
         assertEq(s.rainStart, s.current);
         assertTrue(s.raining);
         assertEq(rain.pods, bs.totalPods(bs.activeField()));
-        assertEq(rain.roots, 20008000e18);
+        assertEq(rain.roots, 20008000e24);
 
         SiloGettersFacet.AccountSeasonOfPlenty memory sop = siloGetters.balanceOfSop(users[1]);
 
         assertEq(sop.lastRain, s.rainStart);
-        assertEq(sop.roots, 10004000e18);
+        assertEq(sop.roots, 10004000e24);
     }
 
     function testStopsRaining() public {
@@ -179,7 +179,7 @@ contract FloodTest is TestHelper {
         SiloGettersFacet.AccountSeasonOfPlenty memory userSop = siloGetters.balanceOfSop(users[1]);
         assertEq(userSop.lastRain, 6);
         assertEq(userSop.lastSop, 6);
-        assertEq(userSop.roots, 10004000e18);
+        assertEq(userSop.roots, 10004000e24);
 
         assertGt(userSop.farmerSops.length, 0);
 
@@ -195,7 +195,7 @@ contract FloodTest is TestHelper {
         userSop = siloGetters.balanceOfSop(users[2]);
         assertEq(userSop.lastRain, 6);
         assertEq(userSop.lastSop, 6);
-        assertEq(userSop.roots, 10004000e18);
+        assertEq(userSop.roots, 10004000e24);
         assertEq(userSop.farmerSops[0].well, sopWell);
         assertEq(userSop.farmerSops[0].wellsPlenty.plenty, userCalcPlenty);
         assertEq(userSop.farmerSops[0].wellsPlenty.plentyPerRoot, userCalcPlentyPerRoot);
@@ -253,7 +253,7 @@ contract FloodTest is TestHelper {
 
         assertEq(userSop.lastRain, 9);
         assertEq(userSop.lastSop, 9);
-        assertEq(userSop.roots, 10004000e18);
+        assertEq(userSop.roots, 10004000e24);
         assertEq(userSop.farmerSops[0].well, sopWell);
         assertEq(userSop.farmerSops[0].wellsPlenty.plenty, 38544532214605630101);
         assertEq(userSop.farmerSops[0].wellsPlenty.plentyPerRoot, 3852912056637907847);
@@ -267,7 +267,7 @@ contract FloodTest is TestHelper {
         userSop = siloGetters.balanceOfSop(users[2]);
         assertEq(userSop.lastRain, 9);
         assertEq(userSop.lastSop, 9);
-        assertEq(userSop.roots, 10006000000000000000000000);
+        assertEq(userSop.roots, 10006000e24);
         assertEq(userSop.farmerSops[0].wellsPlenty.plenty, 38547120970363278477);
         assertEq(userSop.farmerSops[0].wellsPlenty.plentyPerRoot, 3852912056637907847);
     }
@@ -317,7 +317,7 @@ contract FloodTest is TestHelper {
 
         assertEq(userSop.lastRain, 6);
         assertEq(userSop.lastSop, 6);
-        assertEq(userSop.roots, 10004000e18);
+        assertEq(userSop.roots, 10004000e24);
         assertEq(userSop.farmerSops[0].wellsPlenty.plenty, 25595575914848452999);
         assertEq(userSop.farmerSops[0].wellsPlenty.plentyPerRoot, 2558534177813719812);
 
@@ -330,7 +330,7 @@ contract FloodTest is TestHelper {
         userSop = siloGetters.balanceOfSop(users[2]);
         assertEq(userSop.lastRain, 6);
         assertEq(userSop.lastSop, 6);
-        assertEq(userSop.roots, 10004000e18);
+        assertEq(userSop.roots, 10004000e24);
         assertEq(userSop.farmerSops[0].wellsPlenty.plenty, 25595575914848452999);
         assertEq(userSop.farmerSops[0].wellsPlenty.plentyPerRoot, 2558534177813719812);
 

--- a/protocol/test/foundry/utils/TestHelper.sol
+++ b/protocol/test/foundry/utils/TestHelper.sol
@@ -57,7 +57,7 @@ contract TestHelper is
     // The largest deposit that can occur on the first season.
     // Given the supply of beans should starts at 0,
     // this should never occur.
-    uint256 constant MAX_DEPOSIT_BOUND = 1.7e22; // 2 ** 128 / 2e16
+    uint256 constant MAX_DEPOSIT_BOUND = 1.7e16; // 2 ** 128 / 2e16
 
     struct initERC20params {
         address targetAddr;

--- a/protocol/test/hardhat/ConvertUnripe.test.js
+++ b/protocol/test/hardhat/ConvertUnripe.test.js
@@ -85,7 +85,7 @@ describe("Unripe Convert", function () {
     await revertToSnapshot(snapshotId);
   });
 
-  describe("calclates beans to peg", async function () {
+  describe("calculates beans to peg", async function () {
     it("p > 1", async function () {
       await this.well
         .connect(user)
@@ -105,7 +105,7 @@ describe("Unripe Convert", function () {
     });
   });
 
-  describe("calclates lp to peg", async function () {
+  describe("calculates lp to peg", async function () {
     it("p > 1", async function () {
       await this.well
         .connect(user)
@@ -193,14 +193,16 @@ describe("Unripe Convert", function () {
         );
         expect(await beanstalk.getGerminatingTotalDepositedBdv(this.unripeLP.address)).to.eq(bdv);
 
-        expect(await beanstalk.totalStalk()).to.eq("1000000000400");
-        expect(await beanstalk.getTotalGerminatingStalk()).to.eq(bdv.mul("10000"));
+        expect(await beanstalk.totalStalk()).to.eq("1000000000400000000");
+        expect(await beanstalk.getTotalGerminatingStalk()).to.eq(bdv.mul("10000000000"));
       });
 
       it("properly updates user values", async function () {
         const bdv = await beanstalk.bdv(this.unripeLP.address, "4711829");
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq("1000000000400");
-        expect(await beanstalk.balanceOfGerminatingStalk(user.address)).to.eq(bdv.mul("10000"));
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq("1000000000400000000");
+        expect(await beanstalk.balanceOfGerminatingStalk(user.address)).to.eq(
+          bdv.mul("10000000000")
+        );
       });
 
       it("properly updates user deposits", async function () {
@@ -286,17 +288,12 @@ describe("Unripe Convert", function () {
 
       it("properly updates total values", async function () {
         const bdv = await beanstalk.bdv(this.unripeBean.address, "636776401");
-        // const oldBdv = await beanstalk.bdv(this.unripeLP.address, to6('3'))
 
-        expect(await beanstalk.getTotalDeposited(this.unripeBean.address)).to.eq("0");
-        expect(await beanstalk.getGerminatingTotalDeposited(this.unripeBean.address)).to.eq(
-          "636776401"
-        );
+        expect(await beanstalk.getTotalDeposited(this.unripeBean.address)).to.eq("636776401");
+        expect(await beanstalk.getGerminatingTotalDeposited(this.unripeBean.address)).to.eq("0");
 
-        expect(await beanstalk.getTotalDepositedBdv(this.unripeBean.address)).to.eq("0");
-        expect(await beanstalk.getGerminatingTotalDepositedBdv(this.unripeBean.address)).to.eq(
-          189738509
-        );
+        expect(await beanstalk.getTotalDepositedBdv(this.unripeBean.address)).to.eq("189738509");
+        expect(await beanstalk.getGerminatingTotalDepositedBdv(this.unripeBean.address)).to.eq("0");
         expect(await beanstalk.getTotalDeposited(this.unripeLP.address)).to.eq(to6("0"));
         expect(await beanstalk.getGerminatingTotalDeposited(this.unripeLP.address)).to.eq(to6("0"));
 
@@ -306,15 +303,13 @@ describe("Unripe Convert", function () {
         );
 
         // 379 comes from grown stalk. (189738509/1e6 * 2)
-        expect(await beanstalk.totalStalk()).to.eq(379);
-        expect(await beanstalk.getTotalGerminatingStalk()).to.eq(1897385090000);
+        expect(await beanstalk.totalStalk()).to.eq(toStalk("189.7385090379477018"));
+        expect(await beanstalk.getTotalGerminatingStalk()).to.eq(0);
       });
 
       it("properly updates user values", async function () {
-        const bdv = await beanstalk.bdv(this.unripeBean.address, "636776401");
-        const oldBdv = await beanstalk.bdv(this.unripeLP.address, to6("3"));
-        expect(await beanstalk.balanceOfGerminatingStalk(user.address)).to.eq(1897385090000);
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(379);
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(toStalk("189.7385090379477018"));
+        expect(await beanstalk.balanceOfGerminatingStalk(user.address)).to.eq(0);
       });
     });
   });

--- a/protocol/test/hardhat/Field.test.js
+++ b/protocol/test/hardhat/Field.test.js
@@ -7,7 +7,7 @@ const { MAX_UINT32, MAX_UINT256 } = require("./utils/constants.js");
 const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot");
 const { getAllBeanstalkContracts } = require("../../utils/contracts");
 const {
-  initalizeUsersForToken,
+  initializeUsersForToken,
   endGermination,
   addMockUnderlying,
   endGerminationWithMockToken
@@ -30,7 +30,7 @@ describe("newField", function () {
     // `mockBeanstalk` has functions that are only available in the mockFacets.
     [beanstalk, mockBeanstalk] = await getAllBeanstalkContracts(this.diamond.address);
 
-    bean = await initalizeUsersForToken(BEAN, [user, user2], to6("10000"));
+    bean = await initializeUsersForToken(BEAN, [user, user2], to6("10000"));
   });
 
   beforeEach(async function () {
@@ -535,7 +535,7 @@ describe("twoField", function () {
     this.activeField = 1;
     mockBeanstalk.setActiveField(this.activeField, 1);
 
-    bean = await initalizeUsersForToken(BEAN, [user, user2], to6("10000"));
+    bean = await initializeUsersForToken(BEAN, [user, user2], to6("10000"));
   });
 
   beforeEach(async function () {

--- a/protocol/test/hardhat/Silo.test.js
+++ b/protocol/test/hardhat/Silo.test.js
@@ -5,7 +5,7 @@ const { EXTERNAL } = require("./utils/balances.js");
 const { to18, to6, toStalk, toBN } = require("./utils/helpers.js");
 const { BEAN, ZERO_ADDRESS } = require("./utils/constants");
 const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot");
-const { initalizeUsersForToken, endGermination } = require("./utils/testHelpers.js");
+const { initializeUsersForToken, endGermination } = require("./utils/testHelpers.js");
 const axios = require("axios");
 const fs = require("fs");
 const { impersonateBeanWstethWell } = require("../../utils/well.js");
@@ -22,7 +22,7 @@ describe("newSilo", function () {
     [beanstalk, mockBeanstalk] = await getAllBeanstalkContracts(contracts.beanstalkDiamond.address);
 
     // initalize users - mint bean and approve beanstalk to use all beans.
-    await initalizeUsersForToken(BEAN, [user, user2, user3, user4], to6("10000"));
+    await initializeUsersForToken(BEAN, [user, user2, user3, user4], to6("10000"));
 
     // deposit 1000 beans from 2 users.
     await beanstalk.connect(user).deposit(BEAN, to6("1000"), EXTERNAL);
@@ -120,12 +120,14 @@ describe("newSilo", function () {
 
     it("properly updates the total balances", async function () {
       expect(await beanstalk.balanceOfStalk(user.address)).to.eq(toStalk("1050.6"));
-      expect(await beanstalk.balanceOfRoots(user.address)).to.eq("10005714285714285714285714");
+      expect(await beanstalk.balanceOfRoots(user.address)).to.eq(
+        "10005714285714285714285714285714"
+      );
     });
 
     it("properly updates the total balances", async function () {
-      expect(await beanstalk.totalStalk()).to.eq(to6("21012000"));
-      expect(await beanstalk.totalRoots()).to.eq("20011428571428571428571428");
+      expect(await beanstalk.totalStalk()).to.eq(to6("21012000000000"));
+      expect(await beanstalk.totalRoots()).to.eq("20011428571428571428571428571428");
     });
 
     it("properly emits events", async function () {
@@ -136,7 +138,9 @@ describe("newSilo", function () {
       await beanstalk.connect(user2).plant();
       expect(await beanstalk.totalEarnedBeans()).to.eq("0");
       expect(await beanstalk.balanceOfStalk(user2.address)).to.eq(toStalk("1050.6"));
-      expect(await beanstalk.balanceOfRoots(user2.address)).to.eq("10005714285714285714285714");
+      expect(await beanstalk.balanceOfRoots(user2.address)).to.eq(
+        "10005714285714285714285714285714"
+      );
     });
 
     it("user can withdraw earned beans", async function () {

--- a/protocol/test/hardhat/SiloEnroot.test.js
+++ b/protocol/test/hardhat/SiloEnroot.test.js
@@ -47,7 +47,7 @@ describe("Silo Enroot", function () {
     const contracts = await deploy((verbose = false), (mock = true), (reset = true));
     ownerAddress = contracts.account;
     this.diamond = contracts.beanstalkDiamond;
-    // `beanstalk` contains all functions that the regualar beanstalk has.
+    // `beanstalk` contains all functions that the regular beanstalk has.
     // `mockBeanstalk` has functions that are only available in the mockFacets.
     [beanstalk, mockBeanstalk] = await getAllBeanstalkContracts(this.diamond.address);
 
@@ -63,7 +63,7 @@ describe("Silo Enroot", function () {
     await mockBeanstalk.mockWhitelistToken(
       this.siloToken.address,
       mockBeanstalk.interface.getSighash("mockBDV(uint256 amount)"),
-      "10000",
+      "10000000000",
       "1"
     );
 
@@ -133,15 +133,13 @@ describe("Silo Enroot", function () {
       it("properly updates the total balances", async function () {
         expect(await beanstalk.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6("10"));
         expect(await beanstalk.getTotalDepositedBdv(UNRIPE_BEAN)).to.eq(
-          pruneToStalk(to6("10")).add(toStalk("0.5")).div("10000")
+          pruneToStalk(to6("10")).add(toStalk("0.0000005")).div("10000")
         );
-        expect(await beanstalk.totalStalk()).to.eq(pruneToStalk(to6("10")).add(toStalk("0.5")));
+        expect(await beanstalk.totalStalk()).to.eq(toStalk("2.355646"));
       });
 
       it("properly updates the user balance", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(
-          pruneToStalk(to6("10")).add(toStalk("0.5"))
-        );
+        expect(await beanstalk.totalStalk()).to.eq(toStalk("2.355646"));
         expect(await beanstalk.balanceOfGerminatingStalk(user.address)).to.eq("0");
       });
 
@@ -229,8 +227,8 @@ describe("Silo Enroot", function () {
 
         await mockBeanstalk.setStalkAndRoots(
           user.address,
-          "18558315646",
-          "18558315646000000000000"
+          "18558315646000000",
+          "18558315646000000000000000000"
         );
 
         this.result = await beanstalk
@@ -296,8 +294,8 @@ describe("Silo Enroot", function () {
           .depositAtStemAndBdv(UNRIPE_LP, to6("10"), stem1, "1855646", 0);
         await mockBeanstalk.setStalkAndRoots(
           user.address,
-          "37120342584",
-          "37120342584000000000000"
+          "37120342584000000",
+          "37120342584000000000000000000"
         );
         this.result = await beanstalk
           .connect(user)
@@ -306,11 +304,11 @@ describe("Silo Enroot", function () {
 
       it("properly updates the total balances", async function () {
         expect(await beanstalk.getTotalDeposited(UNRIPE_LP)).to.eq(to6("20"));
-        expect(await beanstalk.totalStalk()).to.eq(toStalk("234.7697275564"));
+        expect(await beanstalk.totalStalk()).to.eq(toStalk("234.7697275564000000"));
       });
 
       it("properly updates the user balance", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(toStalk("234.7697275564"));
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(toStalk("234.7697275564000000"));
       });
 
       it("properly updates the crate", async function () {

--- a/protocol/test/hardhat/SiloToken.test.js
+++ b/protocol/test/hardhat/SiloToken.test.js
@@ -12,7 +12,7 @@ const { BEAN, UNRIPE_LP, UNRIPE_BEAN, ZERO_BYTES, MAX_UINT256 } = require("./uti
 const { to18, to6, toStalk } = require("./utils/helpers.js");
 const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot");
 const {
-  initalizeUsersForToken,
+  initializeUsersForToken,
   endGermination,
   addMockUnderlying,
   endGerminationWithMockToken
@@ -52,14 +52,14 @@ describe("New Silo Token", function () {
     await mockBeanstalk.mockWhitelistToken(
       siloToken.address,
       mockBeanstalk.interface.getSighash("mockBDV(uint256 amount)"),
-      "10000",
+      "10000000000",
       1e6 //aka "1 seed"
     );
 
     // Needed to appease invariants when underlying asset of urBean != Bean.
     await mockBeanstalk.removeWhitelistStatus(BEAN);
 
-    await initalizeUsersForToken(
+    await initializeUsersForToken(
       siloToken.address,
       [user, user2, owner, flashLoanExploiter],
       to18("100000000000")
@@ -104,11 +104,11 @@ describe("New Silo Token", function () {
         expect(await beanstalk.getGerminatingTotalDeposited(siloToken.address)).to.eq("0");
         expect(await beanstalk.getTotalDepositedBdv(siloToken.address)).to.eq("1000");
         expect(await beanstalk.getGerminatingTotalDepositedBdv(siloToken.address)).to.eq("0");
-        expect(await beanstalk.totalStalk()).to.eq("10000000");
+        expect(await beanstalk.totalStalk()).to.eq("10000000000000");
       });
 
       it("properly updates the user balance", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq("10000000");
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq("10000000000000");
       });
 
       it("properly adds the crate", async function () {
@@ -132,14 +132,14 @@ describe("New Silo Token", function () {
         // deposit has grown 2 seeds worth of stalk, as 2 seasons has elasped.
         expect(
           await beanstalk.grownStalkForDeposit(user.address, siloToken.address, depositStem)
-        ).to.eq("2000");
+        ).to.eq("2000000000");
 
         // verify the function changes after a season has elapsed.
         await mockBeanstalk.lightSunrise();
 
         expect(
           await beanstalk.grownStalkForDeposit(user.address, siloToken.address, depositStem)
-        ).to.eq("3000");
+        ).to.eq("3000000000");
       });
     });
 
@@ -156,11 +156,11 @@ describe("New Silo Token", function () {
         expect(await beanstalk.getGerminatingTotalDeposited(siloToken.address)).to.eq("0");
         expect(await beanstalk.getTotalDepositedBdv(siloToken.address)).to.eq("2000");
         expect(await beanstalk.getGerminatingTotalDepositedBdv(siloToken.address)).to.eq("0");
-        expect(await beanstalk.totalStalk()).to.eq("20000000");
+        expect(await beanstalk.totalStalk()).to.eq("20000000000000");
       });
 
       it("properly updates the user balance", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq("20000000");
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq("20000000000000");
       });
 
       it("properly adds the crate", async function () {
@@ -185,14 +185,14 @@ describe("New Silo Token", function () {
         expect(await beanstalk.getGerminatingTotalDeposited(siloToken.address)).to.eq("0");
         expect(await beanstalk.getTotalDepositedBdv(siloToken.address)).to.eq("2000");
         expect(await beanstalk.getGerminatingTotalDepositedBdv(siloToken.address)).to.eq("0");
-        expect(await beanstalk.totalStalk()).to.eq("20000000");
+        expect(await beanstalk.totalStalk()).to.eq("20000000000000");
       });
 
       it("properly updates the user balance", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq("10000000");
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq("10000000000000");
       });
       it("properly updates the user2 balance", async function () {
-        expect(await beanstalk.balanceOfStalk(user2.address)).to.eq("10000000");
+        expect(await beanstalk.balanceOfStalk(user2.address)).to.eq("10000000000000");
       });
 
       it("properly adds the crate", async function () {
@@ -278,13 +278,13 @@ describe("New Silo Token", function () {
           expect(await beanstalk.totalStalk()).to.eq("0");
           expect(
             (await beanstalk.getGerminatingStalkAndRootsForSeason(await beanstalk.season()))[0]
-          ).to.eq("5000000");
+          ).to.eq("5000000000000");
         });
 
         it("properly updates the user balance", async function () {
           // user should not have any stalk, but should have germinating stalk.
           expect(await beanstalk.balanceOfStalk(user.address)).to.eq("0");
-          expect(await beanstalk.balanceOfGerminatingStalk(user.address)).to.eq("5000000");
+          expect(await beanstalk.balanceOfGerminatingStalk(user.address)).to.eq("5000000000000");
           expect((await siloToken.balanceOf(user.address)).sub(userBalanceBefore)).to.eq("500");
         });
 
@@ -320,19 +320,19 @@ describe("New Silo Token", function () {
           expect(await beanstalk.getTotalDepositedBdv(siloToken.address)).to.eq("0");
           expect(await beanstalk.getGerminatingTotalDeposited(siloToken.address)).to.eq("500");
           expect(await beanstalk.getGerminatingTotalDepositedBdv(siloToken.address)).to.eq("500");
-          expect(await beanstalk.totalStalk()).to.eq("500");
+          expect(await beanstalk.totalStalk()).to.eq("500000000");
           expect(
             (
               await beanstalk.getGerminatingStalkAndRootsForSeason(
                 toBN(await beanstalk.season()).sub("1")
               )
             )[0]
-          ).to.eq("5000000");
+          ).to.eq("5000000000000");
         });
         it("properly updates the user balance", async function () {
           // the user should have 500 microStalk, and 5e6 germinating stalk.
-          expect(await beanstalk.balanceOfStalk(user.address)).to.eq("500");
-          expect(await beanstalk.balanceOfGerminatingStalk(user.address)).to.eq("5000000");
+          expect(await beanstalk.balanceOfStalk(user.address)).to.eq("500000000");
+          expect(await beanstalk.balanceOfGerminatingStalk(user.address)).to.eq("5000000000000");
           expect((await siloToken.balanceOf(user.address)).sub(userBalanceBefore)).to.eq("1500");
         });
         it("properly removes the crate", async function () {
@@ -467,7 +467,7 @@ describe("New Silo Token", function () {
       });
 
       it("updates users stalk", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.be.equal("500100");
+        expect(await beanstalk.balanceOfStalk(user.address)).to.be.equal("500100000000");
       });
 
       it("add the deposit to the recipient", async function () {
@@ -477,7 +477,7 @@ describe("New Silo Token", function () {
       });
 
       it("updates users stalk", async function () {
-        expect(await beanstalk.balanceOfStalk(user2.address)).to.be.equal("500100");
+        expect(await beanstalk.balanceOfStalk(user2.address)).to.be.equal("500100000000");
       });
 
       it("totalStalk is unchanged", async function () {
@@ -575,7 +575,7 @@ describe("New Silo Token", function () {
       it("updates users stalk and seeds", async function () {
         // 3 seasons have passed for 1 deposit and 2 season for the other. (500 total stalk)
         // (300 * 50%) + (200 * 75%) = 300
-        expect(await beanstalk.balanceOfStalk(user.address)).to.be.equal("1250300");
+        expect(await beanstalk.balanceOfStalk(user.address)).to.be.equal("1250300000000");
       });
 
       it("add the deposit to the recipient", async function () {
@@ -591,11 +591,11 @@ describe("New Silo Token", function () {
       it("updates users stalk and seeds", async function () {
         // 3 seasons have passed for 1 deposit and 2 season for the other. (500 total stalk)
         // (300 * 50%) + (200 * 25%) = 200
-        expect(await beanstalk.balanceOfStalk(user2.address)).to.be.equal("750200");
+        expect(await beanstalk.balanceOfStalk(user2.address)).to.be.equal("750200000000");
       });
 
       it("updates total stalk and seeds", async function () {
-        expect(await beanstalk.totalStalk()).to.be.equal("2000500");
+        expect(await beanstalk.totalStalk()).to.be.equal("2000500000000");
       });
     });
 
@@ -620,7 +620,7 @@ describe("New Silo Token", function () {
       });
 
       it("updates users stalk and seeds", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.be.equal("500100");
+        expect(await beanstalk.balanceOfStalk(user.address)).to.be.equal("500100000000");
       });
 
       it("add the deposit to the recipient", async function () {
@@ -630,11 +630,11 @@ describe("New Silo Token", function () {
       });
 
       it("updates users stalk and seeds", async function () {
-        expect(await beanstalk.balanceOfStalk(user2.address)).to.be.equal("500100");
+        expect(await beanstalk.balanceOfStalk(user2.address)).to.be.equal("500100000000");
       });
 
       it("updates total stalk and seeds", async function () {
-        expect(await beanstalk.totalStalk()).to.be.equal("1000200");
+        expect(await beanstalk.totalStalk()).to.be.equal("1000200000000");
       });
 
       it("properly updates users token allowance", async function () {
@@ -690,11 +690,11 @@ describe("New Silo Token", function () {
       });
 
       it("updates users stalk and seeds", async function () {
-        expect(await beanstalk.balanceOfStalk(user2.address)).to.be.equal("1000200");
+        expect(await beanstalk.balanceOfStalk(user2.address)).to.be.equal("1000200000000");
       });
 
       it("updates total stalk and seeds", async function () {
-        expect(await beanstalk.totalStalk()).to.be.equal("1000200");
+        expect(await beanstalk.totalStalk()).to.be.equal("1000200000000");
       });
 
       it("properly updates users token allowance", async function () {
@@ -742,7 +742,7 @@ describe("New Silo Token", function () {
       });
 
       it("updates users stalk and seeds", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.be.equal("1250300");
+        expect(await beanstalk.balanceOfStalk(user.address)).to.be.equal("1250300000000");
       });
 
       it("add the deposit to the recipient", async function () {
@@ -755,11 +755,11 @@ describe("New Silo Token", function () {
       });
 
       it("updates users stalk and seeds", async function () {
-        expect(await beanstalk.balanceOfStalk(user2.address)).to.be.equal("750200");
+        expect(await beanstalk.balanceOfStalk(user2.address)).to.be.equal("750200000000");
       });
 
       it("updates total stalk and seeds", async function () {
-        expect(await beanstalk.totalStalk()).to.be.equal("2000500");
+        expect(await beanstalk.totalStalk()).to.be.equal("2000500000000");
       });
 
       it("properly updates users token allowance", async function () {
@@ -847,11 +847,13 @@ describe("New Silo Token", function () {
 
       it("properly updates the total balances", async function () {
         expect(await beanstalk.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6("10"));
-        expect(await beanstalk.totalStalk()).to.eq(toStalk("1.5").add(toBN("3")));
+        expect(await beanstalk.totalStalk()).to.eq(toStalk("1.5").add(toBN("3000000")));
       });
 
       it("properly updates the user balance", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(toStalk("1.5").add(toBN("3")));
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(
+          toStalk("1.5").add(toBN("3000000"))
+        );
       });
 
       it("properly updates the crate", async function () {
@@ -896,11 +898,13 @@ describe("New Silo Token", function () {
 
       it("properly updates the total balances", async function () {
         expect(await beanstalk.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6("10"));
-        expect(await beanstalk.totalStalk()).to.eq(toStalk("2").add(toBN("4")));
+        expect(await beanstalk.totalStalk()).to.eq(toStalk("2").add(toBN("4000000")));
       });
 
       it("properly updates the user balance", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(toStalk("2").add(toBN("4")));
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(
+          toStalk("2").add(toBN("4000000"))
+        );
       });
 
       it("properly removes the crate", async function () {
@@ -937,8 +941,10 @@ describe("New Silo Token", function () {
         // currently, there are 10,000 units underlying 100,000 beans (10% bdv)
         // depositing 10 urBeans should result in (0.1)*10 = 1 stalk.
         // note a micro stalk is incremented due to a min stalk requirement to grow stalk.
-        expect(await beanstalk.totalStalk()).to.eq(toStalk("2").add(toBN("1")));
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(toStalk("2").add(toBN("1")));
+        expect(await beanstalk.totalStalk()).to.eq(toStalk("2").add(toBN("1000000")));
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(
+          toStalk("2").add(toBN("1000000"))
+        );
 
         // add the underlying token, to increase the bdv of the unripe asset.
         // prev. unripeBeans had 10,000 units. Now it has 20,000 (20% bdv).
@@ -952,11 +958,13 @@ describe("New Silo Token", function () {
 
       it("properly updates the total balances", async function () {
         expect(await beanstalk.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6("20"));
-        expect(await beanstalk.totalStalk()).to.eq(toStalk("3").add(toBN("8")));
+        expect(await beanstalk.totalStalk()).to.eq(toStalk("3").add(toBN("7500000")));
       });
 
       it("properly updates the user balance", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(toStalk("3").add(toBN("8")));
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(
+          toStalk("3").add(toBN("7500000"))
+        );
       });
 
       it("properly removes the crate", async function () {
@@ -1005,8 +1013,10 @@ describe("New Silo Token", function () {
         expect(await beanstalk.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6("20"));
         // currently, there are 10,000 units underlying 100,000 beans (10% bdv)
         // depositing 10 urBeans should result in (0.1)*10 = 1 stalk.
-        expect(await beanstalk.totalStalk()).to.eq(toStalk("2").add(toBN("1")));
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(toStalk("2").add(toBN("1")));
+        expect(await beanstalk.totalStalk()).to.eq(toStalk("2").add(toBN("1000000")));
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(
+          toStalk("2").add(toBN("1000000"))
+        );
 
         // add the underlying token, to increase the bdv of the unripe asset.
         // prev. unripeBeans had 10,000 units. Now it has 20,000 (20% bdv).
@@ -1020,11 +1030,13 @@ describe("New Silo Token", function () {
 
       it("properly updates the total balances", async function () {
         expect(await beanstalk.getTotalDeposited(UNRIPE_BEAN)).to.eq(to6("20"));
-        expect(await beanstalk.totalStalk()).to.eq(toStalk("4").add(toBN("10")));
+        expect(await beanstalk.totalStalk()).to.eq(toStalk("4").add(toBN("10000000")));
       });
 
       it("properly updates the user balance", async function () {
-        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(toStalk("4").add(toBN("10")));
+        expect(await beanstalk.balanceOfStalk(user.address)).to.eq(
+          toStalk("4").add(toBN("10000000"))
+        );
       });
 
       it("properly removes the crate", async function () {

--- a/protocol/test/hardhat/utils/helpers.js
+++ b/protocol/test/hardhat/utils/helpers.js
@@ -19,7 +19,7 @@ async function getEthSpentOnGas(result) {
 }
 
 function toBean(amount) {
-  return ethers.utils.parseUnits(amount,6);
+  return ethers.utils.parseUnits(amount, 6);
 }
 
 function to6(amount) {
@@ -27,7 +27,7 @@ function to6(amount) {
 }
 
 function toStalk(amount) {
-  return ethers.utils.parseUnits(amount, 10);
+  return ethers.utils.parseUnits(amount, 16);
 }
 
 function toEther(amount) {

--- a/protocol/test/hardhat/utils/testHelpers.js
+++ b/protocol/test/hardhat/utils/testHelpers.js
@@ -12,12 +12,12 @@ const { to6, to18 } = require("./helpers");
 // general beanstalk test helpers to assist with testing.
 
 /**
- * @notice initalizes the array of users.
+ * @notice initializes the array of users.
  * @dev
  * - approves beanstalk to use all beans.
  * - mints `amount` to `users`.
  */
-async function initalizeUsersForToken(tokenAddress, users, amount) {
+async function initializeUsersForToken(tokenAddress, users, amount) {
   const token = await ethers.getContractAt("MockToken", tokenAddress);
   for (let i = 0; i < users.length; i++) {
     await token.connect(users[i]).approve(BEANSTALK, MAX_UINT256);
@@ -27,8 +27,8 @@ async function initalizeUsersForToken(tokenAddress, users, amount) {
 }
 
 /**
- * ends germination for the beanstalk, by elasping 2 seasons.
- * @dev mockBeanstalk should be initalized prior to calling this function.
+ * ends germination for the beanstalk, by elapsing 2 seasons.
+ * @dev mockBeanstalk should be initialized prior to calling this function.
  */
 async function endGermination() {
   await mockBeanstalk.siloSunrise(to6("0"));
@@ -36,9 +36,9 @@ async function endGermination() {
 }
 
 /**
- * ends germination for the beanstalk, by elasping 2 seasons.
+ * ends germination for the beanstalk, by elapsing 2 seasons.
  * Also ends total germination for a specific token.
- * @dev mockBeanstalk should be initalized prior to calling this function.
+ * @dev mockBeanstalk should be initialized prior to calling this function.
  */
 async function endGerminationWithMockToken(token) {
   await mockBeanstalk.siloSunrise(to6("0"));
@@ -88,5 +88,5 @@ async function setRecapitalizationParams(
 exports.addMockUnderlying = addMockUnderlying;
 exports.endGermination = endGermination;
 exports.endGerminationWithMockToken = endGerminationWithMockToken;
-exports.initalizeUsersForToken = initalizeUsersForToken;
+exports.initializeUsersForToken = initializeUsersForToken;
 exports.setRecapitalizationParams = setRecapitalizationParams;


### PR DESCRIPTION
The seed gauge update increased the precision of stems by 1e6. This introduced the ability for microStalk (fractions of 1 unit of stalk) to be deducted due to an integer division error.  By increasing the stalk precision by 1e6 (1 stalk = 1e16 stalk), this solves this issue. 