### PR TITLE
Test removing all deposits

### DIFF
--- a/protocol/contracts/beanstalk/silo/SiloFacet/SiloGettersFacet.sol
+++ b/protocol/contracts/beanstalk/silo/SiloFacet/SiloGettersFacet.sol
@@ -176,6 +176,15 @@ contract SiloGettersFacet is ReentrancyGuard {
     }
 
     /**
+     * @notice outputs the token and stem given a depositId.
+     */
+    function getAddressAndStem(
+        uint256 depositId
+    ) external pure returns (address token, int96 stem) {
+        return LibBytes.unpackAddressAndStem(depositId);
+    }
+
+    /**
      * @notice returns the bean denominated value ("bdv") of a token amount.
      */
     function bdv(address token, uint256 amount) public view returns (uint256 _bdv) {

--- a/protocol/contracts/interfaces/IMockFBeanstalk.sol
+++ b/protocol/contracts/interfaces/IMockFBeanstalk.sol
@@ -991,6 +991,8 @@ interface IMockFBeanstalk {
 
     function getActiveFertilizer() external view returns (uint256);
 
+    function getAddressAndStem(uint256 depositId) external pure returns (address token, int96 stem);
+
     function getAllBalance(address account, address token) external view returns (Balance memory b);
 
     function getAllBalances(

--- a/protocol/test/foundry/Migration/ReseedState.t.sol
+++ b/protocol/test/foundry/Migration/ReseedState.t.sol
@@ -340,6 +340,16 @@ contract ReseedStateTest is TestHelper {
 
     function test_AccountDeposits() public {
         vm.pauseGasMetering();
+
+        uint256 totalStalkBefore = l2Beanstalk.totalStalk();
+        assertGt(totalStalkBefore, 0);
+
+        uint256 totalRootsBefore = l2Beanstalk.totalRoots();
+        assertGt(totalRootsBefore, 0);
+
+        // verify ratio is 1:1 on reseed
+        assertEq(totalStalkBefore * 1e12, totalRootsBefore);
+
         address[] memory tokens = l2Beanstalk.getWhitelistedTokens();
 
         // for every account

--- a/protocol/test/foundry/Migration/ReseedState.t.sol
+++ b/protocol/test/foundry/Migration/ReseedState.t.sol
@@ -407,10 +407,6 @@ contract ReseedStateTest is TestHelper {
             }
         }
 
-        // check system level stalk and roots
-        // todo: capture stalk/root ratio before and after
-        // call sunrise and see that the average grown stalk per season is updated?
-
         uint256 totalStalk = l2Beanstalk.totalStalk();
         assertEq(totalStalk, 0);
 

--- a/protocol/test/foundry/Migration/ReseedState.t.sol
+++ b/protocol/test/foundry/Migration/ReseedState.t.sol
@@ -85,6 +85,7 @@ contract ReseedStateTest is TestHelper {
     function setUp() public {
         // parse accounts and populate the accounts.txt file
         // the number of accounts to parse, for testing purposes
+        // the total number of accounts is 3665
         uint256 numAccounts = 10;
         accountNumber = parseAccounts(numAccounts);
         console.log("Number of accounts: ", accountNumber);
@@ -338,6 +339,7 @@ contract ReseedStateTest is TestHelper {
     //////////////////// Account Deposits ////////////////////
 
     function test_AccountDeposits() public {
+        vm.pauseGasMetering();
         address[] memory tokens = l2Beanstalk.getWhitelistedTokens();
 
         // for every account
@@ -374,6 +376,19 @@ contract ReseedStateTest is TestHelper {
                     assertEq(
                         accountDepositsStorage[j].tokenDeposits[k].bdv,
                         accountDepositsJson[j].tokenDeposits[k].bdv
+                    );
+
+                    (address token, int96 stem) = l2Beanstalk.getAddressAndStem(
+                        accountDepositsStorage[j].depositIds[k]
+                    );
+
+                    // withdraw deposit
+                    vm.prank(account);
+                    l2Beanstalk.withdrawDeposit(
+                        accountDepositsStorage[j].token,
+                        stem,
+                        accountDepositsStorage[j].tokenDeposits[k].amount,
+                        0
                     );
                 }
             }

--- a/protocol/test/foundry/Migration/ReseedState.t.sol
+++ b/protocol/test/foundry/Migration/ReseedState.t.sol
@@ -86,7 +86,7 @@ contract ReseedStateTest is TestHelper {
         // parse accounts and populate the accounts.txt file
         // the number of accounts to parse, for testing purposes
         // the total number of accounts is 3665
-        uint256 numAccounts = 10;
+        uint256 numAccounts = 10000;
         accountNumber = parseAccounts(numAccounts);
         console.log("Number of accounts: ", accountNumber);
         l2Beanstalk = IMockFBeanstalk(L2_BEANSTALK);
@@ -392,6 +392,41 @@ contract ReseedStateTest is TestHelper {
                     );
                 }
             }
+        }
+
+        // check system level stalk and roots
+        // todo: capture stalk/root ratio before and after
+        // call sunrise and see that the average grown stalk per season is updated?
+
+        uint256 totalStalk = l2Beanstalk.totalStalk();
+        assertEq(totalStalk, 0);
+
+        uint256 totalRoots = l2Beanstalk.totalRoots();
+        assertEq(totalRoots, 0);
+
+        uint256 totalRainRoots = l2Beanstalk.totalRainRoots();
+        assertEq(totalRainRoots, 0);
+
+        uint256 getTotalBdv = l2Beanstalk.getTotalBdv();
+        assertEq(getTotalBdv, 0);
+
+        uint256[] memory depositedAmounts = l2Beanstalk.getTotalSiloDeposited();
+        for (uint256 i = 0; i < depositedAmounts.length; i++) {
+            assertEq(depositedAmounts[i], 0);
+        }
+
+        uint256[] memory depositedBdvs = l2Beanstalk.getTotalSiloDepositedBdv();
+        for (uint256 i = 0; i < depositedBdvs.length; i++) {
+            assertEq(depositedBdvs[i], 0);
+        }
+
+        // loop through whitelisted tokens
+        for (uint256 i = 0; i < tokens.length; i++) {
+            address token = whitelistedTokens[i];
+            uint256 totalDeposited = l2Beanstalk.getTotalDeposited(token);
+            assertEq(totalDeposited, 0);
+            uint256 totalDepositedBdv = l2Beanstalk.getTotalDepositedBdv(token);
+            assertEq(totalDepositedBdv, 0);
         }
     }
 

--- a/protocol/test/foundry/Migration/ReseedState.t.sol
+++ b/protocol/test/foundry/Migration/ReseedState.t.sol
@@ -303,6 +303,7 @@ contract ReseedStateTest is TestHelper {
     function test_AccountPlots() public {
         // test the L2 Beanstalk
         string memory account;
+        uint256 totalPlotsAmount;
         // for every account
         for (uint256 i = 0; i < accountNumber; i++) {
             account = vm.readLine(ACCOUNTS_PATH);
@@ -332,8 +333,10 @@ contract ReseedStateTest is TestHelper {
                 // compare the plot amount and index
                 assertEq(accountPlotAmountJsonDecoded, plots[j].pods);
                 assertEq(plotindexesJsonDecoded[j], plots[j].index);
+                totalPlotsAmount += plots[j].pods;
             }
         }
+        console.log("total plots amount:", totalPlotsAmount);
     }
 
     //////////////////// Account Deposits ////////////////////


### PR DESCRIPTION
Ensures stalk number line up by being able to remove all deposits after reseed. Total number of accounts is 3665. I don't recommend running this test with the -vvvvv flag because it takes a long time to spit out the final output.