### PR TITLE
`getWellTwaUsdLiquidityFromReserves` decimal fix. 

### DIFF
--- a/protocol/contracts/libraries/Well/LibWell.sol
+++ b/protocol/contracts/libraries/Well/LibWell.sol
@@ -162,8 +162,15 @@ library LibWell {
         // if the function reaches here, then this is called outside the sunrise function
         // (i.e, seasonGetterFacet.getLiquidityToSupplyRatio()).We use LibUsdOracle
         // to get the price. This should never be reached during sunrise and thus
-        // should not impact gas.
-        return LibUsdOracle.getTokenPrice(token).mul(twaReserves[j]).div(1e6);
+        // should not impact gas. 
+        // LibUsdOracle returns the price with 6 decimal precision.
+        // This is canceled out by dividing by 1e6.
+        // This block is then used in calcLPToSupplyRatio that assumes 18 decimal precision,
+        // so we need to account for whitelisted tokens that have less than 18 decimals by multiplying the 
+        // precision difference.
+
+        uint8 tokenDecimals = IERC20Decimals(token).decimals();
+        return LibUsdOracle.getTokenPrice(token).mul(twaReserves[j]).div(1e6).mul(10**(18 - tokenDecimals));
     }
 
     /**

--- a/protocol/contracts/libraries/Well/LibWell.sol
+++ b/protocol/contracts/libraries/Well/LibWell.sol
@@ -165,7 +165,7 @@ library LibWell {
         // should not impact gas. 
         // LibUsdOracle returns the price with 6 decimal precision.
         // This is canceled out by dividing by 1e6.
-        // This block is then used in calcLPToSupplyRatio that assumes 18 decimal precision,
+        // This return value is then used in LibEvaluate.calcLPToSupplyRatio that assumes 18 decimal precision,
         // so we need to account for whitelisted tokens that have less than 18 decimals by multiplying the 
         // precision difference.
 


### PR DESCRIPTION
Addresses [L-05] from timoh and L-010 from codehawks:

When `getWellTwaUsdLiquidityFromReserves` is called by `SeasonGetterFacet` it calls `LibUsdOracle` which returns the non bean token price in a well with 6 decimal precision. before retunring the result, we divide by 1e6 so this precision is canceled out. We then multiuply by the twa reserves that have as many decimals as the `token` itself so the actual return value has as many decimals as `token`. The return value from `getWellTwaUsdLiquidityFromReserves` is then used in `LibEvaluate.calcLPToSupplyRatio` that assumes 18 decimal precision, so we need to account for whitelisted tokens that have less than 18 decimals by multiplying the precision difference.