### PR TITLE
Constants + Whitelist Update

### DIFF
--- a/protocol/abi/Beanstalk.json
+++ b/protocol/abi/Beanstalk.json
@@ -329,6 +329,30 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "cumulativeReserves",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint40",
+        "name": "timestamp",
+        "type": "uint40"
+      }
+    ],
+    "name": "getLockedBeansFromTwaReserves",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "getLockedBeansUnderlyingUnripeBean",
     "outputs": [
@@ -5676,37 +5700,6 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes4",
-        "name": "gpSelector",
-        "type": "bytes4"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes4",
-        "name": "lwSelector",
-        "type": "bytes4"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint64",
-        "name": "optimalPercentDepositedBdv",
-        "type": "uint64"
-      }
-    ],
-    "name": "UpdateGaugeSettings",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
         "indexed": false,
         "internalType": "address",
         "name": "token",
@@ -5744,6 +5737,96 @@
       }
     ],
     "name": "UpdateWhitelistStatus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "maxBeanMaxLpGpPerBdvRatio",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minBeanMaxLpGpPerBdvRatio",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "targetSeasonsToCatchUp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "podRateLowerBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "podRateOptimal",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "podRateUpperBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deltaPodDemandLowerBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deltaPodDemandUpperBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lpToSupplyRatioUpperBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lpToSupplyRatioOptimal",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lpToSupplyRatioLowerBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "excessivePriceThreshold",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientLow",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "baseReward",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct EvaluationParameters",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "name": "UpdatedEvaluationParameters",
     "type": "event"
   },
   {
@@ -5838,6 +5921,25 @@
         "type": "address"
       },
       {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "optimalPercentDepositedBdv",
+        "type": "uint64"
+      }
+    ],
+    "name": "UpdatedOptimalPercentDepositedBdvForToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
         "components": [
           {
             "internalType": "address",
@@ -5867,81 +5969,6 @@
       }
     ],
     "name": "UpdatedOracleImplementationForToken",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "maxBeanMaxLpGpPerBdvRatio",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "minBeanMaxLpGpPerBdvRatio",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "targetSeasonsToCatchUp",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "podRateLowerBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "podRateOptimal",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "podRateUpperBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "deltaPodDemandLowerBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "deltaPodDemandUpperBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "lpToSupplyRatioUpperBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "lpToSupplyRatioOptimal",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "lpToSupplyRatioLowerBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "excessivePriceThreshold",
-            "type": "uint256"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct EvaluationParameters",
-        "name": "",
-        "type": "tuple"
-      }
-    ],
-    "name": "UpdatedSeedGaugeSettings",
     "type": "event"
   },
   {
@@ -5998,18 +6025,6 @@
       },
       {
         "indexed": false,
-        "internalType": "bytes4",
-        "name": "gpSelector",
-        "type": "bytes4"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes4",
-        "name": "lwSelector",
-        "type": "bytes4"
-      },
-      {
-        "indexed": false,
         "internalType": "uint128",
         "name": "gaugePoints",
         "type": "uint128"
@@ -6028,32 +6043,10 @@
     "anonymous": false,
     "inputs": [
       {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "target",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes4",
-            "name": "selector",
-            "type": "bytes4"
-          },
-          {
-            "internalType": "bytes1",
-            "name": "encodeType",
-            "type": "bytes1"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct Implementation",
-        "name": "oracleImplementation",
-        "type": "tuple"
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
       },
       {
         "components": [
@@ -6112,7 +6105,7 @@
         "type": "tuple"
       }
     ],
-    "name": "WhitelistTokenWithExternalImplementation",
+    "name": "WhitelistTokenImplementations",
     "type": "event"
   },
   {
@@ -6126,6 +6119,88 @@
     "name": "dewhitelistToken",
     "outputs": [],
     "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getGaugePointImplementationForToken",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes1",
+            "name": "encodeType",
+            "type": "bytes1"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Implementation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getLiquidityWeightImplementationForToken",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes1",
+            "name": "encodeType",
+            "type": "bytes1"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Implementation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -6315,19 +6390,63 @@
         "type": "address"
       },
       {
-        "internalType": "bytes4",
-        "name": "gaugePointSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "liquidityWeightSelector",
-        "type": "bytes4"
-      },
-      {
         "internalType": "uint64",
         "name": "optimalPercentDepositedBdv",
         "type": "uint64"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes1",
+            "name": "encodeType",
+            "type": "bytes1"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Implementation",
+        "name": "gpImplementation",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes1",
+            "name": "encodeType",
+            "type": "bytes1"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Implementation",
+        "name": "lwImplementation",
+        "type": "tuple"
       }
     ],
     "name": "updateGaugeForToken",
@@ -6518,6 +6637,21 @@
             "internalType": "uint256",
             "name": "excessivePriceThreshold",
             "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientLow",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "baseReward",
+            "type": "uint256"
           }
         ],
         "internalType": "struct EvaluationParameters",
@@ -6544,161 +6678,6 @@
       }
     ],
     "name": "updateStalkPerBdvPerSeasonForToken",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "selector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint48",
-        "name": "stalkIssuedPerBdv",
-        "type": "uint48"
-      },
-      {
-        "internalType": "uint32",
-        "name": "stalkEarnedPerSeason",
-        "type": "uint32"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "gaugePointSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "liquidityWeightSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint128",
-        "name": "gaugePoints",
-        "type": "uint128"
-      },
-      {
-        "internalType": "uint64",
-        "name": "optimalPercentDepositedBdv",
-        "type": "uint64"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "target",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes4",
-            "name": "selector",
-            "type": "bytes4"
-          },
-          {
-            "internalType": "bytes1",
-            "name": "encodeType",
-            "type": "bytes1"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct Implementation",
-        "name": "oracleImplementation",
-        "type": "tuple"
-      }
-    ],
-    "name": "whitelistToken",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "selector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint48",
-        "name": "stalkIssuedPerBdv",
-        "type": "uint48"
-      },
-      {
-        "internalType": "uint32",
-        "name": "stalkEarnedPerSeason",
-        "type": "uint32"
-      },
-      {
-        "internalType": "bytes1",
-        "name": "encodeType",
-        "type": "bytes1"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "gaugePointSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "liquidityWeightSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint128",
-        "name": "gaugePoints",
-        "type": "uint128"
-      },
-      {
-        "internalType": "uint64",
-        "name": "optimalPercentDepositedBdv",
-        "type": "uint64"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "target",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes4",
-            "name": "selector",
-            "type": "bytes4"
-          },
-          {
-            "internalType": "bytes1",
-            "name": "encodeType",
-            "type": "bytes1"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct Implementation",
-        "name": "oracleImplementation",
-        "type": "tuple"
-      }
-    ],
-    "name": "whitelistTokenWithEncodeType",
     "outputs": [],
     "stateMutability": "payable",
     "type": "function"
@@ -6822,7 +6801,7 @@
         "type": "tuple"
       }
     ],
-    "name": "whitelistTokenWithExternalImplementation",
+    "name": "whitelistToken",
     "outputs": [],
     "stateMutability": "payable",
     "type": "function"
@@ -8673,7 +8652,7 @@
         "type": "uint256"
       }
     ],
-    "stateMutability": "pure",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -9079,7 +9058,13 @@
     "type": "function"
   },
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
     "name": "maxWeight",
     "outputs": [
       {
@@ -9092,7 +9077,13 @@
     "type": "function"
   },
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
     "name": "noWeight",
     "outputs": [
       {
@@ -9881,6 +9872,21 @@
             "internalType": "uint256",
             "name": "excessivePriceThreshold",
             "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientLow",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "baseReward",
+            "type": "uint256"
           }
         ],
         "internalType": "struct EvaluationParameters",
@@ -10617,6 +10623,11 @@
         "internalType": "uint256",
         "name": "percentOfDepositedBdv",
         "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
       }
     ],
     "name": "defaultGaugePointFunction",
