### PR TITLE
Update Reseed Account Status Events

### DIFF
--- a/protocol/contracts/beanstalk/init/reseed/L2/ReseedAccountStatus.sol
+++ b/protocol/contracts/beanstalk/init/reseed/L2/ReseedAccountStatus.sol
@@ -38,10 +38,7 @@ contract ReseedAccountStatus {
     event MigratedAccountStatus(
         address indexed account,
         uint256 stalk,
-        uint256 roots,
-        uint32 lastUpdate,
-        uint128 germinatingStalkOdd,
-        uint128 germinatingStalkEven
+        uint256 roots
     );
 
     function init(AccountStatus[] calldata accountStatuses) external {
@@ -84,10 +81,7 @@ contract ReseedAccountStatus {
             emit MigratedAccountStatus(
                 accountStatuses[i].account,
                 accountStatuses[i].stalk,
-                accountStatuses[i].stalk * 1e12,
-                accountStatuses[i].lastUpdate,
-                accountStatuses[i].germinatingStalkOdd,
-                accountStatuses[i].germinatingStalkEven
+                accountStatuses[i].stalk * 1e12 // roots
             );
         }
     }

--- a/protocol/contracts/beanstalk/init/reseed/L2/ReseedAccountStatus.sol
+++ b/protocol/contracts/beanstalk/init/reseed/L2/ReseedAccountStatus.sol
@@ -35,11 +35,7 @@ contract ReseedAccountStatus {
     );
 
     // emitted when a status is migrated.
-    event MigratedAccountStatus(
-        address indexed account,
-        uint256 stalk,
-        uint256 roots
-    );
+    event MigratedAccountStatus(address indexed account, uint256 stalk, uint256 roots);
 
     function init(AccountStatus[] calldata accountStatuses) external {
         // for each account
@@ -55,7 +51,7 @@ contract ReseedAccountStatus {
                     .accts[accountStatuses[i].account]
                     .mowStatuses[accountStatuses[i].tokens[j]]
                     .lastStem = accountStatuses[i].mowStatuses[j].lastStem;
-                
+
                 // emit event on a per account per token basis.
                 emit MigratedAccountTokenStatus(
                     accountStatuses[i].account,

--- a/protocol/contracts/beanstalk/init/reseed/L2/ReseedAccountStatus.sol
+++ b/protocol/contracts/beanstalk/init/reseed/L2/ReseedAccountStatus.sol
@@ -27,14 +27,21 @@ contract ReseedAccountStatus {
         uint128 germinatingStalkEven;
     }
 
+    event MigratedAccountTokenStatus(
+        address indexed account,
+        address indexed token,
+        uint256 bdv,
+        int96 lastStem
+    );
+
     // emitted when a status is migrated.
     event MigratedAccountStatus(
         address indexed account,
-        address indexed token,
         uint256 stalk,
         uint256 roots,
-        uint256 bdv,
-        int96 lastStem
+        uint32 lastUpdate,
+        uint128 germinatingStalkOdd,
+        uint128 germinatingStalkEven
     );
 
     function init(AccountStatus[] calldata accountStatuses) external {
@@ -51,6 +58,14 @@ contract ReseedAccountStatus {
                     .accts[accountStatuses[i].account]
                     .mowStatuses[accountStatuses[i].tokens[j]]
                     .lastStem = accountStatuses[i].mowStatuses[j].lastStem;
+                
+                // emit event on a per account per token basis.
+                emit MigratedAccountTokenStatus(
+                    accountStatuses[i].account,
+                    accountStatuses[i].tokens[j],
+                    accountStatuses[i].mowStatuses[j].bdv,
+                    accountStatuses[i].mowStatuses[j].lastStem
+                );
             }
             // set stalk and roots for account.
             s.accts[accountStatuses[i].account].stalk = accountStatuses[i].stalk;
@@ -64,6 +79,16 @@ contract ReseedAccountStatus {
             s.accts[accountStatuses[i].account].germinatingStalk[
                 GerminationSide.EVEN
             ] = accountStatuses[i].germinatingStalkEven;
+
+            // emit event on a per account basis.
+            emit MigratedAccountStatus(
+                accountStatuses[i].account,
+                accountStatuses[i].stalk,
+                accountStatuses[i].stalk * 1e12,
+                accountStatuses[i].lastUpdate,
+                accountStatuses[i].germinatingStalkOdd,
+                accountStatuses[i].germinatingStalkEven
+            );
         }
     }
 }


### PR DESCRIPTION
- Emission of `MigratedAccountStatus` and `MigratedAccountTokenStatus` events on a per account and per account, per token basis.