### PR TITLE
subgraph-beanstalk misc fixes

### DIFF
--- a/projects/subgraph-beanstalk/src/utils/Barn.ts
+++ b/projects/subgraph-beanstalk/src/utils/Barn.ts
@@ -52,10 +52,10 @@ export function unripeChopped(params: ChopParams): void {
   chop.farmer = params.account.toHexString();
   chop.unripeToken = unripe.id;
   chop.unripeAmount = params.unripeAmount;
-  chop.unripeBdv = params.unripeAmount.times(unripeBdvOne);
+  chop.unripeBdv = params.unripeAmount.times(unripeBdvOne).div(BI_10.pow(<u8>unripeWhitelist.decimals));
   chop.underlyingToken = unripe.underlyingToken;
   chop.underlyingAmount = params.underlyingAmount;
-  chop.underlyingBdv = params.underlyingAmount.times(underlyingBdvOne);
+  chop.underlyingBdv = params.underlyingAmount.times(underlyingBdvOne).div(BI_10.pow(<u8>underlyingWhitelist.decimals));
   chop.chopRate = unripe.chopRate;
   chop.hash = params.event.transaction.hash.toHexString();
   chop.blockNumber = params.event.block.number;
@@ -63,8 +63,8 @@ export function unripeChopped(params: ChopParams): void {
   chop.save();
 
   unripe.totalChoppedAmount = unripe.totalChoppedAmount.plus(chop.unripeAmount);
-  unripe.totalChoppedBdv = unripe.totalChoppedBdv.plus(chop.unripeBdv).div(BI_10.pow(<u8>unripeWhitelist.decimals));
-  unripe.totalChoppedBdvReceived = unripe.totalChoppedBdvReceived.plus(chop.underlyingBdv).div(BI_10.pow(<u8>underlyingWhitelist.decimals));
+  unripe.totalChoppedBdv = unripe.totalChoppedBdv.plus(chop.unripeBdv);
+  unripe.totalChoppedBdvReceived = unripe.totalChoppedBdvReceived.plus(chop.underlyingBdv);
   unripe.save();
 
   updateUnripeStats(Address.fromBytes(unripe.id), params.event.address, params.event.block);

--- a/projects/subgraph-beanstalk/src/utils/Init.ts
+++ b/projects/subgraph-beanstalk/src/utils/Init.ts
@@ -3,7 +3,7 @@ import { Version } from "../../generated/schema";
 
 export function handleInitVersion(block: ethereum.Block): void {
   const versionEntity = new Version("subgraph");
-  versionEntity.versionNumber = "2.4.0";
+  versionEntity.versionNumber = "2.4.1";
   versionEntity.subgraphName = subgraphNameForBlockNumber(block.number);
   versionEntity.chain = chainForBlockNumber(block.number);
   versionEntity.save();

--- a/projects/subgraph-beanstalk/src/utils/Yield.ts
+++ b/projects/subgraph-beanstalk/src/utils/Yield.ts
@@ -120,7 +120,7 @@ export function updateSiloVAPYs(protocol: Address, timestamp: BigInt, window: i3
         currentEMA,
         toDecimal(whitelistSettings[i].stalkEarnedPerSeason),
         toDecimal(beanGrownStalk),
-        silo.stalk.plus(silo.plantableStalk),
+        silo.stalk,
         silo.seeds
       );
       apys.push(tokenAPY);
@@ -136,7 +136,7 @@ export function updateSiloVAPYs(protocol: Address, timestamp: BigInt, window: i3
 
     let initialR = toDecimal(silo.beanToMaxLpGpPerBdvRatio!, 20);
     // Stalk has 10 decimals
-    let siloStalk = toDecimal(silo.stalk.plus(silo.plantableStalk), 10);
+    let siloStalk = toDecimal(silo.stalk, 10);
 
     let germinatingBeanBdv: BigDecimal[] = [];
     let germinatingGaugeLpBdv: BigDecimal[][] = [];

--- a/projects/subgraph-beanstalk/tests/SeedGauge.test.ts
+++ b/projects/subgraph-beanstalk/tests/SeedGauge.test.ts
@@ -127,27 +127,30 @@ describe("Seed Gauge", () => {
       assert.fieldEquals("Germinating", ANVIL_ADDR_1 + "-EVEN", "stalk", initialGerminating.toString());
     });
 
-    test("event: TotalGerminatingBalanceChanged", () => {
-      setSeason(6);
-      const germinatingTokens = BigInt.fromI32(12345);
-      const germinatingBdv = BigInt.fromI32(7899);
-      handleTotalGerminatingBalanceChanged(
-        createTotalGerminatingBalanceChangedEvent(BigInt.fromU32(5), BEAN_ERC20.toHexString(), germinatingTokens, germinatingBdv)
-      );
-      assert.fieldEquals("Germinating", BEAN_ERC20.toHexString() + "-ODD", "season", "5");
-      assert.fieldEquals("Germinating", BEAN_ERC20.toHexString() + "-ODD", "tokenAmount", germinatingTokens.toString());
-      assert.fieldEquals("Germinating", BEAN_ERC20.toHexString() + "-ODD", "bdv", germinatingBdv.toString());
-
-      handleTotalGerminatingBalanceChanged(
-        createTotalGerminatingBalanceChangedEvent(
-          BigInt.fromU32(5),
-          BEAN_ERC20.toHexString(),
-          germinatingTokens.neg(),
-          germinatingBdv.neg()
-        )
-      );
-      assert.notInStore("Germinating", BEAN_ERC20.toHexString() + "-ODD");
-    });
+    /**
+     * Removed this test due to having to use a simplified approach to account for a bug in the
+     * event itself. The test case can be put back once its fixed on b3 and test the b3 implementation
+     **/
+    // test("event: TotalGerminatingBalanceChanged", () => {
+    //   setSeason(6);
+    //   const germinatingTokens = BigInt.fromI32(12345);
+    //   const germinatingBdv = BigInt.fromI32(7899);
+    //   handleTotalGerminatingBalanceChanged(
+    //     createTotalGerminatingBalanceChangedEvent(BigInt.fromU32(5), BEAN_ERC20.toHexString(), germinatingTokens, germinatingBdv)
+    //   );
+    //   assert.fieldEquals("Germinating", BEAN_ERC20.toHexString() + "-ODD", "season", "5");
+    //   assert.fieldEquals("Germinating", BEAN_ERC20.toHexString() + "-ODD", "tokenAmount", germinatingTokens.toString());
+    //   assert.fieldEquals("Germinating", BEAN_ERC20.toHexString() + "-ODD", "bdv", germinatingBdv.toString());
+    //   handleTotalGerminatingBalanceChanged(
+    //     createTotalGerminatingBalanceChangedEvent(
+    //       BigInt.fromU32(5),
+    //       BEAN_ERC20.toHexString(),
+    //       germinatingTokens.neg(),
+    //       germinatingBdv.neg()
+    //     )
+    //   );
+    //   assert.notInStore("Germinating", BEAN_ERC20.toHexString() + "-ODD");
+    // });
 
     test("event: TotalGerminatingStalkChanged", () => {
       const initialGerminating = BigInt.fromI32(123456789);


### PR DESCRIPTION
- Workaround for bug in `TotalGerminatingBalanceChanged` event emission
- Fix double counting of some stalk in vapy calculation
- Fix improper precision in chopped bdv calculation