@@ -10813,6 +10824,667 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "ticketId",
+        "type": "uint256"
+      }
+    ],
+    "name": "RetryableTicketCreated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "L2Beanstalk",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxSubmissionCost",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxGas",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "gasPriceBid",
+        "type": "uint256"
+      }
+    ],
+    "name": "approveL2Reciever",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ticketID",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "L2Beanstalk",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum LibTransfer.To",
+        "name": "toMode",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxSubmissionCost",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxGas",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "gasPriceBid",
+        "type": "uint256"
+      }
+    ],
+    "name": "migrateL2Beans",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ticketID",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum LibTransfer.To",
+        "name": "toMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "L1BeansMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "depositIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "bdvs",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "L1DepositsMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "fertIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128[]",
+        "name": "amounts",
+        "type": "uint128[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "lastBpf",
+        "type": "uint128"
+      }
+    ],
+    "name": "L1FertilizerMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "L1InternalBalancesMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "index",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "pods",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "L1PlotsMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      }
+    ],
+    "name": "RecieverApproved",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      }
+    ],
+    "name": "approveReciever",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDepositMerkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFertilizerMerkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getInternalBalanceMerkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPlotMerkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "getReciever",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "depositIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "bdvs",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "issueDeposits",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "fertIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "amounts",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint128",
+        "name": "lastBpf",
+        "type": "uint128"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "issueFertilizer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "issueInternalBalances",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "index",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "pods",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "issuePlots",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum LibTransfer.To",
+        "name": "toMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "recieveL1Beans",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "depositIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "bdvs",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "verifyDepositMerkleProof",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "fertIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "amounts",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint128",
+        "name": "lastBpf",
+        "type": "uint128"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "verifyFertilizerMerkleProof",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "verifyInternalBalanceMerkleProof",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "index",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "verifyPlotMerkleProof",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
     "type": "function"
   }
 ]

--- a/protocol/abi/MockBeanstalk.json
+++ b/protocol/abi/MockBeanstalk.json
@@ -329,6 +329,30 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "cumulativeReserves",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint40",
+        "name": "timestamp",
+        "type": "uint40"
+      }
+    ],
+    "name": "getLockedBeansFromTwaReserves",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "getLockedBeansUnderlyingUnripeBean",
     "outputs": [
@@ -5676,37 +5700,6 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes4",
-        "name": "gpSelector",
-        "type": "bytes4"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes4",
-        "name": "lwSelector",
-        "type": "bytes4"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint64",
-        "name": "optimalPercentDepositedBdv",
-        "type": "uint64"
-      }
-    ],
-    "name": "UpdateGaugeSettings",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
         "indexed": false,
         "internalType": "address",
         "name": "token",
@@ -5744,6 +5737,96 @@
       }
     ],
     "name": "UpdateWhitelistStatus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "maxBeanMaxLpGpPerBdvRatio",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minBeanMaxLpGpPerBdvRatio",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "targetSeasonsToCatchUp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "podRateLowerBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "podRateOptimal",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "podRateUpperBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deltaPodDemandLowerBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deltaPodDemandUpperBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lpToSupplyRatioUpperBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lpToSupplyRatioOptimal",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lpToSupplyRatioLowerBound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "excessivePriceThreshold",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientLow",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "baseReward",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct EvaluationParameters",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "name": "UpdatedEvaluationParameters",
     "type": "event"
   },
   {
@@ -5838,6 +5921,25 @@
         "type": "address"
       },
       {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "optimalPercentDepositedBdv",
+        "type": "uint64"
+      }
+    ],
+    "name": "UpdatedOptimalPercentDepositedBdvForToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
         "components": [
           {
             "internalType": "address",
@@ -5867,81 +5969,6 @@
       }
     ],
     "name": "UpdatedOracleImplementationForToken",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "maxBeanMaxLpGpPerBdvRatio",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "minBeanMaxLpGpPerBdvRatio",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "targetSeasonsToCatchUp",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "podRateLowerBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "podRateOptimal",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "podRateUpperBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "deltaPodDemandLowerBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "deltaPodDemandUpperBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "lpToSupplyRatioUpperBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "lpToSupplyRatioOptimal",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "lpToSupplyRatioLowerBound",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "excessivePriceThreshold",
-            "type": "uint256"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct EvaluationParameters",
-        "name": "",
-        "type": "tuple"
-      }
-    ],
-    "name": "UpdatedSeedGaugeSettings",
     "type": "event"
   },
   {
@@ -5998,18 +6025,6 @@
       },
       {
         "indexed": false,
-        "internalType": "bytes4",
-        "name": "gpSelector",
-        "type": "bytes4"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes4",
-        "name": "lwSelector",
-        "type": "bytes4"
-      },
-      {
-        "indexed": false,
         "internalType": "uint128",
         "name": "gaugePoints",
         "type": "uint128"
@@ -6028,32 +6043,10 @@
     "anonymous": false,
     "inputs": [
       {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "target",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes4",
-            "name": "selector",
-            "type": "bytes4"
-          },
-          {
-            "internalType": "bytes1",
-            "name": "encodeType",
-            "type": "bytes1"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct Implementation",
-        "name": "oracleImplementation",
-        "type": "tuple"
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
       },
       {
         "components": [
@@ -6112,7 +6105,7 @@
         "type": "tuple"
       }
     ],
-    "name": "WhitelistTokenWithExternalImplementation",
+    "name": "WhitelistTokenImplementations",
     "type": "event"
   },
   {
@@ -6126,6 +6119,88 @@
     "name": "dewhitelistToken",
     "outputs": [],
     "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getGaugePointImplementationForToken",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes1",
+            "name": "encodeType",
+            "type": "bytes1"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Implementation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getLiquidityWeightImplementationForToken",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes1",
+            "name": "encodeType",
+            "type": "bytes1"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Implementation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -6315,19 +6390,63 @@
         "type": "address"
       },
       {
-        "internalType": "bytes4",
-        "name": "gaugePointSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "liquidityWeightSelector",
-        "type": "bytes4"
-      },
-      {
         "internalType": "uint64",
         "name": "optimalPercentDepositedBdv",
         "type": "uint64"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes1",
+            "name": "encodeType",
+            "type": "bytes1"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Implementation",
+        "name": "gpImplementation",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          },
+          {
+            "internalType": "bytes1",
+            "name": "encodeType",
+            "type": "bytes1"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Implementation",
+        "name": "lwImplementation",
+        "type": "tuple"
       }
     ],
     "name": "updateGaugeForToken",
@@ -6518,6 +6637,21 @@
             "internalType": "uint256",
             "name": "excessivePriceThreshold",
             "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientLow",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "baseReward",
+            "type": "uint256"
           }
         ],
         "internalType": "struct EvaluationParameters",
@@ -6544,161 +6678,6 @@
       }
     ],
     "name": "updateStalkPerBdvPerSeasonForToken",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "selector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint48",
-        "name": "stalkIssuedPerBdv",
-        "type": "uint48"
-      },
-      {
-        "internalType": "uint32",
-        "name": "stalkEarnedPerSeason",
-        "type": "uint32"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "gaugePointSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "liquidityWeightSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint128",
-        "name": "gaugePoints",
-        "type": "uint128"
-      },
-      {
-        "internalType": "uint64",
-        "name": "optimalPercentDepositedBdv",
-        "type": "uint64"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "target",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes4",
-            "name": "selector",
-            "type": "bytes4"
-          },
-          {
-            "internalType": "bytes1",
-            "name": "encodeType",
-            "type": "bytes1"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct Implementation",
-        "name": "oracleImplementation",
-        "type": "tuple"
-      }
-    ],
-    "name": "whitelistToken",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "selector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint48",
-        "name": "stalkIssuedPerBdv",
-        "type": "uint48"
-      },
-      {
-        "internalType": "uint32",
-        "name": "stalkEarnedPerSeason",
-        "type": "uint32"
-      },
-      {
-        "internalType": "bytes1",
-        "name": "encodeType",
-        "type": "bytes1"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "gaugePointSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "bytes4",
-        "name": "liquidityWeightSelector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "uint128",
-        "name": "gaugePoints",
-        "type": "uint128"
-      },
-      {
-        "internalType": "uint64",
-        "name": "optimalPercentDepositedBdv",
-        "type": "uint64"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "target",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes4",
-            "name": "selector",
-            "type": "bytes4"
-          },
-          {
-            "internalType": "bytes1",
-            "name": "encodeType",
-            "type": "bytes1"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct Implementation",
-        "name": "oracleImplementation",
-        "type": "tuple"
-      }
-    ],
-    "name": "whitelistTokenWithEncodeType",
     "outputs": [],
     "stateMutability": "payable",
     "type": "function"
