### PR TITLE
update pipelineConvert to use pipecalls instead of advancedFarmCalls.

### DIFF
--- a/protocol/contracts/beanstalk/silo/PipelineConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/PipelineConvertFacet.sol
@@ -69,7 +69,7 @@ contract PipelineConvertFacet is Invariable, ReentrancyGuard {
         external
         payable
         fundsSafu
-        nonReentrantFarm
+        nonReentrant
         returns (int96 toStem, uint256 fromAmount, uint256 toAmount, uint256 fromBdv, uint256 toBdv)
     {
         // require that input and output tokens be wells (Unripe not supported)

--- a/protocol/contracts/beanstalk/silo/PipelineConvertFacet.sol
+++ b/protocol/contracts/beanstalk/silo/PipelineConvertFacet.sol
@@ -14,7 +14,7 @@ import {LibRedundantMath256} from "contracts/libraries/LibRedundantMath256.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {LibConvert} from "contracts/libraries/Convert/LibConvert.sol";
-import {AdvancedFarmCall} from "../../libraries/LibFarm.sol";
+import {AdvancedPipeCall} from "contracts/interfaces/IPipeline.sol";
 import {LibWell} from "contracts/libraries/Well/LibWell.sol";
 import {LibConvertData} from "contracts/libraries/Convert/LibConvertData.sol";
 import {Invariable} from "contracts/beanstalk/Invariable.sol";
@@ -52,7 +52,7 @@ contract PipelineConvertFacet is Invariable, ReentrancyGuard {
      * @param stems The stems of the deposits to convert from.
      * @param amounts The amounts of the deposits to convert from.
      * @param outputToken The token to convert to.
-     * @param advancedFarmCalls The farm calls to execute.
+     * @param advancedPipeCalls The pipe calls to execute.
      * @return toStem the new stems of the converted deposit
      * @return fromAmount the amount of tokens converted from
      * @return toAmount the amount of tokens converted to
@@ -64,7 +64,7 @@ contract PipelineConvertFacet is Invariable, ReentrancyGuard {
         int96[] calldata stems,
         uint256[] calldata amounts,
         address outputToken,
-        AdvancedFarmCall[] calldata advancedFarmCalls
+        AdvancedPipeCall[] memory advancedPipeCalls
     )
         external
         payable
@@ -107,7 +107,7 @@ contract PipelineConvertFacet is Invariable, ReentrancyGuard {
             fromAmount,
             fromBdv,
             grownStalk,
-            advancedFarmCalls
+            advancedPipeCalls
         );
 
         toStem = LibConvert._depositTokensForConvert(

--- a/protocol/contracts/libraries/Convert/LibPipelineConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibPipelineConvert.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 
 import {C} from "contracts/C.sol";
 import {LibConvert} from "./LibConvert.sol";
-import {AdvancedFarmCall, LibFarm} from "../../libraries/LibFarm.sol";
+import {AdvancedPipeCall} from "contracts/interfaces/IPipeline.sol";
 import {LibWell} from "../Well/LibWell.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {LibWhitelistedTokens} from "contracts/libraries/Silo/LibWhitelistedTokens.sol";
@@ -40,7 +40,7 @@ library LibPipelineConvert {
         uint256 fromAmount,
         uint256 fromBdv,
         uint256 initialGrownStalk,
-        AdvancedFarmCall[] calldata advancedFarmCalls
+        AdvancedPipeCall[] memory advancedPipeCalls
     ) external returns (uint256 toAmount, uint256 newGrownStalk, uint256 newBdv) {
         PipelineConvertData memory pipeData = LibPipelineConvert.populatePipelineConvertData(
             inputToken,
@@ -51,7 +51,7 @@ library LibPipelineConvert {
         pipeData.overallConvertCapacity = LibConvert.abs(LibDeltaB.overallCappedDeltaB());
 
         IERC20(inputToken).transfer(C.PIPELINE, fromAmount);
-        executeAdvancedFarmCalls(advancedFarmCalls);
+        IPipeline(C.PIPELINE).advancedPipe(advancedPipeCalls);
 
         // user MUST leave final assets in pipeline, allowing us to verify that the farm has been called successfully.
         // this also let's us know how many assets to attempt to pull out of the final type
@@ -124,14 +124,7 @@ library LibPipelineConvert {
     /**
      * @param calls The advanced farm calls to execute.
      */
-    function executeAdvancedFarmCalls(AdvancedFarmCall[] calldata calls) internal {
-        bytes[] memory results;
-        results = new bytes[](calls.length);
-        for (uint256 i = 0; i < calls.length; ++i) {
-            require(calls[i].callData.length != 0, "Convert: empty AdvancedFarmCall");
-            results[i] = LibFarm._advancedFarm(calls[i], results);
-        }
-    }
+    function executeAdvancedPipeCalls(AdvancedPipeCall[] memory calls) internal {}
 
     /**
      * @notice Determines input token amount left in pipeline and returns to Beanstalk

--- a/protocol/contracts/libraries/Convert/LibPipelineConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibPipelineConvert.sol
@@ -122,11 +122,6 @@ library LibPipelineConvert {
     }
 
     /**
-     * @param calls The advanced farm calls to execute.
-     */
-    function executeAdvancedPipeCalls(AdvancedPipeCall[] memory calls) internal {}
-
-    /**
      * @notice Determines input token amount left in pipeline and returns to Beanstalk
      * @param tokenOut The token to pull out of pipeline
      */

--- a/protocol/test/foundry/farm/PipelineConvert.t.sol
+++ b/protocol/test/foundry/farm/PipelineConvert.t.sol
@@ -1409,7 +1409,7 @@ contract PipelineConvertTest is TestHelper {
 
         vm.resumeGasMetering();
         vm.prank(users[1]);
-        bs.advancedFarm(advancedFarmCalls); // currently fails with: ReentrancyGuard: reentrant farm call
+        bs.advancedFarm(advancedFarmCalls);
     }
 
     ////// CONVERT TEST HELPERS //////


### PR DESCRIPTION
Currently,`PipelineConvert` performs a set of advanced Farm Calls. With the recent security update, Farm functions cannot call other Farm functions. This means that pipelineConvert cannot be used in farm and tractor calls. This limits composability given that it limits the ability of tractor functionality. 

This PR replaces farm calls with pipe calls instead. Given that most, if not all previous functionally can be done with a pipelineConvert within a farm call.