### PR TITLE
Adjust seeds upon rain start

### DIFF
--- a/protocol/contracts/libraries/Silo/LibFlood.sol
+++ b/protocol/contracts/libraries/Silo/LibFlood.sol
@@ -62,6 +62,7 @@ library LibFlood {
             }
             return;
         } else if (!s.sys.season.raining) {
+            initRainVariables();
             startRain();
         } else {
             // flood podline first, because it checks current Bean supply
@@ -92,9 +93,9 @@ library LibFlood {
     }
 
     /**
-     * @notice Handles any system-level logic that occurs when it starts raining.
+     * @notice Snapshot variables required to start raining.
      */
-    function startRain() internal {
+    function initRainVariables() internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         s.sys.season.raining = true;
@@ -108,6 +109,13 @@ library LibFlood {
         s.sys.season.rainStart = s.sys.season.current;
         s.sys.rain.pods = s.sys.fields[s.sys.activeField].pods;
         s.sys.rain.roots = s.sys.silo.roots;
+    }
+
+    /**
+     * @notice Handles any system-level logic that occurs when it starts raining.
+     */
+    function startRain() internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
 
         // upon rain, set beanToMaxLpGpPerBdvRatio to zero, to encourage converts down before starting to flood
         s.sys.seedGauge.beanToMaxLpGpPerBdvRatio = 0;

--- a/protocol/contracts/libraries/Silo/LibFlood.sol
+++ b/protocol/contracts/libraries/Silo/LibFlood.sol
@@ -62,20 +62,7 @@ library LibFlood {
             }
             return;
         } else if (!s.sys.season.raining) {
-            s.sys.season.raining = true;
-            address[] memory wells = LibWhitelistedTokens.getCurrentlySoppableWellLpTokens();
-            // Set the plenty per root equal to previous rain start.
-            uint32 season = s.sys.season.current;
-            uint32 rainstartSeason = s.sys.season.rainStart;
-            for (uint i; i < wells.length; i++) {
-                s.sys.sop.sops[season][wells[i]] = s.sys.sop.sops[rainstartSeason][wells[i]];
-            }
-            s.sys.season.rainStart = s.sys.season.current;
-            s.sys.rain.pods = s.sys.fields[s.sys.activeField].pods;
-            s.sys.rain.roots = s.sys.silo.roots;
-
-            // upon rain, set beanToMaxLpGpPerBdvRatio to zero, to encourage converts down before starting to flood
-            s.sys.seedGauge.beanToMaxLpGpPerBdvRatio = 0;
+            startRain();
         } else {
             // flood podline first, because it checks current Bean supply
             floodPodline();
@@ -102,6 +89,28 @@ library LibFlood {
                 s.sys.season.lastSopSeason = s.sys.season.current;
             }
         }
+    }
+
+    /**
+     * @notice Handles any system-level logic that occurs when it starts raining.
+     */
+    function startRain() internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        s.sys.season.raining = true;
+        address[] memory wells = LibWhitelistedTokens.getCurrentlySoppableWellLpTokens();
+        // Set the plenty per root equal to previous rain start.
+        uint32 season = s.sys.season.current;
+        uint32 rainstartSeason = s.sys.season.rainStart;
+        for (uint i; i < wells.length; i++) {
+            s.sys.sop.sops[season][wells[i]] = s.sys.sop.sops[rainstartSeason][wells[i]];
+        }
+        s.sys.season.rainStart = s.sys.season.current;
+        s.sys.rain.pods = s.sys.fields[s.sys.activeField].pods;
+        s.sys.rain.roots = s.sys.silo.roots;
+
+        // upon rain, set beanToMaxLpGpPerBdvRatio to zero, to encourage converts down before starting to flood
+        s.sys.seedGauge.beanToMaxLpGpPerBdvRatio = 0;
     }
 
     /**

--- a/protocol/contracts/libraries/Silo/LibFlood.sol
+++ b/protocol/contracts/libraries/Silo/LibFlood.sol
@@ -73,6 +73,9 @@ library LibFlood {
             s.sys.season.rainStart = s.sys.season.current;
             s.sys.rain.pods = s.sys.fields[s.sys.activeField].pods;
             s.sys.rain.roots = s.sys.silo.roots;
+
+            // upon rain, set beanToMaxLpGpPerBdvRatio to zero, to encourage converts down before starting to flood
+            s.sys.seedGauge.beanToMaxLpGpPerBdvRatio = 0;
         } else {
             // flood podline first, because it checks current Bean supply
             floodPodline();

--- a/protocol/test/foundry/sun/Flood.t.sol
+++ b/protocol/test/foundry/sun/Flood.t.sol
@@ -304,6 +304,8 @@ contract FloodTest is TestHelper {
     }
 
     function testRaining() public {
+        // verify the beanToMaxLpGpPerBdvRatio is not zero before raining
+        assertGt(bs.getBeanToMaxLpGpPerBdvRatio(), 0);
         field.incrementTotalPodsE(1000e18, bs.activeField());
         season.rainSunrise();
         bs.mow(users[1], BEAN);
@@ -320,6 +322,9 @@ contract FloodTest is TestHelper {
 
         assertEq(sop.lastRain, s.rainStart);
         assertEq(sop.roots, 10004000e24);
+
+        // verify the beanToMaxLpGpPerBdvRatio is zero after rain starts
+        assertEq(bs.getBeanToMaxLpGpPerBdvRatio(), 0);
     }
 
     function testStopsRaining() public {
@@ -355,6 +360,8 @@ contract FloodTest is TestHelper {
     }
 
     function testOneSop() public {
+        assertGt(bs.getBeanToMaxLpGpPerBdvRatio(), 0);
+
         address sopWell = BEAN_ETH_WELL;
         setReserves(sopWell, 1000000e6, 1100e18);
 
@@ -376,6 +383,10 @@ contract FloodTest is TestHelper {
             C.SOP_PRECISION; // 25595575914848452999
 
         season.rainSunrise();
+
+        // verify the beanToMaxLpGpPerBdvRatio is zero after rain starts
+        assertEq(bs.getBeanToMaxLpGpPerBdvRatio(), 0);
+
         bs.mow(users[1], BEAN);
 
         vm.expectEmit();
@@ -444,8 +455,11 @@ contract FloodTest is TestHelper {
     function testMultipleSop() public {
         address sopWell = BEAN_ETH_WELL;
         setReserves(sopWell, 1000000e6, 1100e18);
+        assertGt(bs.getBeanToMaxLpGpPerBdvRatio(), 0);
 
         season.rainSunrise();
+
+        assertEq(bs.getBeanToMaxLpGpPerBdvRatio(), 0);
         bs.mow(users[2], BEAN);
         season.rainSunrise();
         season.droughtSunrise();


### PR DESCRIPTION
Converts would be more beneficial for Beanstalk than the system Flood the wells. Beanstalk should incentivize this action as much as possible, which is currently done when P > Q, but not when its about to flood. By adjusting Bean seeds as low as possible upon rain, the likelihood that a flood can be avoided is increased, as converts suddenly become more favorable.