@@ -6822,7 +6801,7 @@
         "type": "tuple"
       }
     ],
-    "name": "whitelistTokenWithExternalImplementation",
+    "name": "whitelistToken",
     "outputs": [],
     "stateMutability": "payable",
     "type": "function"
@@ -8673,7 +8652,7 @@
         "type": "uint256"
       }
     ],
-    "stateMutability": "pure",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -8868,7 +8847,13 @@
     "type": "function"
   },
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
     "name": "maxWeight",
     "outputs": [
       {
@@ -8881,7 +8866,13 @@
     "type": "function"
   },
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
     "name": "noWeight",
     "outputs": [
       {
@@ -9670,6 +9661,21 @@
             "internalType": "uint256",
             "name": "excessivePriceThreshold",
             "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "soilCoefficientLow",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "baseReward",
+            "type": "uint256"
           }
         ],
         "internalType": "struct EvaluationParameters",
@@ -10406,6 +10412,11 @@
         "internalType": "uint256",
         "name": "percentOfDepositedBdv",
         "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
       }
     ],
     "name": "defaultGaugePointFunction",
@@ -10602,6 +10613,667 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "ticketId",
+        "type": "uint256"
+      }
+    ],
+    "name": "RetryableTicketCreated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "L2Beanstalk",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxSubmissionCost",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxGas",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "gasPriceBid",
+        "type": "uint256"
+      }
+    ],
+    "name": "approveL2Reciever",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ticketID",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "L2Beanstalk",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum LibTransfer.To",
+        "name": "toMode",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxSubmissionCost",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxGas",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "gasPriceBid",
+        "type": "uint256"
+      }
+    ],
+    "name": "migrateL2Beans",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ticketID",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum LibTransfer.To",
+        "name": "toMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "L1BeansMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "depositIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "bdvs",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "L1DepositsMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "fertIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128[]",
+        "name": "amounts",
+        "type": "uint128[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "lastBpf",
+        "type": "uint128"
+      }
+    ],
+    "name": "L1FertilizerMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "L1InternalBalancesMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "index",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "pods",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "L1PlotsMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      }
+    ],
+    "name": "RecieverApproved",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      }
+    ],
+    "name": "approveReciever",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDepositMerkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFertilizerMerkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getInternalBalanceMerkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPlotMerkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "getReciever",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "depositIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "bdvs",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "issueDeposits",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "fertIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "amounts",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint128",
+        "name": "lastBpf",
+        "type": "uint128"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "issueFertilizer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "issueInternalBalances",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "index",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "pods",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "issuePlots",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "reciever",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum LibTransfer.To",
+        "name": "toMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "recieveL1Beans",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "depositIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "bdvs",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "verifyDepositMerkleProof",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "fertIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "amounts",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint128",
+        "name": "lastBpf",
+        "type": "uint128"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "verifyFertilizerMerkleProof",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "verifyInternalBalanceMerkleProof",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "index",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "verifyPlotMerkleProof",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -12747,6 +13419,37 @@
       }
     ],
     "name": "RemoveWhitelistStatus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "gpSelector",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "lwSelector",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "optimalPercentDepositedBdv",
