### PR TITLE
Fix: Incorrect Plot issuance in case `activeField` is updated before user's migration

### DIFF
--- a/protocol/contracts/beanstalk/migration/L1RecieverFacet.sol
+++ b/protocol/contracts/beanstalk/migration/L1RecieverFacet.sol
@@ -393,7 +393,7 @@ contract L1RecieverFacet is ReentrancyGuard {
 
     /**
      * @notice adds the migrated plots to the account.
-     * @dev active field is hardcoded here to confirm with L1 field id.
+     * @dev active field is hardcoded here to conform with L1 field id.
      */
     function addMigratedPlotsToAccount(
         address reciever,

--- a/protocol/contracts/beanstalk/migration/L1RecieverFacet.sol
+++ b/protocol/contracts/beanstalk/migration/L1RecieverFacet.sol
@@ -392,14 +392,15 @@ contract L1RecieverFacet is ReentrancyGuard {
     }
 
     /**
-     * @notice adds the migrated deposits to the account.
+     * @notice adds the migrated plots to the account.
+     * @dev active field is hardcoded here to confirm with L1 field id.
      */
     function addMigratedPlotsToAccount(
         address reciever,
         uint256[] calldata index,
         uint256[] calldata pods
     ) internal {
-        uint256 activeField = s.sys.activeField;
+        uint256 activeField = 0;
         Field storage field = s.accts[reciever].fields[activeField];
         for (uint i; i < index.length; i++) {
             field.plots[index[i]] = pods[i];


### PR DESCRIPTION
Fixes [M-02]: Usually there is no problem because activeField is 0 (old version). However if user waited so long such that activeField was updated, migration would corrupt storage.