### PR TITLE
Expose calculateDeltaBFromReserves

### DIFF
--- a/protocol/contracts/beanstalk/silo/ConvertGettersFacet.sol
+++ b/protocol/contracts/beanstalk/silo/ConvertGettersFacet.sol
@@ -70,6 +70,21 @@ contract ConvertGettersFacet {
     }
 
     /**
+     * @notice calculates the deltaB for a given well using the reserves.
+     * @dev reverts if the bean reserve is less than the minimum,
+     * or if the usd oracle fails.
+     * This differs from the twaDeltaB, as this function should not be used within the sunrise function.
+     * @return deltaB The deltaB using the reserves.
+     */
+    function calculateDeltaBFromReserves(
+        address well,
+        uint256[] memory reserves,
+        uint256 lookback
+    ) external view returns (int256) {
+        return LibDeltaB.calculateDeltaBFromReserves(well, reserves, lookback);
+    }
+
+    /**
      * @notice Returns currently available convert power for this block
      * @return convertCapacity The amount of convert power available for this block
      */

--- a/protocol/contracts/interfaces/IMockFBeanstalk.sol
+++ b/protocol/contracts/interfaces/IMockFBeanstalk.sol
@@ -751,7 +751,7 @@ interface IMockFBeanstalk {
         uint256 outputTokenAmountInDirectionOfPeg
     ) external view returns (uint256 cumulativePenalty, PenaltyData memory pdCapacity);
 
-    function calculateDeltaBFromReservesE(
+    function calculateDeltaBFromReserves(
         address well,
         uint256[] memory reserves,
         uint256 lookback

--- a/protocol/contracts/mocks/mockFacets/MockPipelineConvertFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockPipelineConvertFacet.sol
@@ -32,12 +32,4 @@ contract MockPipelineConvertFacet is PipelineConvertFacet {
             outputTokenAmountInDirectionOfPeg
         );
     }
-
-    function calculateDeltaBFromReservesE(
-        address well,
-        uint256[] memory reserves,
-        uint256 lookback
-    ) external view returns (int256) {
-        return LibDeltaB.calculateDeltaBFromReserves(well, reserves, lookback);
-    }
 }

--- a/protocol/test/foundry/farm/PipelineConvert.t.sol
+++ b/protocol/test/foundry/farm/PipelineConvert.t.sol
@@ -1949,7 +1949,7 @@ contract PipelineConvertTest is TestHelper {
         reserves[beanIndex] = reserves[beanIndex].sub(beansOut);
 
         // get new deltaB
-        deltaB = pipelineConvert.calculateDeltaBFromReservesE(well, reserves, 0);
+        deltaB = bs.calculateDeltaBFromReserves(well, reserves, 0);
     }
 
     function calculateDeltaBForWellAfterAddingBean(
@@ -1969,7 +1969,7 @@ contract PipelineConvertTest is TestHelper {
         // add to bean index (no beans out on this one)
         reserves[beanIndex] = reserves[beanIndex].add(beansIn);
         // get new deltaB
-        deltaB = pipelineConvert.calculateDeltaBFromReservesE(well, reserves, 0);
+        deltaB = bs.calculateDeltaBFromReserves(well, reserves, 0);
     }
 
     function calculateDeltaBForWellAfterAddingNonBean(
@@ -1989,7 +1989,7 @@ contract PipelineConvertTest is TestHelper {
         reserves[nonBeanIndex] = reserves[nonBeanIndex].add(amountIn);
 
         // get new deltaB
-        deltaB = pipelineConvert.calculateDeltaBFromReservesE(well, reserves, 0);
+        deltaB = bs.calculateDeltaBFromReserves(well, reserves, 0);
     }
 
     // verifies there's no way to withdraw from a deposit without losing grown stalk


### PR DESCRIPTION
Exposes the calculateDeltaBFromReserves function so that the frontend UI can use it to calculate how deltaB will be affected before/after swaps.