+        "type": "uint64"
+      }
+    ],
+    "name": "UpdateGaugeSettings",
     "type": "event"
   },
   {

--- a/protocol/contracts/C.sol
+++ b/protocol/contracts/C.sol
@@ -6,6 +6,7 @@ import "./interfaces/IBean.sol";
 import "./interfaces/IFertilizer.sol";
 import "./interfaces/IProxyAdmin.sol";
 import "./libraries/Decimal.sol";
+import "./interfaces/IPipeline.sol";
 
 /**
  * @title C
@@ -73,5 +74,9 @@ library C {
 
     function precision() internal pure returns (uint256) {
         return PRECISION;
+    }
+
+    function pipeline() internal pure returns (IPipeline) {
+        return IPipeline(PIPELINE);
     }
 }

--- a/protocol/contracts/beanstalk/farm/DepotFacet.sol
+++ b/protocol/contracts/beanstalk/farm/DepotFacet.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.20;
 import "contracts/interfaces/IPipeline.sol";
 import "contracts/libraries/LibFunction.sol";
 import "contracts/libraries/Token/LibEth.sol";
+import {C} from "contracts/C.sol";
 import {Invariable} from "contracts/beanstalk/Invariable.sol";
 import {ReentrancyGuard} from "contracts/beanstalk/ReentrancyGuard.sol";
 
@@ -18,9 +19,6 @@ import {ReentrancyGuard} from "contracts/beanstalk/ReentrancyGuard.sol";
  **/
 
 contract DepotFacet is Invariable, ReentrancyGuard {
-    // Pipeline V1.0.1
-    address private constant PIPELINE = 0xb1bE000644bD25996b0d9C2F7a6D6BA3954c91B0;
-
     /**
      * @notice Pipe a PipeCall through Pipeline.
      * @param p PipeCall to pipe through Pipeline
@@ -29,7 +27,7 @@ contract DepotFacet is Invariable, ReentrancyGuard {
     function pipe(
         PipeCall calldata p
     ) external payable fundsSafu noSupplyIncrease nonReentrant returns (bytes memory result) {
-        result = IPipeline(PIPELINE).pipe(p);
+        result = C.pipeline().pipe(p);
     }
 
     /**
@@ -41,7 +39,7 @@ contract DepotFacet is Invariable, ReentrancyGuard {
     function multiPipe(
         PipeCall[] calldata pipes
     ) external payable fundsSafu noSupplyIncrease nonReentrant returns (bytes[] memory results) {
-        results = IPipeline(PIPELINE).multiPipe(pipes);
+        results = C.pipeline().multiPipe(pipes);
     }
 
     /**
@@ -53,7 +51,7 @@ contract DepotFacet is Invariable, ReentrancyGuard {
         AdvancedPipeCall[] calldata pipes,
         uint256 value
     ) external payable fundsSafu noSupplyIncrease nonReentrant returns (bytes[] memory results) {
-        results = IPipeline(PIPELINE).advancedPipe{value: value}(pipes);
+        results = C.pipeline().advancedPipe{value: value}(pipes);
         LibEth.refundEth();
     }
 
@@ -67,7 +65,7 @@ contract DepotFacet is Invariable, ReentrancyGuard {
         PipeCall calldata p,
         uint256 value
     ) external payable fundsSafu noSupplyIncrease nonReentrant returns (bytes memory result) {
-        result = IPipeline(PIPELINE).pipe{value: value}(p);
+        result = C.pipeline().pipe{value: value}(p);
         LibEth.refundEth();
     }
 

--- a/protocol/contracts/beanstalk/init/InitalizeDiamond.sol
+++ b/protocol/contracts/beanstalk/init/InitalizeDiamond.sol
@@ -53,6 +53,15 @@ contract InitalizeDiamond {
     // Excessive price threshold constant
     uint256 internal constant EXCESSIVE_PRICE_THRESHOLD = 1.05e6;
 
+    /// @dev When the Pod Rate is high, issue less Soil.
+    uint256 private constant SOIL_COEFFICIENT_HIGH = 0.5e18;
+
+    /// @dev When the Pod Rate is low, issue more Soil.
+    uint256 private constant SOIL_COEFFICIENT_LOW = 1.5e18;
+
+    /// @dev Base BEAN reward to cover cost of operating a bot.
+    uint256 internal constant BASE_REWARD = 5e6; // 5 BEAN
+
     // Gauge
     uint256 internal constant TARGET_SEASONS_TO_CATCHUP = 4320;
     uint256 internal constant MAX_BEAN_MAX_LP_GP_PER_BDV_RATIO = 100e18;
@@ -270,6 +279,9 @@ contract InitalizeDiamond {
         s.sys.evaluationParameters.lpToSupplyRatioOptimal = LP_TO_SUPPLY_RATIO_OPTIMAL;
         s.sys.evaluationParameters.lpToSupplyRatioLowerBound = LP_TO_SUPPLY_RATIO_LOWER_BOUND;
         s.sys.evaluationParameters.excessivePriceThreshold = EXCESSIVE_PRICE_THRESHOLD;
+        s.sys.evaluationParameters.soilCoefficientHigh = SOIL_COEFFICIENT_HIGH;
+        s.sys.evaluationParameters.soilCoefficientLow = SOIL_COEFFICIENT_LOW;
+        s.sys.evaluationParameters.baseReward = BASE_REWARD;
     }
 
     function initalizeFarmAndTractor() internal {

--- a/protocol/contracts/beanstalk/storage/System.sol
+++ b/protocol/contracts/beanstalk/storage/System.sol
@@ -442,6 +442,9 @@ struct EvaluationParameters {
     uint256 lpToSupplyRatioOptimal;
     uint256 lpToSupplyRatioLowerBound;
     uint256 excessivePriceThreshold;
+    uint256 soilCoefficientHigh;
+    uint256 soilCoefficientLow;
+    uint256 baseReward;
 }
 
 /**

--- a/protocol/contracts/beanstalk/sun/GaugePoints/GaugePointFacet.sol
+++ b/protocol/contracts/beanstalk/sun/GaugePoints/GaugePointFacet.sol
@@ -46,7 +46,7 @@ contract GaugePointFacet {
         uint256 currentGaugePoints,
         uint256 optimalPercentDepositedBdv,
         uint256 percentOfDepositedBdv,
-        bytes calldata
+        bytes memory
     ) public pure returns (uint256 newGaugePoints) {
         if (
             percentOfDepositedBdv >

--- a/protocol/contracts/beanstalk/sun/GaugePoints/GaugePointFacet.sol
+++ b/protocol/contracts/beanstalk/sun/GaugePoints/GaugePointFacet.sol
@@ -45,7 +45,8 @@ contract GaugePointFacet {
     function defaultGaugePointFunction(
         uint256 currentGaugePoints,
         uint256 optimalPercentDepositedBdv,
-        uint256 percentOfDepositedBdv
+        uint256 percentOfDepositedBdv,
+        bytes calldata
     ) public pure returns (uint256 newGaugePoints) {
         if (
             percentOfDepositedBdv >

--- a/protocol/contracts/beanstalk/sun/GaugePoints/GaugePointFacet.sol
+++ b/protocol/contracts/beanstalk/sun/GaugePoints/GaugePointFacet.sol
@@ -13,7 +13,8 @@ interface IGaugePointFacet {
     function defaultGaugePointFunction(
         uint256 currentGaugePoints,
         uint256 optimalPercentDepositedBdv,
-        uint256 percentOfDepositedBdv
+        uint256 percentOfDepositedBdv,
+        bytes memory
     ) external pure returns (uint256 newGaugePoints);
 }
 

--- a/protocol/contracts/beanstalk/sun/GaugePoints/GaugePointPrice.sol
+++ b/protocol/contracts/beanstalk/sun/GaugePoints/GaugePointPrice.sol
@@ -54,7 +54,7 @@ contract GaugePointPrice is GaugePointFacet {
         uint256 currentGaugePoints,
         uint256 optimalPercentDepositedBdv,
         uint256 percentOfDepositedBdv,
-        bytes calldata data
+        bytes memory data
     ) public view returns (uint256 newGaugePoints) {
         try IBS(beanstalk).getTokenUsdPrice(token) returns (uint256 price) {
             if (priceThreshold >= price) {

--- a/protocol/contracts/beanstalk/sun/GaugePoints/GaugePointPrice.sol
+++ b/protocol/contracts/beanstalk/sun/GaugePoints/GaugePointPrice.sol
@@ -53,7 +53,8 @@ contract GaugePointPrice is GaugePointFacet {
     function priceGaugePointFunction(
         uint256 currentGaugePoints,
         uint256 optimalPercentDepositedBdv,
-        uint256 percentOfDepositedBdv
+        uint256 percentOfDepositedBdv,
+        bytes calldata data
     ) public view returns (uint256 newGaugePoints) {
         try IBS(beanstalk).getTokenUsdPrice(token) returns (uint256 price) {
             if (priceThreshold >= price) {
@@ -64,7 +65,8 @@ contract GaugePointPrice is GaugePointFacet {
                     defaultGaugePointFunction(
                         currentGaugePoints,
                         optimalPercentDepositedBdv,
-                        percentOfDepositedBdv
+                        percentOfDepositedBdv,
+                        data
                     );
             }
         } catch {

--- a/protocol/contracts/beanstalk/sun/LiquidityWeightFacet.sol
+++ b/protocol/contracts/beanstalk/sun/LiquidityWeightFacet.sol
@@ -16,11 +16,11 @@ interface ILiquidityWeightFacet {
 contract LiquidityWeightFacet {
     uint256 constant MAX_WEIGHT = 1e18;
 
-    function maxWeight() external pure returns (uint256) {
+    function maxWeight(bytes calldata) external pure returns (uint256) {
         return MAX_WEIGHT;
     }
 
-    function noWeight() external pure returns (uint256) {
+    function noWeight(bytes calldata) external pure returns (uint256) {
         return 0;
     }
 }

--- a/protocol/contracts/beanstalk/sun/LiquidityWeightFacet.sol
+++ b/protocol/contracts/beanstalk/sun/LiquidityWeightFacet.sol
@@ -10,17 +10,19 @@ pragma solidity ^0.8.20;
  * @notice determines the liquidity weight. Used in the gauge system.
  */
 interface ILiquidityWeightFacet {
-    function maxWeight() external pure returns (uint256);
+    function maxWeight(bytes memory) external pure returns (uint256);
+
+    function noWeight(bytes memory) external pure returns (uint256);
 }
 
 contract LiquidityWeightFacet {
     uint256 constant MAX_WEIGHT = 1e18;
 
-    function maxWeight(bytes calldata) external pure returns (uint256) {
+    function maxWeight(bytes memory) external pure returns (uint256) {
         return MAX_WEIGHT;
     }
 
-    function noWeight(bytes calldata) external pure returns (uint256) {
+    function noWeight(bytes memory) external pure returns (uint256) {
         return 0;
     }
 }

--- a/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
+++ b/protocol/contracts/beanstalk/sun/SeasonFacet/Sun.sol
@@ -25,12 +25,6 @@ contract Sun is Oracle, Distribution {
     using LibRedundantMath128 for uint128;
     using SignedMath for int256;
 
-    /// @dev When the Pod Rate is high, issue less Soil.
-    uint256 private constant SOIL_COEFFICIENT_HIGH = 0.5e18;
-
-    /// @dev When the Pod Rate is low, issue more Soil.
-    uint256 private constant SOIL_COEFFICIENT_LOW = 1.5e18;
-
     /**
      * @notice Emitted during Sunrise when Beanstalk adjusts the amount of available Soil.
      * @param season The Season in which Soil was adjusted.
@@ -76,9 +70,9 @@ contract Sun is Oracle, Distribution {
     function setSoilAbovePeg(uint256 newHarvestable, uint256 caseId) internal {
         uint256 newSoil = newHarvestable.mul(100).div(100 + s.sys.weather.temp);
         if (caseId.mod(36) >= 24) {
-            newSoil = newSoil.mul(SOIL_COEFFICIENT_HIGH).div(C.PRECISION); // high podrate
+            newSoil = newSoil.mul(s.sys.evaluationParameters.soilCoefficientHigh).div(C.PRECISION); // high podrate
         } else if (caseId.mod(36) < 8) {
-            newSoil = newSoil.mul(SOIL_COEFFICIENT_LOW).div(C.PRECISION); // low podrate
+            newSoil = newSoil.mul(s.sys.evaluationParameters.soilCoefficientLow).div(C.PRECISION); // low podrate
         }
         setSoil(newSoil);
     }

--- a/protocol/contracts/libraries/Convert/LibPipelineConvert.sol
+++ b/protocol/contracts/libraries/Convert/LibPipelineConvert.sol
@@ -144,7 +144,7 @@ library LibPipelineConvert {
         PipeCall memory p;
         p.target = address(tokenOut);
         p.data = abi.encodeWithSelector(IERC20.transfer.selector, address(this), amountOut);
-        IPipeline(C.PIPELINE).pipe(p);
+        C.pipeline().pipe(p);
     }
 
     function populatePipelineConvertData(

--- a/protocol/contracts/libraries/LibEvaluate.sol
+++ b/protocol/contracts/libraries/LibEvaluate.sol
@@ -318,7 +318,9 @@ library LibEvaluate {
         address target = lw.target;
         if (target == address(0)) target = address(this);
 
-        (bool success, bytes memory data) = target.staticcall(abi.encodeWithSelector(lw.selector));
+        (bool success, bytes memory data) = target.staticcall(
+            abi.encodeWithSelector(lw.selector, lw.data)
+        );
 
         if (!success) return 0;
         assembly {

--- a/protocol/contracts/libraries/LibGauge.sol
+++ b/protocol/contracts/libraries/LibGauge.sol
@@ -200,7 +200,8 @@ library LibGauge {
                 selector,
                 ss.gaugePoints,
                 ss.optimalPercentDepositedBdv,
-                percentDepositedBdv
+                percentDepositedBdv,
+                ss.gaugePointImplementation.data
             )
         );
 

--- a/protocol/contracts/libraries/LibIncentive.sol
+++ b/protocol/contracts/libraries/LibIncentive.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 
 import {LibRedundantMath256} from "contracts/libraries/LibRedundantMath256.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "../C.sol";
+import {LibAppStorage, AppStorage} from "contracts/libraries/LibAppStorage.sol";
 
 /**
  * @title LibIncentive
@@ -33,7 +33,8 @@ library LibIncentive {
     /**
      * @param secondsLate The number of seconds late that {sunrise()} was called.
      */
-    function determineReward(uint256 secondsLate) external pure returns (uint256) {
+    function determineReward(uint256 secondsLate) external view returns (uint256) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
         // Cap the maximum number of seconds late. If the sunrise is later than
         // this, Beanstalk will pay the same amount. Prevents unbounded return value.
         if (secondsLate > MAX_SECONDS_LATE) {
@@ -43,7 +44,7 @@ library LibIncentive {
         // Scale the reward up as the number of seconds after expected sunrise increases.
         // `sunriseReward * (1 + 1/100)^(seconds late)`
         // NOTE: 1.01^(300) = 19.78, This is the maximum multiplier.
-        return fracExp(BASE_REWARD, secondsLate);
+        return fracExp(s.sys.evaluationParameters.baseReward, secondsLate);
     }
 
     //////////////////// MATH UTILITIES ////////////////////

--- a/protocol/contracts/libraries/LibIncentive.sol
+++ b/protocol/contracts/libraries/LibIncentive.sol
@@ -25,9 +25,6 @@ library LibIncentive {
     /// @dev The Sunrise reward reaches its maximum after this many seconds elapse.
     uint256 internal constant MAX_SECONDS_LATE = 300;
 
-    /// @dev Base BEAN reward to cover cost of operating a bot.
-    uint256 internal constant BASE_REWARD = 5e6; // 5 BEAN
-
     /// @dev `sunriseReward` is precomputed in {fracExp} using this precision.
     uint256 private constant FRAC_EXP_PRECISION = 1e6;
 

--- a/protocol/contracts/mocks/MockOracle.sol
+++ b/protocol/contracts/mocks/MockOracle.sol
@@ -22,7 +22,7 @@ contract MockOracle {
     /**
      * @notice Valid Implementation.
      */
-    function getPrice(uint256 lookback) public view returns (uint256) {
+    function getPrice(uint256, uint256 lookback, bytes memory) public view returns (uint256) {
         if (lookback > 0) {
             return twaPrice;
         } else {
@@ -33,10 +33,14 @@ contract MockOracle {
     /**
      * @notice Invalid due to changing state.
      */
-    function invalidGetPrice(uint256 lookback) external returns (uint256) {
+    function invalidGetPrice(
+        uint256 decimals,
+        uint256 lookback,
+        bytes memory
+    ) external returns (uint256) {
         twaPrice = twaPrice;
         price = price;
-        return getPrice(lookback);
+        return getPrice(decimals, lookback, new bytes(0));
     }
 
     /**
@@ -45,6 +49,6 @@ contract MockOracle {
     function invalidGetPrice2(uint256 lookback, uint256 param2) external returns (uint256) {
         twaPrice = twaPrice;
         price = price;
-        return getPrice(lookback + param2);
+        return getPrice(lookback + param2, 0, new bytes(0));
     }
 }

--- a/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -57,12 +57,6 @@ contract MockSeasonFacet is SeasonFacet {
     event GaugePointChange(uint256 indexed season, address indexed token, uint256 gaugePoints);
     event Incentivization(address indexed account, uint256 beans);
     event UpdateAverageStalkPerBdvPerSeason(uint256 newStalkPerBdvPerSeason);
-    event UpdateGaugeSettings(
-        address indexed token,
-        bytes4 gpSelector,
-        bytes4 lwSelector,
-        uint64 optimalPercentDepositedBdv
-    );
     event TotalGerminatingStalkChanged(uint256 season, int256 deltaStalk);
     event TotalStalkChangedFromGermination(int256 deltaStalk, int256 deltaRoots);
 
@@ -518,12 +512,6 @@ contract MockSeasonFacet is SeasonFacet {
         ss.gaugePointImplementation.selector = gaugePointSelector;
         ss.liquidityWeightImplementation.selector = liquidityWeightSelector;
         ss.optimalPercentDepositedBdv = optimalPercentDepositedBdv;
-        emit UpdateGaugeSettings(
-            token,
-            gaugePointSelector,
-            liquidityWeightSelector,
-            optimalPercentDepositedBdv
-        );
     }
 
     function mockEndTotalGerminationForToken(address token) external {

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -36,7 +36,12 @@ const { to6 } = require("./test/hardhat/utils/helpers.js");
 const { reseed } = require("./reseed/reseed.js");
 const { task } = require("hardhat/config");
 const { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } = require("hardhat/builtin-tasks/task-names");
-const { bipNewSilo, bipMorningAuction, bipSeedGauge, bipMiscellaneousImprovements } = require("./scripts/bips.js");
+const {
+  bipNewSilo,
+  bipMorningAuction,
+  bipSeedGauge,
+  bipMiscellaneousImprovements
+} = require("./scripts/bips.js");
 const { ebip9, ebip10, ebip11, ebip13, ebip14, ebip15 } = require("./scripts/ebips.js");
 
 //////////////////////// UTILITIES ////////////////////////
@@ -119,7 +124,17 @@ task("diamondABI", "Generates ABI file for diamond, includes all ABIs of facets"
   const modulesDir = path.join("contracts", "beanstalk");
 
   // The list of modules to combine into a single ABI. All facets (and facet dependencies) will be aggregated.
-  const modules = ["barn", "diamond", "farm", "field", "market", "silo", "sun", "metadata"];
+  const modules = [
+    "barn",
+    "diamond",
+    "farm",
+    "field",
+    "market",
+    "silo",
+    "sun",
+    "metadata",
+    "migration"
+  ];
 
   // The glob returns the full file path like this:
   // contracts/beanstalk/barn/UnripeFacet.sol
@@ -190,7 +205,17 @@ task("mockDiamondABI", "Generates ABI file for mock contracts", async () => {
   const modulesDir = path.join("contracts", "beanstalk");
 
   // The list of modules to combine into a single ABI. All facets (and facet dependencies) will be aggregated.
-  const modules = ["barn", "diamond", "farm", "field", "market", "silo", "sun", "metadata"];
+  const modules = [
+    "barn",
+    "diamond",
+    "farm",
+    "field",
+    "market",
+    "silo",
+    "sun",
+    "metadata",
+    "migration"
+  ];
 
   // The glob returns the full file path like this:
   // contracts/beanstalk/barn/UnripeFacet.sol

--- a/protocol/test/foundry/silo/Whitelist.t.sol
+++ b/protocol/test/foundry/silo/Whitelist.t.sol
@@ -4,18 +4,30 @@ pragma abicoder v2;
 
 import {TestHelper, LibTransfer, C} from "test/foundry/utils/TestHelper.sol";
 import {IMockFBeanstalk} from "contracts/interfaces/IMockFBeanstalk.sol";
-import {MockToken} from "contracts/mocks/MockToken.sol";
 import {IDiamondCut} from "contracts/interfaces/IDiamondCut.sol";
 import {WhitelistFacet} from "contracts/beanstalk/silo/WhitelistFacet/WhitelistFacet.sol";
 import {LibUsdOracle} from "contracts/libraries/Oracle/LibUsdOracle.sol";
 import {OracleFacet} from "contracts/beanstalk/sun/OracleFacet.sol";
 import {LibChainlinkOracle} from "contracts/libraries/Oracle/LibChainlinkOracle.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Implementation} from "contracts/beanstalk/storage/System.sol";
+import {MockOracle} from "contracts/mocks/MockOracle.sol";
+import {GaugePointFacet} from "contracts/beanstalk/sun/GaugePoints/GaugePointFacet.sol";
+import {LiquidityWeightFacet} from "contracts/beanstalk/sun/LiquidityWeightFacet.sol";
+
+contract MockWellToken {
+    function tokens() public returns (IERC20[] memory) {
+        IERC20[] memory _tokens = new IERC20[](2);
+        _tokens[0] = IERC20(C.WETH);
+        _tokens[1] = IERC20(C.WETH);
+        return _tokens;
+    }
+}
 
 /**
  * @notice Tests the functionality of whitelisting.
  */
 contract WhitelistTest is TestHelper {
-    address constant wBTC = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
     // events
     event AddWhitelistStatus(
         address token,
@@ -25,16 +37,49 @@ contract WhitelistTest is TestHelper {
         bool isWhitelistedWell,
         bool isSoppable
     );
+    /**
+     * @notice Emitted when a token is added to the Silo Whitelist.
+     * @param token ERC-20 token being added to the Silo Whitelist.
+     * @param selector The function selector that returns the BDV of a given token.
+     * @param stalkEarnedPerSeason The Stalk per BDV per Season received from depositing `token`.
+     * @param stalkIssuedPerBdv The Stalk per BDV given from depositing `token`.
+     * @param gaugePoints The gauge points of the token.
+     * @param optimalPercentDepositedBdv The target percentage
+     * of the total LP deposited BDV for this token.
+     */
     event WhitelistToken(
         address indexed token,
         bytes4 selector,
         uint32 stalkEarnedPerSeason,
         uint256 stalkIssuedPerBdv,
-        bytes4 gpSelector,
-        bytes4 lwSelector,
         uint128 gaugePoints,
         uint64 optimalPercentDepositedBdv
     );
+
+    /**
+     * @notice Emitted when the oracle implementation for a token is updated.
+     */
+    event UpdatedOracleImplementationForToken(
+        address indexed token,
+        IMockFBeanstalk.Implementation oracleImplementation
+    );
+
+    /**
+     * @notice Emitted when the gauge point implementation for a token is updated.
+     */
+    event UpdatedGaugePointImplementationForToken(
+        address indexed token,
+        IMockFBeanstalk.Implementation gpImplementation
+    );
+
+    /**
+     * @notice Emitted when the liquidity weight implementation for a token is updated.
+     */
+    event UpdatedLiquidityWeightImplementationForToken(
+        address indexed token,
+        IMockFBeanstalk.Implementation lwImplementation
+    );
+
     event DewhitelistToken(address indexed token);
 
     function setUp() public {
@@ -50,124 +95,89 @@ contract WhitelistTest is TestHelper {
             bytes4(0),
             0,
             0,
-            bytes4(0),
-            bytes4(0),
-            0,
-            0,
-            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0))
-        );
-
-        vm.expectRevert("LibDiamond: Must be contract or owner");
-        bs.whitelistTokenWithEncodeType(
-            address(0),
-            bytes4(0),
-            0,
-            0,
             bytes1(0),
-            bytes4(0),
-            bytes4(0),
             0,
             0,
+            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0)),
+            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0)),
             IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0))
         );
     }
 
-    function test_whitelistRevertInvalidGaugePointSelector(uint i) public prank(BEANSTALK) {
-        bytes4 bdvSelector = IMockFBeanstalk.beanToBDV.selector;
-        bytes4 gaugePointSelector = bytes4(keccak256(abi.encode(i)));
+    function test_whitelistRevertInvalidgpImplementation(uint i) public prank(BEANSTALK) {
+        bytes4 gpSelector = bytes4(keccak256(abi.encode(i)));
 
-        vm.expectRevert("Whitelist: Invalid GaugePoint selector");
+        vm.expectRevert("Whitelist: Invalid GaugePoint Implementation");
         bs.whitelistToken(
             address(0),
-            bdvSelector,
-            0,
-            0,
-            gaugePointSelector,
-            bytes4(0),
-            0,
-            0,
-            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0))
-        );
-
-        vm.expectRevert("Whitelist: Invalid GaugePoint selector");
-        bs.whitelistTokenWithEncodeType(
-            address(0),
-            bdvSelector,
+            IMockFBeanstalk.beanToBDV.selector,
             0,
             0,
             bytes1(0),
-            gaugePointSelector,
-            bytes4(0),
             0,
             0,
+            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0)),
+            IMockFBeanstalk.Implementation(address(0), gpSelector, bytes1(0), new bytes(0)),
             IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0))
         );
     }
 
-    function test_whitelistRevertInvalidLiquidityWeightSelector(uint i) public prank(BEANSTALK) {
-        bytes4 bdvSelector = IMockFBeanstalk.beanToBDV.selector;
-        bytes4 gaugePointSelector = IMockFBeanstalk.defaultGaugePointFunction.selector;
-        bytes4 liquidityWeightSelector = bytes4(keccak256(abi.encode(i)));
+    function test_whitelistRevertInvalidlwImplementation(uint i) public prank(BEANSTALK) {
+        bytes4 gpSelector = IMockFBeanstalk.defaultGaugePointFunction.selector;
+        bytes4 lwSelector = bytes4(keccak256(abi.encode(i)));
 
-        vm.expectRevert("Whitelist: Invalid LiquidityWeight selector");
+        vm.expectRevert("Whitelist: Invalid LiquidityWeight Implementation");
         bs.whitelistToken(
             address(0),
-            bdvSelector,
-            0,
-            0,
-            gaugePointSelector,
-            liquidityWeightSelector,
-            0,
-            0,
-            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0))
-        );
-
-        vm.expectRevert("Whitelist: Invalid LiquidityWeight selector");
-        bs.whitelistTokenWithEncodeType(
-            address(0),
-            bdvSelector,
+            IMockFBeanstalk.beanToBDV.selector,
             0,
             0,
             bytes1(0),
-            gaugePointSelector,
-            liquidityWeightSelector,
             0,
             0,
-            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0))
+            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0)),
+            IMockFBeanstalk.Implementation(address(0), gpSelector, bytes1(0), new bytes(0)),
+            IMockFBeanstalk.Implementation(address(0), lwSelector, bytes1(0), new bytes(0))
+        );
+    }
+
+    function test_whitelistRevertInvalidOracleImplementation(uint i) public prank(BEANSTALK) {
+        address token = address(new MockWellToken());
+        bytes4 gpSelector = IMockFBeanstalk.defaultGaugePointFunction.selector;
+        bytes4 lwSelector = IMockFBeanstalk.maxWeight.selector;
+        bytes4 oSelector = bytes4(keccak256(abi.encode(i)));
+
+        vm.expectRevert("Whitelist: Invalid Oracle Implementation");
+        bs.whitelistToken(
+            token,
+            IMockFBeanstalk.wellBdv.selector,
+            0,
+            0,
+            bytes1(0x01),
+            0,
+            0,
+            IMockFBeanstalk.Implementation(address(0), oSelector, bytes1(0), new bytes(0)),
+            IMockFBeanstalk.Implementation(address(0), gpSelector, bytes1(0), new bytes(0)),
+            IMockFBeanstalk.Implementation(address(0), lwSelector, bytes1(0), new bytes(0))
         );
     }
 
     function test_whitelistRevertExistingWhitelistedToken() public prank(BEANSTALK) {
-        bytes4 bdvSelector = IMockFBeanstalk.beanToBDV.selector;
-        bytes4 gaugePointSelector = IMockFBeanstalk.defaultGaugePointFunction.selector;
-        bytes4 liquidityWeightSelector = IMockFBeanstalk.maxWeight.selector;
-        address token = BEAN;
+        bytes4 gpSelector = IMockFBeanstalk.defaultGaugePointFunction.selector;
+        bytes4 lwSelector = IMockFBeanstalk.maxWeight.selector;
 
         vm.expectRevert("Whitelist: Token already whitelisted");
         bs.whitelistToken(
-            token,
-            bdvSelector,
-            0,
-            0,
-            gaugePointSelector,
-            liquidityWeightSelector,
-            0,
-            0,
-            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0))
-        );
-
-        vm.expectRevert("Whitelist: Token already whitelisted");
-        bs.whitelistTokenWithEncodeType(
-            token,
-            bdvSelector,
+            BEAN,
+            IMockFBeanstalk.beanToBDV.selector,
             0,
             0,
             bytes1(0),
-            gaugePointSelector,
-            liquidityWeightSelector,
             0,
             0,
-            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0))
+            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0x01), new bytes(0)),
+            IMockFBeanstalk.Implementation(address(0), gpSelector, bytes1(0), new bytes(0)),
+            IMockFBeanstalk.Implementation(address(0), lwSelector, bytes1(0), new bytes(0))
         );
     }
 
