### PR TITLE
Million USD Price.

### DIFF
--- a/protocol/contracts/beanstalk/sun/OracleFacet.sol
+++ b/protocol/contracts/beanstalk/sun/OracleFacet.sol
@@ -87,7 +87,16 @@ contract OracleFacet is Invariable, ReentrancyGuard {
     function getRatiosAndBeanIndex(
         IERC20[] memory tokens,
         uint256 lookback
-    ) internal view returns (uint[] memory ratios, uint beanIndex, bool success) {
+    ) external view returns (uint[] memory ratios, uint beanIndex, bool success) {
         (ratios, beanIndex, success) = LibWell.getRatiosAndBeanIndex(tokens, lookback);
+    }
+
+    /**
+     * @notice Fetches the amount of tokens equal to 1 Million USD for a given token.
+     * @param token address of the token to get the amount for.
+     * @param lookback the amount of time to look back in seconds.
+     */
+    function getMillionUsdPrice(address token, uint256 lookback) external view returns (uint256) {
+        return LibUsdOracle.getMillionUsdPrice(token, lookback);
     }
 }

--- a/protocol/contracts/libraries/Oracle/LibUniswapOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibUniswapOracle.sol
@@ -15,9 +15,6 @@ interface IERC20Decimals {
 /**
  * @title Uniswap Oracle Library
  * @notice Contains functionalty to read prices from Uniswap V3 pools.
- * @dev currently supports:
- * - ETH:USDC price from the ETH:USDC 0.05% pool
- * - ETH:USDT price from the ETH:USDT 0.05% pool
  **/
 library LibUniswapOracle {
     // All instantaneous queries of Uniswap Oracles should use a 15 minute lookback.

--- a/protocol/contracts/libraries/Well/LibWell.sol
+++ b/protocol/contracts/libraries/Well/LibWell.sol
@@ -191,7 +191,9 @@ library LibWell {
 
     /**
      * @dev Sets the price in {AppStorage.usdTokenPrice} given a set of ratios.
-     * It assumes that the ratios correspond to the Constant Product Well indexes.
+     * Assumes
+     * 1) Ratios correspond to the Constant Product Well indexes.
+     * 2) the Well is a 2 token Well.
      */
     function setUsdTokenPriceForWell(address well, uint256[] memory ratios) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -203,7 +205,12 @@ library LibWell {
             s.sys.usdTokenPrice[well] = 0;
         } else {
             (, uint256 j) = getNonBeanTokenAndIndexFromWell(well);
-            s.sys.usdTokenPrice[well] = ratios[j];
+            uint256 i = j == 0 ? 1 : 0;
+            // usdTokenPrice is scaled down to USD/TOKEN, in the cases where
+            // Beanstalk calculated the MILLION_USD/TOKEN price instead of USD/TOKEN price.
+            // Beanstalk accepts the loss of precision here, as `usdTokenPrice[well]` is used for
+            // calculating the liquidity and excessive price.
+            s.sys.usdTokenPrice[well] = (ratios[j] * 1e6) / ratios[i];
         }
     }
 

--- a/protocol/test/foundry/Migration/L1Reciever.t.sol
+++ b/protocol/test/foundry/Migration/L1Reciever.t.sol
@@ -224,13 +224,12 @@ contract L1RecieverFacetTest is Order, TestHelper {
     }
 
     function test_L2MigrateInvalidPodOrder() public {
-        bs.setRecieverForL1Migration(OWNER, RECIEVER);
-
         (
             address owner,
             L1RecieverFacet.L1PodOrder[] memory podOrders,
             bytes32[] memory proof
         ) = getMockPodOrder();
+        bs.setRecieverForL1Migration(owner, RECIEVER);
 
         // update pod orderer
         podOrders[0].podOrder.orderer = RECIEVER;
@@ -244,6 +243,7 @@ contract L1RecieverFacetTest is Order, TestHelper {
     // test helpers
     function getMockDepositData()
         internal
+        pure
         returns (address, uint256[] memory, uint256[] memory, uint256[] memory, bytes32[] memory)
     {
         address account = address(0x000000009d3a9e5C7c620514e1f36905C4Eb91e1);


### PR DESCRIPTION
Beanstalk currently calculates the DeltaB of a Well by calculating the difference in beans from the current ratio of the pool, to the target ratio of the pool. This is done by fetching the USD:TOKEN ratio for a given token. 

When this is done for a token that has 1) low decimals (<=8), and 2) a high price (5 figures or higher), this can lead to inaccuracies due to precision loss. 

This PR adds an option to fetch the MILLION_USD/TOKEN price for a given token, to increase the precision of the price.