### PR TITLE
Fix: Update `STALK_BDV_PRECISION` to new decimals. 

### DIFF
--- a/protocol/contracts/libraries/LibGauge.sol
+++ b/protocol/contracts/libraries/LibGauge.sol
@@ -40,7 +40,7 @@ library LibGauge {
 
     // 24 * 30 * 6
     // uint256 internal constant TARGET_SEASONS_TO_CATCHUP = 4320; //state
-    uint256 internal constant STALK_BDV_PRECISION = 1e4;
+    uint256 internal constant STALK_BDV_PRECISION = 1e10;
 
     /**
      * @notice Emitted when the AverageGrownStalkPerBdvPerSeason Updates.


### PR DESCRIPTION
Fixes [M-04] from timoh review.