@@ -185,102 +195,122 @@ contract WhitelistTest is TestHelper {
         uint128 gaugePoints,
         uint64 optimalPercentDepositedBdv
     ) public prank(BEANSTALK) {
-        address token = address(new MockToken("Mock Token", "MTK"));
-        bytes4 bdvSelector = IMockFBeanstalk.beanToBDV.selector;
-        bytes4 gaugePointSelector = IMockFBeanstalk.defaultGaugePointFunction.selector;
-        bytes4 liquidityWeightSelector = IMockFBeanstalk.maxWeight.selector;
+        address token = address(new MockWellToken());
+        bytes4 bdvSelector = IMockFBeanstalk.wellBdv.selector;
+        IMockFBeanstalk.Implementation memory oracleImplementation = IMockFBeanstalk.Implementation(
+            address(ETH_USD_CHAINLINK_PRICE_AGGREGATOR),
+            bytes4(0),
+            bytes1(0x01),
+            new bytes(0)
+        );
 
-        vm.expectEmit();
-        emit AddWhitelistStatus(token, 5, true, true, false, false);
-        vm.expectEmit();
-        emit WhitelistToken(
+        IMockFBeanstalk.Implementation memory gpImplementation = IMockFBeanstalk.Implementation(
+            address(0),
+            IMockFBeanstalk.defaultGaugePointFunction.selector,
+            bytes1(0x01),
+            new bytes(0)
+        );
+
+        IMockFBeanstalk.Implementation memory lwImplementation = IMockFBeanstalk.Implementation(
+            address(0),
+            IMockFBeanstalk.maxWeight.selector,
+            bytes1(0x01),
+            new bytes(0)
+        );
+
+        verifyWhitelistEvents(
             token,
             bdvSelector,
-            stalkEarnedPerSeason == 0 ? 1 : stalkEarnedPerSeason,
+            stalkEarnedPerSeason,
             stalkIssuedPerBdv,
-            gaugePointSelector,
-            liquidityWeightSelector,
             gaugePoints,
-            optimalPercentDepositedBdv
+            optimalPercentDepositedBdv,
+            oracleImplementation,
+            gpImplementation,
+            lwImplementation
+        );
+
+        bs.whitelistToken(
+            token,
+            bdvSelector,
+            stalkIssuedPerBdv,
+            stalkEarnedPerSeason,
+            bytes1(0),
+            gaugePoints,
+            optimalPercentDepositedBdv,
+            oracleImplementation,
+            gpImplementation,
+            lwImplementation
+        );
+
+        verifyWhitelistState(
+            token,
+            bdvSelector,
+            stalkEarnedPerSeason,
+            stalkIssuedPerBdv,
+            gpImplementation.selector,
+            lwImplementation.selector,
+            gaugePoints,
+            optimalPercentDepositedBdv,
+            true,
+            true,
+            true
+        );
+    }
+
+    function test_whitelistTokenWithExternalImplementation(
+        uint32 stalkEarnedPerSeason,
+        uint48 stalkIssuedPerBdv,
+        uint128 gaugePoints,
+        uint64 optimalPercentDepositedBdv
+    ) public prank(BEANSTALK) {
+        address token = address(new MockWellToken());
+        bytes4 bdvSelector = IMockFBeanstalk.wellBdv.selector;
+
+        // deploy mock Oracle:
+        IMockFBeanstalk.Implementation memory oracleImplementation = IMockFBeanstalk.Implementation(
+            address(new MockOracle(1e6, 1e6)),
+            MockOracle.getPrice.selector,
+            bytes1(0),
+            new bytes(0)
+        );
+
+        IMockFBeanstalk.Implementation memory gpImplementation = IMockFBeanstalk.Implementation(
+            address(new GaugePointFacet()),
+            GaugePointFacet.defaultGaugePointFunction.selector,
+            bytes1(0),
+            new bytes(0)
+        );
+
+        IMockFBeanstalk.Implementation memory lwImplementation = IMockFBeanstalk.Implementation(
+            address(new LiquidityWeightFacet()),
+            LiquidityWeightFacet.maxWeight.selector,
+            bytes1(0),
+            new bytes(0)
+        );
+
+        verifyWhitelistEvents(
+            token,
+            bdvSelector,
+            stalkEarnedPerSeason,
+            stalkIssuedPerBdv,
+            gaugePoints,
+            optimalPercentDepositedBdv,
+            oracleImplementation,
+            gpImplementation,
+            lwImplementation
         );
         bs.whitelistToken(
             token,
             bdvSelector,
             stalkIssuedPerBdv,
             stalkEarnedPerSeason,
-            gaugePointSelector,
-            liquidityWeightSelector,
+            0x01,
             gaugePoints,
             optimalPercentDepositedBdv,
-            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0))
-        );
-
-        verifyWhitelistState(
-            token,
-            bdvSelector,
-            stalkEarnedPerSeason,
-            stalkIssuedPerBdv,
-            gaugePointSelector,
-            liquidityWeightSelector,
-            gaugePoints,
-            optimalPercentDepositedBdv,
-            true,
-            true,
-            false
-        );
-    }
-
-    /**
-     * @notice validates general whitelist functionality.
-     */
-    function test_whitelistTokenWithEncodeType(
-        uint32 stalkEarnedPerSeason,
-        uint48 stalkIssuedPerBdv,
-        uint8 encodeType,
-        uint128 gaugePoints,
-        uint64 optimalPercentDepositedBdv
-    ) public prank(BEANSTALK) {
-        address token = address(new MockToken("Mock Token", "MTK"));
-        bytes4 bdvSelector = IMockFBeanstalk.beanToBDV.selector;
-        bytes4 gaugePointSelector = IMockFBeanstalk.defaultGaugePointFunction.selector;
-        bytes4 liquidityWeightSelector = IMockFBeanstalk.maxWeight.selector;
-        encodeType = encodeType % 2; // 0 or 1
-        verifyWhitelistEvents(
-            token,
-            bdvSelector,
-            stalkEarnedPerSeason,
-            stalkIssuedPerBdv,
-            gaugePointSelector,
-            liquidityWeightSelector,
-            gaugePoints,
-            optimalPercentDepositedBdv,
-            false
-        );
-        bs.whitelistTokenWithEncodeType(
-            token,
-            bdvSelector,
-            stalkIssuedPerBdv,
-            stalkEarnedPerSeason,
-            bytes1(encodeType),
-            gaugePointSelector,
-            liquidityWeightSelector,
-            gaugePoints,
-            optimalPercentDepositedBdv,
-            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0), new bytes(0))
-        );
-
-        verifyWhitelistState(
-            token,
-            bdvSelector,
-            stalkEarnedPerSeason,
-            stalkIssuedPerBdv,
-            gaugePointSelector,
-            liquidityWeightSelector,
-            gaugePoints,
-            optimalPercentDepositedBdv,
-            true,
-            true,
-            false
+            oracleImplementation,
+            gpImplementation,
+            lwImplementation
         );
     }
 
