### PR TITLE
Fix LibWhitelist.verifyOracleImplementation() is inconsistent with LibUsdOracle.sol

### DIFF
--- a/protocol/contracts/libraries/Oracle/LibUsdOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibUsdOracle.sol
@@ -141,11 +141,10 @@ library LibUsdOracle {
             }
         }
 
-        // If the oracle implementation address is not set, use the current contract.
-        address target = oracleImpl.target;
-        if (target == address(0)) target = address(this);
+        // Non-zero addresses are enforced in verifyOracleImplementation, this is just an extra check.
+        if (oracleImpl.target == address(0)) return 0;
 
-        (bool success, bytes memory data) = target.staticcall(
+        (bool success, bytes memory data) = oracleImpl.target.staticcall(
             abi.encodeWithSelector(oracleImpl.selector, tokenDecimals, lookback, oracleImpl.data)
         );
 

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -347,6 +347,9 @@ library LibWhitelist {
                 abi.encodeWithSelector(0x0dfe1681)
             );
         } else {
+            if (oracleImplementation.target == address(0))
+                oracleImplementation.target = address(this);
+
             // verify you passed in a callable oracle selector
             (success, returnData) = oracleImplementation.target.call(
                 abi.encodeWithSelector(

--- a/protocol/contracts/libraries/Silo/LibWhitelist.sol
+++ b/protocol/contracts/libraries/Silo/LibWhitelist.sol
@@ -347,8 +347,8 @@ library LibWhitelist {
                 abi.encodeWithSelector(0x0dfe1681)
             );
         } else {
-            if (oracleImplementation.target == address(0))
-                oracleImplementation.target = address(this);
+            // external oracles must have a target address
+            require(oracleImplementation.target != address(0), "Whitelist: Invalid Target Address");
 
             // verify you passed in a callable oracle selector
             (success, returnData) = oracleImplementation.target.call(

--- a/protocol/test/foundry/silo/Oracle.t.sol
+++ b/protocol/test/foundry/silo/Oracle.t.sol
@@ -212,7 +212,7 @@ contract OracleTest is TestHelper {
     function testZeroAddressOracleImplementationTarget() public {
         vm.prank(BEANSTALK);
         // exersizes address 0 and bytes 0x00, although there's no current way to whitelist something with these values.
-        vm.expectRevert("Whitelist: Invalid Oracle Implementation");
+        vm.expectRevert("Whitelist: Invalid Target Address");
         bs.updateOracleImplementationForToken(
             WBTC,
             IMockFBeanstalk.Implementation(

--- a/protocol/test/foundry/silo/Oracle.t.sol
+++ b/protocol/test/foundry/silo/Oracle.t.sol
@@ -8,6 +8,7 @@ import {MockChainlinkAggregator} from "contracts/mocks/chainlink/MockChainlinkAg
 import {MockToken} from "contracts/mocks/MockToken.sol";
 import {LSDChainlinkOracle} from "contracts/ecosystem/oracles/LSDChainlinkOracle.sol";
 import {LibChainlinkOracle} from "contracts/libraries/Oracle/LibChainlinkOracle.sol";
+import {IMockFBeanstalk} from "contracts/interfaces/IMockFBeanstalk.sol";
 
 /**
  * @notice Tests the functionality of the Oracles.
@@ -206,6 +207,21 @@ contract OracleTest is TestHelper {
         IMockFBeanstalk.Implementation memory oracleImplementation = bs
             .getOracleImplementationForToken(WBTC);
         assertEq(oracleImplementation.target, WBTC_USD_CHAINLINK_PRICE_AGGREGATOR);
+    }
+
+    function testZeroAddressOracleImplementationTarget() public {
+        vm.prank(BEANSTALK);
+        // exersizes address 0 and bytes 0x00, although there's no current way to whitelist something with these values.
+        vm.expectRevert("Whitelist: Invalid Oracle Implementation");
+        bs.updateOracleImplementationForToken(
+            WBTC,
+            IMockFBeanstalk.Implementation(
+                address(0),
+                IMockFBeanstalk.getUsdTokenPriceFromExternal.selector,
+                bytes1(0x00),
+                abi.encode(LibChainlinkOracle.FOUR_HOUR_TIMEOUT)
+            )
+        );
     }
 
     function testGetTokenPrice() public {

--- a/protocol/test/foundry/silo/Whitelist.t.sol
+++ b/protocol/test/foundry/silo/Whitelist.t.sol
@@ -156,6 +156,27 @@ contract WhitelistTest is TestHelper {
             bytes1(0x01),
             0,
             0,
+            IMockFBeanstalk.Implementation(BEANSTALK, oSelector, bytes1(0), new bytes(0)),
+            IMockFBeanstalk.Implementation(BEANSTALK, gpSelector, bytes1(0), new bytes(0)),
+            IMockFBeanstalk.Implementation(BEANSTALK, lwSelector, bytes1(0), new bytes(0))
+        );
+    }
+
+    function test_whitelistRevertZeroTargetOracleImplementation(uint i) public prank(BEANSTALK) {
+        address token = address(new MockWellToken());
+        bytes4 gpSelector = IMockFBeanstalk.defaultGaugePointFunction.selector;
+        bytes4 lwSelector = IMockFBeanstalk.maxWeight.selector;
+        bytes4 oSelector = bytes4(keccak256(abi.encode(i)));
+
+        vm.expectRevert("Whitelist: Invalid Target Address");
+        bs.whitelistToken(
+            token,
+            IMockFBeanstalk.wellBdv.selector,
+            0,
+            0,
+            bytes1(0x01),
+            0,
+            0,
             IMockFBeanstalk.Implementation(address(0), oSelector, bytes1(0), new bytes(0)),
             IMockFBeanstalk.Implementation(address(0), gpSelector, bytes1(0), new bytes(0)),
             IMockFBeanstalk.Implementation(address(0), lwSelector, bytes1(0), new bytes(0))
@@ -175,9 +196,9 @@ contract WhitelistTest is TestHelper {
             bytes1(0),
             0,
             0,
-            IMockFBeanstalk.Implementation(address(0), bytes4(0), bytes1(0x01), new bytes(0)),
-            IMockFBeanstalk.Implementation(address(0), gpSelector, bytes1(0), new bytes(0)),
-            IMockFBeanstalk.Implementation(address(0), lwSelector, bytes1(0), new bytes(0))
+            IMockFBeanstalk.Implementation(BEANSTALK, bytes4(0), bytes1(0x01), new bytes(0)),
+            IMockFBeanstalk.Implementation(BEANSTALK, gpSelector, bytes1(0x01), new bytes(0)),
+            IMockFBeanstalk.Implementation(BEANSTALK, lwSelector, bytes1(0x01), new bytes(0))
         );
     }
 


### PR DESCRIPTION
T1MOH593 report [L-04] fix.

LibUsdOracle uses address(this) if target address is not specified:
However in sanity check during whitelist it will make call to address(0) which always succeeds instead of real sanity check (`function verifyOracleImplementation`)
This performs a similar check in `LibWhitelist.verifyOracleImplementation`.

Would've liked to have written a test for it, but it seems there's currently no way to fully exercise this code path due to no matching public selector available for use.