### PR TITLE
Fix: Set only individual receiver internal balance in `L1RecieverFacet`.

### DIFF
--- a/protocol/contracts/beanstalk/migration/L1RecieverFacet.sol
+++ b/protocol/contracts/beanstalk/migration/L1RecieverFacet.sol
@@ -464,7 +464,7 @@ contract L1RecieverFacet is ReentrancyGuard {
     /**
      * @notice adds the migrated internal balances to the account.
      * Since global internal balances set in ReseedGlobal also reflect smart contract balances,
-     * we do not need to update global internal balances here, 
+     * we do not need to update global internal balances here,
      * only balances for the individual account.
      */
     function addMigratedInternalBalancesToAccount(

--- a/protocol/contracts/beanstalk/migration/L1RecieverFacet.sol
+++ b/protocol/contracts/beanstalk/migration/L1RecieverFacet.sol
@@ -21,6 +21,7 @@ import {IBean} from "contracts/interfaces/IBean.sol";
 import {IFertilizer} from "contracts/interfaces/IFertilizer.sol";
 import {Order} from "contracts/beanstalk/market/MarketplaceFacet/Order.sol";
 import {Listing} from "contracts/beanstalk/market/MarketplaceFacet/Listing.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /**
  * @author Brean
@@ -462,6 +463,9 @@ contract L1RecieverFacet is ReentrancyGuard {
 
     /**
      * @notice adds the migrated internal balances to the account.
+     * Since global internal balances set in ReseedGlobal also reflect smart contract balances,
+     * we do not need to update global internal balances here, 
+     * only balances for the individual account.
      */
     function addMigratedInternalBalancesToAccount(
         address reciever,
@@ -469,7 +473,9 @@ contract L1RecieverFacet is ReentrancyGuard {
         uint256[] calldata amounts
     ) internal {
         for (uint i; i < tokens.length; i++) {
-            LibBalance.increaseInternalBalance(reciever, IERC20(tokens[i]), amounts[i]);
+            IERC20 token = IERC20(tokens[i]);
+            s.accts[reciever].internalTokenBalance[token] += amounts[i];
+            emit LibBalance.InternalBalanceChanged(reciever, token, SafeCast.toInt256(amounts[i]));
         }
     }
 


### PR DESCRIPTION
fixes [M-05] from timo.
- ReseedGlobal sets internal balances that also reflect smart contract account balances. 
- When performing the migration, all assets are optimistically minted to the diamond address. 
- When smart contracts migrate their internal balance via the `L2MigrationFacet` and `L1RecieverFacet`, an amount of assets will be allocated to their delegated `receiver`. This does not need to trigger an increase in global internal balances as its already accounted for in `ReseedGlobal`. 
- This way the effectiveness of the `fundsSafu` invariant modifier will be preserved.