@@ -308,83 +338,35 @@ contract WhitelistTest is TestHelper {
         assertEq(uint256(newSS.milestoneSeason), season);
     }
 
-    function test_whitelistTokenWithExternalImplementation(
-        uint32 stalkEarnedPerSeason,
-        uint48 stalkIssuedPerBdv,
-        uint128 gaugePoints,
-        uint64 optimalPercentDepositedBdv
-    ) public prank(BEANSTALK) {
-        address token = address(new MockToken("Mock Token", "MTK"));
-        bytes4 liquidityWeightSelector = IMockFBeanstalk.maxWeight.selector;
-        bytes1 encodeType = 0x01;
-
-        IMockFBeanstalk.Implementation memory oracleImplementation = IMockFBeanstalk.Implementation(
-            address(0),
-            bytes4(0),
-            bytes1(0),
-            new bytes(0)
-        );
-
-        IMockFBeanstalk.Implementation memory gaugePointImplementation = IMockFBeanstalk
-            .Implementation(
-                address(0),
-                IMockFBeanstalk.defaultGaugePointFunction.selector,
-                bytes1(0),
-                new bytes(0)
-            );
-
-        IMockFBeanstalk.Implementation memory liquidityWeightImplementation = IMockFBeanstalk
-            .Implementation(address(0), liquidityWeightSelector, bytes1(0), new bytes(0));
-
-        verifyWhitelistEvents(
-            token,
-            IMockFBeanstalk.beanToBDV.selector,
-            stalkEarnedPerSeason,
-            stalkIssuedPerBdv,
-            bytes4(0),
-            bytes4(0),
-            gaugePoints,
-            optimalPercentDepositedBdv,
-            false
-        );
-        bs.whitelistTokenWithExternalImplementation(
-            token,
-            IMockFBeanstalk.beanToBDV.selector,
-            stalkIssuedPerBdv,
-            stalkEarnedPerSeason,
-            encodeType,
-            gaugePoints,
-            optimalPercentDepositedBdv,
-            oracleImplementation,
-            gaugePointImplementation,
-            liquidityWeightImplementation
-        );
-    }
-
     function verifyWhitelistEvents(
         address token,
         bytes4 bdvSelector,
         uint32 stalkEarnedPerSeason,
         uint48 stalkIssuedPerBdv,
-        bytes4 gaugePointSelector,
-        bytes4 liquidityWeightSelector,
         uint128 gaugePoints,
         uint64 optimalPercentDepositedBdv,
-        bool isSoppable
+        IMockFBeanstalk.Implementation memory oracleImplementation,
+        IMockFBeanstalk.Implementation memory gpImplementation,
+        IMockFBeanstalk.Implementation memory lwImplementation
     ) public {
+        (address _token, ) = bs.getNonBeanTokenAndIndexFromWell(token);
         vm.expectEmit();
-        emit AddWhitelistStatus(token, 5, true, true, false, isSoppable);
+        emit AddWhitelistStatus(token, 5, true, true, true, true);
+        vm.expectEmit();
+        emit UpdatedOracleImplementationForToken(_token, oracleImplementation);
         vm.expectEmit();
         emit WhitelistToken(
             token,
             bdvSelector,
             stalkEarnedPerSeason == 0 ? 1 : stalkEarnedPerSeason,
             stalkIssuedPerBdv,
-            gaugePointSelector,
-            liquidityWeightSelector,
             gaugePoints,
             optimalPercentDepositedBdv
         );
+        vm.expectEmit();
+        emit UpdatedGaugePointImplementationForToken(token, gpImplementation);
+        vm.expectEmit();
+        emit UpdatedLiquidityWeightImplementationForToken(token, lwImplementation);
     }
 
     function verifyWhitelistState(

--- a/protocol/test/foundry/sun/Flood.t.sol
+++ b/protocol/test/foundry/sun/Flood.t.sol
@@ -436,7 +436,7 @@ contract FloodTest is TestHelper {
         // claims user plenty
         bs.mow(users[2], BEAN);
         vm.prank(users[2]);
-        bs.claimPlenty(sopWell, IMockFBeanstalk.To.EXTERNAL);
+        bs.claimPlenty(sopWell, 0);
         assertEq(bs.balanceOfPlenty(users[2], sopWell), 0);
         assertEq(IERC20(C.WETH).balanceOf(users[2]), userCalcPlenty);
     }
@@ -570,7 +570,7 @@ contract FloodTest is TestHelper {
         // claims user plenty
         bs.mow(users[2], sopWell);
         vm.prank(users[2]);
-        bs.claimPlenty(sopWell, IMockFBeanstalk.To.EXTERNAL);
+        bs.claimPlenty(sopWell, 0);
         assertEq(bs.balanceOfPlenty(users[2], sopWell), 0);
         assertEq(IERC20(C.WETH).balanceOf(users[2]), 25595575914848452999);
     }
@@ -781,7 +781,7 @@ contract FloodTest is TestHelper {
         // claims user plenty
         bs.mow(users[2], BEAN);
         vm.prank(users[2]);
-        bs.claimPlenty(sopWell, IMockFBeanstalk.To.EXTERNAL);
+        bs.claimPlenty(sopWell, 0);
         assertEq(
             bs.balanceOfPlenty(users[2], sopWell),
             0,

--- a/protocol/test/foundry/sun/Gauge.t.sol
+++ b/protocol/test/foundry/sun/Gauge.t.sol
@@ -534,7 +534,8 @@ contract GaugeTest is TestHelper {
         uint256 newGaugePoints = gpP.priceGaugePointFunction(
             gaugePoints,
             optimalPercentDepositedBdv,
-            percentOfDepositedBdv
+            percentOfDepositedBdv,
+            new bytes(0)
         );
 
         if (gpP.getPriceThreshold() >= price) {
@@ -548,7 +549,8 @@ contract GaugeTest is TestHelper {
                 gpP.defaultGaugePointFunction(
                     gaugePoints,
                     optimalPercentDepositedBdv,
-                    percentOfDepositedBdv
+                    percentOfDepositedBdv,
+                    new bytes(0)
                 )
             );
         }
@@ -566,7 +568,8 @@ contract GaugeTest is TestHelper {
         uint256 newGaugePoints = gpP.defaultGaugePointFunction(
             gaugePoints,
             optimalPercentDepositedBdv,
-            percentOfDepositedBdv
+            percentOfDepositedBdv,
+            new bytes(0)
         );
 
         uint256 extFarAbove = gpP.getExtremelyFarAbove(optimalPercentDepositedBdv);


### PR DESCRIPTION
The Implementation struct was recently provides an generic bytes parameter that any implementation can use to provide data to a given Implementation Contract. This PR adds support for the GaugePoint and LiquidityWeight to use the generic bytes when calling the Implementation. This potentially allows for any implementation to be implemented without introducing new encoding types. 

Encode Types are kept in the instance where multiple Implementations share a common Interface, where the code can be upgraded to support different function signatures, but are not explicitly necessary. 

The various whitelisting functions were consolidated into a single whitelist function due to the redundancy that was 

Misc Changes. 
- Updates the DepotFacet to use C.PIPELINE, rather than defining pipeline in the facet (removes redundancy). 
- Fixed a bug in the GaugePoint, LiquidityWeight, and Oracle Implementation where invalid Calls still were considered valid in some scenarios. 
- the coefficient for soil above peg, and the bean reward, are now set in state rather than defined as a constant.