### PR TITLE
Bore wells from `ReseedBean`

### DIFF
--- a/protocol/contracts/beanstalk/init/reseed/L2/ReseedBean.sol
+++ b/protocol/contracts/beanstalk/init/reseed/L2/ReseedBean.sol
@@ -94,35 +94,35 @@ contract ReseedBean {
         0x0000000000000000000000000000000000000000000000000000000000000004;
     string internal constant BEAN_WSTETH_NAME = "BEAN:WSTETH Constant Product 2 Upgradeable Well";
     string internal constant BEAN_WSTETH_SYMBOL = "U-BEANWSTETHCP2w";
-    address internal constant WSTETH = address(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
+    address internal constant WSTETH = address(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
 
     // BEAN_WEETH parameters.
     bytes32 internal constant BEAN_WEETH_SALT =
         0x0000000000000000000000000000000000000000000000000000000000000005;
     string internal constant BEAN_WEETH_NAME = "BEAN:WEETH Constant Product 2 Upgradeable Well";
     string internal constant BEAN_WEETH_SYMBOL = "U-BEANWEETHCCP2w";
-    address internal constant WEETH = address(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
+    address internal constant WEETH = address(0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee);
 
     // BEAN_WBTC parameters.
     bytes32 internal constant BEAN_WBTC_SALT =
         0x0000000000000000000000000000000000000000000000000000000000000004;
     string internal constant BEAN_WBTC_NAME = "BEAN:WBTC Constant Product 2 Upgradeable Well";
     string internal constant BEAN_WBTC_SYMBOL = "U-BEANWBTCCP2w";
-    address internal constant WBTC = address(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
+    address internal constant WBTC = address(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
 
     // BEAN_USDC parameters.
     bytes32 internal constant BEAN_USDC_SALT =
         0x0000000000000000000000000000000000000000000000000000000000000005;
     string internal constant BEAN_USDC_NAME = "BEAN:USDC Stable 2 Upgradeable Well";
     string internal constant BEAN_USDC_SYMBOL = "U-BEANUSDCS2w";
-    address internal constant USDC = address(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
+    address internal constant USDC = address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
 
     // BEAN_USDT parameters.
     bytes32 internal constant BEAN_USDT_SALT =
         0x0000000000000000000000000000000000000000000000000000000000000003;
     string internal constant BEAN_USDT_NAME = "BEAN:USDT Stable 2 Upgradeable Well";
     string internal constant BEAN_USDT_SYMBOL = "U-BEANUSDTS2w";
-    address internal constant USDT = address(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
+    address internal constant USDT = address(0xdAC17F958D2ee523a2206206994597C13D831ec7);
 
     /**
      * @notice deploys bean, unripe bean, unripe lp, and wells.
@@ -147,7 +147,7 @@ contract ReseedBean {
         // deploy new unripe lp contract.
         deployUnripeLP(unripeLpSupply);
         // wells are deployed as ERC1967Proxies in order to allow for future upgrades.
-        deployUpgradableWells();
+        deployUpgradableWells(address(bean));
     }
 
     function deployBean(uint256 supply) internal returns (BeanstalkERC20) {
@@ -192,46 +192,107 @@ contract ReseedBean {
         string memory symbol
     ) internal {
         
-        // Bore upgradeable well.
+        // Encode well data
         (bytes memory immutableData, bytes memory initData) =
             encodeWellDeploymentData(AQUIFER, tokens, wellFunction, pumps);
 
-        console.logBytes(immutableData);
-        console.logBytes(initData);
+        // Bore upgradeable well
+        address _well = IAquifer(AQUIFER).boreWell(
+            UPGRADEABLE_WELL_IMPLEMENTATION, immutableData, initData, salt
+        );
 
-        // address _well = IAquifer(AQUIFER).boreWell(
-        //     UPGRADEABLE_WELL_IMPLEMENTATION, immutableData, initData, salt
-        // );
-        // console.log("well bored at: ", _well);
-
-        // // deploy proxy
-        // address wellProxy = address(
-        //     new ERC1967Proxy{salt: salt}(
-        //         _well,
-        //         abi.encodeCall(IWellUpgradeable.init, (name, symbol))
-        //     )
-        // );
-        // console.log(name);
-        // console.log("well proxy deployed at:", wellProxy);
+        // Deploy proxy
+        address wellProxy = address(
+            new ERC1967Proxy{salt: salt}(
+                _well,
+                abi.encodeCall(IWellUpgradeable.init, (name, symbol))
+            )
+        );
     }
 
-    function deployUpgradableWells() internal {
-        IERC20[] memory beanEthTokens;
-        beanEthTokens[0] = IERC20(0xBEA0000029AD1c77D3d5D23Ba2D8893dB9d1Efab);
-        beanEthTokens[1] = IERC20(WETH);
+    function deployUpgradableWells(address bean) internal {
+        // tokens
+        IERC20[] memory tokens = new IERC20[](2);
+        tokens[0] = IERC20(bean);
+        tokens[1] = IERC20(WETH);
+
+        // cp2 
+        // TODO: change data if needed
+        Call memory cp2 = Call(CONSTANT_PRODUCT_2, abi.encode("beanWF"));
+
+        // stable2
+        // TODO: change data if needed
+        Call memory stable2 = Call(STABLE_2, abi.encode("beanStable"));
         
-        Call memory beanEthWellFunction = Call(CONSTANT_PRODUCT_2, abi.encode("beanstalkWF"));
-        Call[] memory beanEthPumps;
+        // pumps
+        // TODO: change pump data
+        // NOTE: Different data for each well pump or could this be the same? 
+        Call[] memory beanEthPumps = new Call[](1);
         beanEthPumps[0] = Call(MULTIFLOW_PUMP, abi.encode("beanstalkPump"));
 
         // BEAN/ETH well
         deployUpgradebleWell( 
-            beanEthTokens, // tokens (IERC20[])
-            beanEthWellFunction, // well function (Call)
+            tokens, // tokens (IERC20[])
+            cp2, // well function (Call)
             beanEthPumps, // pumps (Call[])
             BEAN_ETH_SALT, // salt
             BEAN_ETH_NAME, // name
             BEAN_ETH_SYMBOL // symbol
+        );
+
+        // BEAN/WSTETH well
+        tokens[1] = IERC20(WSTETH);
+        deployUpgradebleWell(
+            tokens, // tokens (IERC20[])
+            cp2, // well function (Call)
+            beanEthPumps, // pumps (Call[])
+            BEAN_WSTETH_SALT,
+            BEAN_WSTETH_NAME,
+            BEAN_WSTETH_SYMBOL
+        );
+
+        // BEAN/WEWETH well
+        tokens[1] = IERC20(WEETH);
+        deployUpgradebleWell(
+            tokens, // tokens (IERC20[])
+            cp2, // well function (Call)
+            beanEthPumps, // pumps (Call[])
+            BEAN_WEETH_SALT,
+            BEAN_WEETH_NAME,
+            BEAN_WEETH_SYMBOL
+        );
+
+        // BEAN/WBTC well
+        tokens[1] = IERC20(WBTC);
+        deployUpgradebleWell(
+            tokens, // tokens (IERC20[])
+            cp2, // well function (Call)
+            beanEthPumps, // pumps (Call[])
+            BEAN_WBTC_SALT,
+            BEAN_WBTC_NAME,
+            BEAN_WBTC_SYMBOL
+        );
+
+        // BEAN/USDC well
+        tokens[1] = IERC20(USDC);
+        deployUpgradebleWell(
+            tokens, // tokens (IERC20[])
+            stable2, // well function (Call)
+            beanEthPumps, // pumps (Call[])
+            BEAN_USDC_SALT,
+            BEAN_USDC_NAME,
+            BEAN_USDC_SYMBOL
+        );
+
+        // BEAN/USDT well
+        tokens[1] = IERC20(USDT);
+        deployUpgradebleWell(
+            tokens, // tokens (IERC20[])
+            stable2, // well function (Call)
+            beanEthPumps, // pumps (Call[])
+            BEAN_USDT_SALT,
+            BEAN_USDT_NAME,
+            BEAN_USDT_SYMBOL
         );
 
     }

--- a/protocol/contracts/beanstalk/init/reseed/L2/ReseedBean.sol
+++ b/protocol/contracts/beanstalk/init/reseed/L2/ReseedBean.sol
@@ -217,24 +217,26 @@ contract ReseedBean {
         tokens[1] = IERC20(WETH);
 
         // cp2 
-        // TODO: change data if needed
-        Call memory cp2 = Call(CONSTANT_PRODUCT_2, abi.encode("beanWF"));
+        Call memory cp2;
+        cp2.target = CONSTANT_PRODUCT_2;
 
         // stable2
-        // TODO: change data if needed
-        Call memory stable2 = Call(STABLE_2, abi.encode("beanStable"));
+        uint256 beanDecimals = 1e6;
+        uint256 stableDecimals = 1e6;
+        bytes memory stable2Data = abi.encode(beanDecimals, stableDecimals);
+        Call memory stable2 = Call(STABLE_2, stable2Data);
         
-        // pumps
-        // TODO: change pump data
-        // NOTE: Different data for each well pump or could this be the same? 
-        Call[] memory beanEthPumps = new Call[](1);
-        beanEthPumps[0] = Call(MULTIFLOW_PUMP, abi.encode("beanstalkPump"));
+        // pump
+        Call[] memory pumps = new Call[](1);
+        // Note: mfpData will need to be updated based on the L2 block time.
+        bytes memory mfpData = hex"3ffeef368eb04325c526c2246eec3e5500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000603ff9eb851eb851eb851eb851eb851eb8000000000000000000000000000000003ff9eb851eb851eb851eb851eb851eb8000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003ff747ae147ae147ae147ae147ae147a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000023ff747ae147ae147ae147ae147ae147a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        pumps[0] = Call(MULTIFLOW_PUMP, mfpData);
 
         // BEAN/ETH well
         deployUpgradebleWell( 
             tokens, // tokens (IERC20[])
             cp2, // well function (Call)
-            beanEthPumps, // pumps (Call[])
+            pumps, // pumps (Call[])
             BEAN_ETH_SALT, // salt
             BEAN_ETH_NAME, // name
             BEAN_ETH_SYMBOL // symbol
@@ -245,7 +247,7 @@ contract ReseedBean {
         deployUpgradebleWell(
             tokens, // tokens (IERC20[])
             cp2, // well function (Call)
-            beanEthPumps, // pumps (Call[])
+            pumps, // pumps (Call[])
             BEAN_WSTETH_SALT,
             BEAN_WSTETH_NAME,
             BEAN_WSTETH_SYMBOL
@@ -256,7 +258,7 @@ contract ReseedBean {
         deployUpgradebleWell(
             tokens, // tokens (IERC20[])
             cp2, // well function (Call)
-            beanEthPumps, // pumps (Call[])
+            pumps, // pumps (Call[])
             BEAN_WEETH_SALT,
             BEAN_WEETH_NAME,
             BEAN_WEETH_SYMBOL
@@ -267,29 +269,31 @@ contract ReseedBean {
         deployUpgradebleWell(
             tokens, // tokens (IERC20[])
             cp2, // well function (Call)
-            beanEthPumps, // pumps (Call[])
+            pumps, // pumps (Call[])
             BEAN_WBTC_SALT,
             BEAN_WBTC_NAME,
             BEAN_WBTC_SYMBOL
         );
 
         // BEAN/USDC well
+        // USDC uses 6 decimals
         tokens[1] = IERC20(USDC);
         deployUpgradebleWell(
             tokens, // tokens (IERC20[])
             stable2, // well function (Call)
-            beanEthPumps, // pumps (Call[])
+            pumps, // pumps (Call[])
             BEAN_USDC_SALT,
             BEAN_USDC_NAME,
             BEAN_USDC_SYMBOL
         );
 
         // BEAN/USDT well
+        // USDT uses 6 decimals
         tokens[1] = IERC20(USDT);
         deployUpgradebleWell(
             tokens, // tokens (IERC20[])
             stable2, // well function (Call)
-            beanEthPumps, // pumps (Call[])
+            pumps, // pumps (Call[])
             BEAN_USDT_SALT,
             BEAN_USDT_NAME,
             BEAN_USDT_SYMBOL

--- a/protocol/reseed/reseed3.js
+++ b/protocol/reseed/reseed3.js
@@ -53,77 +53,11 @@ async function reseed3(account, L2Beanstalk, mock = false, deployBasin = true) {
     stable = await ethers.getContractAt("IERC20", L2_WBTC);
   }
 
-  // deploy basin components, if deployBasin is enabled:
-  wells = [];
   if (deployBasin) {
-    // TODO: replace aquifer on L2
-    aquifer = await getWellContractAt("Aquifer", "0xBA51AAAA95aeEFc1292515b36D86C51dC7877773");
-    cp2 = await getWellContractAt(
-      "ConstantProduct2",
-      "0xBA150C2ae0f8450D4B832beeFa3338d4b5982d26",
-      "1.2"
-    );
-    mfp = await getWellContractAt(
-      "MultiFlowPump",
-      "0xBA51AaaAa95bA1d5efB3cB1A3f50a09165315A17",
-      "1.2"
-    );
-    mfpData =
-      "0x3ffeef368eb04325c526c2246eec3e5500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000603ff9eb851eb851eb851eb851eb851eb8000000000000000000000000000000003ff9eb851eb851eb851eb851eb851eb8000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003ff747ae147ae147ae147ae147ae147a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000023ff747ae147ae147ae147ae147ae147a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
     [uWell, stable2] = await deployBasinV1_2Components();
-
-    // deploy the following upgradeable wells:
-    // BEAN/WETH
-    // BEAN/WSTETH
-    // BEAN/WEETH
-    // BEAN/WBTC
-    // BEAN/USDC
-    // BEAN/USDT
-    cp2Tokens = [
-      L2_WETH,
-      L2_WSTETH,
-      L2_WEETH,
-      L2_WBTC,
-    ];
-    s2Tokens = [
-      L2_USDC,
-      L2_USDT
-    ];
-    // loop through tokens:
-    for (let i = 0; i < cp2Tokens.length; i++) {
-      wells.push(
-        await deployUpgradeableWell(
-          aquifer,
-          BEAN,
-          cp2Tokens[i],
-          uWell,
-          cp2,
-          "0x",
-          mfp,
-          mfpData,
-          "0x0000000000000000000000000000000000000000000000000000000000000001"
-        )
-      );
-    }
-
-    for (let i = 0; i < s2Tokens.length; i++) {
-      wells.push(
-        await deployUpgradeableWell(
-          aquifer,
-          BEAN,
-          s2Tokens[i],
-          uWell,
-          stable2,
-          ethers.utils.solidityPack(["uint256", "uint256"], [6, 18]),
-          mfp,
-          mfpData,
-          "0x0000000000000000000000000000000000000000000000000000000000000001"
-        )
-      );
-    }
+    console.log("uWell:", uWell.address);
+    console.log("stable2:", stable2.address);
   }
-
-  console.log("Wells deployed:", wells);
 
   // approve beanstalk:
   await weth.connect(approver).approve(L2Beanstalk, ethInBeanEthWell[0]);

--- a/protocol/reseed/reseedDeployL2Beanstalk.js
+++ b/protocol/reseed/reseedDeployL2Beanstalk.js
@@ -10,8 +10,8 @@ async function reseedDeployL2Beanstalk(account, verbose = true, mock) {
   // Initialize deployer account for vanity address.
   let deployerSigner;
   if (mock) {
-    await mintEth(deployerSigner.address);
     deployerSigner = await impersonateSigner("0xe26367ca850da09a478076481535d7c1c67d62f9");
+    await mintEth(deployerSigner.address);
   } else {
     deployerSigner = new ethers.Wallet(process.env.DIAMOND_DEPLOYER_PRIVATE_KEY, ethers.provider);
   }


### PR DESCRIPTION
- Add support to deploy all upgradeable well implementations in addition to their ERC1967 proxies from the same `ReseedBean` init script,  removing the need to be deployed from js.
- Add token addresses as constants in the init script