### PR TITLE
Bean subgraph - workaround for price contract irregularity

### DIFF
--- a/projects/subgraph-bean/manifests/ethereum.yaml
+++ b/projects/subgraph-bean/manifests/ethereum.yaml
@@ -373,8 +373,8 @@ dataSources:
       blockHandlers:
         - handler: handleBlock
       file: ../src/BlockHandler.ts
-# features:
-#   - grafting
-# graft:
-#   base: QmYnY2GzZbwTqot3H4jAV83mPbGTnBavdbB8bVXYxJzLUd
-#   block: 20291520
+features:
+  - grafting
+graft:
+  base: QmbPDdK3Ez4Aq1gQmt12FEHrk8tBnLW4XMvyA3bAXA8MsS
+  block: 20459100

--- a/projects/subgraph-bean/manifests/ethereum.yaml
+++ b/projects/subgraph-bean/manifests/ethereum.yaml
@@ -373,8 +373,8 @@ dataSources:
       blockHandlers:
         - handler: handleBlock
       file: ../src/BlockHandler.ts
-features:
-  - grafting
-graft:
-  base: QmbPDdK3Ez4Aq1gQmt12FEHrk8tBnLW4XMvyA3bAXA8MsS
-  block: 20459100
+# features:
+#   - grafting
+# graft:
+#   base: QmYnY2GzZbwTqot3H4jAV83mPbGTnBavdbB8bVXYxJzLUd
+#   block: 20291520

--- a/projects/subgraph-bean/src/utils/Pool.ts
+++ b/projects/subgraph-bean/src/utils/Pool.ts
@@ -129,7 +129,9 @@ export function updatePoolValues(
   poolHourly.deltaVolume = poolHourly.deltaVolume.plus(volumeBean);
   poolHourly.deltaVolumeUSD = poolHourly.deltaVolumeUSD.plus(volumeUSD);
   poolHourly.deltaLiquidityUSD = poolHourly.deltaLiquidityUSD.plus(deltaLiquidityUSD);
-  poolHourly.utilization = poolHourly.deltaVolumeUSD.div(poolHourly.liquidityUSD);
+  if (poolHourly.liquidityUSD.gt(ZERO_BD)) {
+    poolHourly.utilization = poolHourly.deltaVolumeUSD.div(poolHourly.liquidityUSD);
+  }
   poolHourly.updatedAt = timestamp;
   poolHourly.save();
 
@@ -140,7 +142,9 @@ export function updatePoolValues(
   poolDaily.deltaVolume = poolDaily.deltaVolume.plus(volumeBean);
   poolDaily.deltaVolumeUSD = poolDaily.deltaVolumeUSD.plus(volumeUSD);
   poolDaily.deltaLiquidityUSD = poolDaily.deltaLiquidityUSD.plus(deltaLiquidityUSD);
-  poolDaily.utilization = poolDaily.deltaVolumeUSD.div(poolDaily.liquidityUSD);
+  if (poolDaily.liquidityUSD.gt(ZERO_BD)) {
+    poolDaily.utilization = poolDaily.deltaVolumeUSD.div(poolDaily.liquidityUSD);
+  }
   poolDaily.updatedAt = timestamp;
   poolDaily.save();
 

--- a/projects/subgraph-bean/src/utils/price/BeanstalkPrice.ts
+++ b/projects/subgraph-bean/src/utils/price/BeanstalkPrice.ts
@@ -121,7 +121,10 @@ export function BeanstalkPrice_try_price(beanAddr: Address, blockNumber: BigInt)
 // Extracts the pool price from the larger result
 export function getPoolPrice(priceResult: BeanstalkPriceResult, pool: Address): PricePoolStruct | null {
   for (let i = 0; i < priceResult.value.ps.length; ++i) {
-    if (priceResult.value.ps[i].pool == pool) {
+    // Zero liquidity responses are also omitted - this can be caused on a legacy price contract implementation
+    // due to extreme discrepancies in chainlink vs uniswap oracle price. Particularly for the bean subgraph,
+    // it is preferable to omit those events from being handled than to have periods where zero liquidity is reported.
+    if (priceResult.value.ps[i].pool == pool && priceResult.value.ps[i].liquidity.gt(ZERO_BI)) {
       return priceResult.value.ps[i];
     }
   }


### PR DESCRIPTION
Omits handling of events where the price contract reported zero values. This is preferable to avoid the liquidity values recording as 0 incorrectly