### PR TITLE
add TokenTransferred event

### DIFF
--- a/protocol/abi/Beanstalk.json
+++ b/protocol/abi/Beanstalk.json
@@ -2135,6 +2135,49 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum LibTransfer.From",
+        "name": "fromMode",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum LibTransfer.To",
+        "name": "toMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "TokenTransferred",
+    "type": "event"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -8344,6 +8387,170 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "beans",
+        "type": "uint256"
+      }
+    ],
+    "name": "Incentivization",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "secondsLate",
+        "type": "uint256"
+      }
+    ],
+    "name": "determineReward",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "deltaStalk",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "deltaRoots",
+        "type": "int256"
+      }
+    ],
+    "name": "TotalStalkChangedFromGermination",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "season",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "well",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "deltaB",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "cumulativeReserves",
+        "type": "bytes"
+      }
+    ],
+    "name": "WellOracle",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "well",
+        "type": "address"
+      }
+    ],
+    "name": "check",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "deltaB",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "RemoveWhitelistStatus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "season",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "gaugePoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "GaugePointChange",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newStalkPerBdvPerSeason",
+        "type": "uint256"
+      }
+    ],
+    "name": "UpdateAverageStalkPerBdvPerSeason",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "enum ShipmentRecipient",
         "name": "recipient",
         "type": "uint8"
@@ -8487,18 +8694,13 @@
         "internalType": "address",
         "name": "token",
         "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "lookback",
-        "type": "uint256"
       }
     ],
-    "name": "getTokenPriceFromExternal",
+    "name": "getTokenUsdPrice",
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "tokenPrice",
+        "name": "",
         "type": "uint256"
       }
     ],
@@ -8511,13 +8713,18 @@
         "internalType": "address",
         "name": "token",
         "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lookback",
+        "type": "uint256"
       }
     ],
-    "name": "getTokenUsdPrice",
+    "name": "getTokenUsdPriceFromExternal",
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "tokenUsd",
         "type": "uint256"
       }
     ],
@@ -8561,6 +8768,30 @@
       {
         "internalType": "uint256",
         "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lookback",
+        "type": "uint256"
+      }
+    ],
+    "name": "getUsdTokenPriceFromExternal",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "usdToken",
         "type": "uint256"
       }
     ],
@@ -9831,25 +10062,6 @@
       }
     ],
     "name": "BeanToMaxLpGpPerBdvRatioChange",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "beans",
-        "type": "uint256"
-      }
-    ],
-    "name": "Incentivization",
     "type": "event"
   },
   {

--- a/protocol/contracts/libraries/Token/LibTransfer.sol
+++ b/protocol/contracts/libraries/Token/LibTransfer.sol
@@ -15,6 +15,15 @@ library LibTransfer {
     using SafeERC20 for IERC20;
     using LibRedundantMath256 for uint256;
 
+    event TokenTransfered(
+        address indexed token,
+        address indexed sender,
+        address indexed recipient,
+        uint256 amount,
+        From fromMode,
+        To toMode
+    );
+
     enum From {
         EXTERNAL,
         INTERNAL,
@@ -41,6 +50,7 @@ library LibTransfer {
         }
         amount = receiveToken(token, amount, sender, fromMode);
         sendToken(token, amount, recipient, toMode);
+        emit TokenTransfered(address(token), sender, recipient, amount, fromMode, toMode);
         return amount;
     }
 

--- a/protocol/contracts/libraries/Token/LibTransfer.sol
+++ b/protocol/contracts/libraries/Token/LibTransfer.sol
@@ -15,7 +15,7 @@ library LibTransfer {
     using SafeERC20 for IERC20;
     using LibRedundantMath256 for uint256;
 
-    event TokenTransfered(
+    event TokenTransferred(
         address indexed token,
         address indexed sender,
         address indexed recipient,
@@ -50,7 +50,7 @@ library LibTransfer {
         }
         amount = receiveToken(token, amount, sender, fromMode);
         sendToken(token, amount, recipient, toMode);
-        emit TokenTransfered(address(token), sender, recipient, amount, fromMode, toMode);
+        emit TokenTransferred(address(token), sender, recipient, amount, fromMode, toMode);
         return amount;
     }
 

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -134,15 +134,14 @@ task("diamondABI", "Generates ABI file for diamond, includes all ABIs of facets"
     const files = glob.sync(pattern);
     if (module == "silo") {
       // Manually add in libraries that emit events
-      // files.push("contracts/libraries/LibIncentive.sol");
-      // files.push("contracts/libraries/Silo/LibWhitelist.sol");
-      // files.push("contracts/libraries/LibGauge.sol");
-      // files.push("contracts/libraries/Silo/LibGerminate.sol");
-      // files.push("contracts/libraries/Minting/LibWellMinting.sol");
-      // files.push("contracts/libraries/Silo/LibWhitelistedTokens.sol");
-      // files.push("contracts/libraries/Silo/LibWhitelist.sol");
-      // files.push("contracts/libraries/LibGauge.sol");
+      files.push("contracts/libraries/LibIncentive.sol");
+      files.push("contracts/libraries/Silo/LibGerminate.sol");
+      files.push("contracts/libraries/Minting/LibWellMinting.sol");
+      files.push("contracts/libraries/Silo/LibWhitelistedTokens.sol");
+      files.push("contracts/libraries/Silo/LibWhitelist.sol");
+      files.push("contracts/libraries/LibGauge.sol");
       files.push("contracts/libraries/LibShipping.sol");
+      files.push("contracts/libraries/Token/LibTransfer.sol");
     }
     files.forEach((file) => {
       const facetName = getFacetName(file);

--- a/protocol/test/hardhat/Token.test.js
+++ b/protocol/test/hardhat/Token.test.js
@@ -173,6 +173,16 @@ describe("Token", function () {
         await expect(this.result)
           .to.emit(beanstalk, "InternalBalanceChanged")
           .withArgs(this.recipient.address, this.token.address, "200");
+        await expect(this.result)
+          .to.emit(beanstalk, "TokenTransferred")
+          .withArgs(
+            this.token.address,
+            this.user.address,
+            this.recipient.address,
+            "200",
+            EXTERNAL,
+            INTERNAL
+          );
       });
     });
 
@@ -212,6 +222,16 @@ describe("Token", function () {
         await expect(this.result)
           .to.emit(beanstalk, "InternalBalanceChanged")
           .withArgs(this.recipient.address, this.token.address, "200");
+        await expect(this.result)
+          .to.emit(beanstalk, "TokenTransferred")
+          .withArgs(
+            this.token.address,
+            this.user.address,
+            this.recipient.address,
+            "200",
+            INTERNAL,
+            INTERNAL
+          );
       });
 
       it("internal tolerant", async function () {
@@ -245,6 +265,16 @@ describe("Token", function () {
         await expect(this.result)
           .to.emit(beanstalk, "InternalBalanceChanged")
           .withArgs(this.recipient.address, this.token.address, "300");
+        await expect(this.result)
+          .to.emit(beanstalk, "TokenTransferred")
+          .withArgs(
+            this.token.address,
+            this.user.address,
+            this.recipient.address,
+            "200",
+            INTERNAL_EXTERNAL,
+            INTERNAL
+          );
       });
 
       it("internal + external", async function () {
@@ -278,6 +308,16 @@ describe("Token", function () {
         await expect(this.result)
           .to.emit(beanstalk, "InternalBalanceChanged")
           .withArgs(this.recipient.address, this.token.address, "200");
+        await expect(this.result)
+          .to.emit(beanstalk, "TokenTransferred")
+          .withArgs(
+            this.token.address,
+            this.user.address,
+            this.recipient.address,
+            "250",
+            INTERNAL_TOLERANT,
+            INTERNAL
+          );
       });
 
       it("0 internal tolerant", async function () {
@@ -328,6 +368,16 @@ describe("Token", function () {
         await expect(this.result)
           .to.emit(beanstalk, "InternalBalanceChanged")
           .withArgs(this.user.address, this.token.address, "-200");
+        await expect(this.result)
+          .to.emit(beanstalk, "TokenTransferred")
+          .withArgs(
+            this.token.address,
+            this.user.address,
+            this.recipient.address,
+            "200",
+            INTERNAL,
+            EXTERNAL
+          );
       });
     });
   });
@@ -365,6 +415,16 @@ describe("Token", function () {
         await expect(this.result)
           .to.emit(beanstalk, "InternalBalanceChanged")
           .withArgs(this.user.address, this.token.address, "-200");
+        await expect(this.result)
+          .to.emit(beanstalk, "TokenTransferred")
+          .withArgs(
+            this.token.address,
+            this.user.address,
+            this.recipient.address,
+            "250",
+            INTERNAL,
+            EXTERNAL
+          );
       });
 
       it("to internal", async function () {
@@ -392,6 +452,16 @@ describe("Token", function () {
         await expect(this.result)
           .to.emit(beanstalk, "InternalBalanceChanged")
           .withArgs(this.user.address, this.token.address, "-200");
+        await expect(this.result)
+          .to.emit(beanstalk, "TokenTransferred")
+          .withArgs(
+            this.token.address,
+            this.user.address,
+            this.recipient.address,
+            "250",
+            INTERNAL,
+            INTERNAL
+          );
       });
     });
 
@@ -458,6 +528,16 @@ describe("Token", function () {
           await expect(this.result)
             .to.emit(beanstalk, "InternalBalanceChanged")
             .withArgs(this.user.address, this.token.address, "-200");
+          await expect(this.result)
+            .to.emit(beanstalk, "TokenTransferred")
+            .withArgs(
+              this.token.address,
+              this.user.address,
+              this.recipient.address,
+              "200",
+              INTERNAL,
+              INTERNAL
+            );
         });
 
         it("some approval", async function () {
@@ -488,6 +568,16 @@ describe("Token", function () {
           await expect(this.result)
             .to.emit(beanstalk, "InternalBalanceChanged")
             .withArgs(this.user.address, this.token.address, "-200");
+          await expect(this.result)
+            .to.emit(beanstalk, "TokenTransferred")
+            .withArgs(
+              this.token.address,
+              this.user.address,
+              this.recipient.address,
+              "200",
+              INTERNAL,
+              INTERNAL
+            );
         });
       });
     });


### PR DESCRIPTION
Tracking Internal Balance transfers is difficult to do solely through events. For example, if a block contains multiple internal transfers, its impossible to deduce which transfer went to what, without directly looking at the transaction txs. This PR adds an event that emits the transfer modes when interacting with Farm balances.