### PR TITLE
Weth constant fix

### DIFF
--- a/protocol/contracts/C.sol
+++ b/protocol/contracts/C.sol
@@ -41,7 +41,6 @@ library C {
 
     //////////////////// Contracts ////////////////////
 
-    address internal constant WETH = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
     address internal constant PIPELINE = 0xb1bE000644bD25996b0d9C2F7a6D6BA3954c91B0;
 
     //////////////////// Well ////////////////////

--- a/protocol/contracts/beanstalk/farm/TokenFacet.sol
+++ b/protocol/contracts/beanstalk/farm/TokenFacet.sol
@@ -233,7 +233,7 @@ contract TokenFacet is Invariable, IERC1155Receiver, ReentrancyGuard {
     function unwrapEth(
         uint256 amount,
         LibTransfer.From mode
-    ) external payable nonReentrant fundsSafu oneOutFlow(C.WETH) noSupplyChange {
+    ) external payable nonReentrant fundsSafu oneOutFlow(LibWeth.WETH) noSupplyChange {
         LibWeth.unwrap(amount, mode);
     }
 

--- a/protocol/contracts/mocks/mockFacets/MockAttackFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockAttackFacet.sol
@@ -13,7 +13,7 @@ import {LibAppStorage} from "contracts/libraries/LibAppStorage.sol";
 import {LibTransfer} from "contracts/libraries/Token/LibTransfer.sol";
 import {LibBalance} from "contracts/libraries/Token/LibBalance.sol";
 import {BeanstalkERC20} from "contracts/tokens/ERC20/BeanstalkERC20.sol";
-import {LibWeth} from "contracts/beanstalk/migration/L1Libraries/LibWeth.sol";
+import {LibWeth} from "contracts/libraries/Token/LibWeth.sol";
 
 /**
  * @title Mock Attack Facet

--- a/protocol/contracts/mocks/mockFacets/MockAttackFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockAttackFacet.sol
@@ -13,6 +13,7 @@ import {LibAppStorage} from "contracts/libraries/LibAppStorage.sol";
 import {LibTransfer} from "contracts/libraries/Token/LibTransfer.sol";
 import {LibBalance} from "contracts/libraries/Token/LibBalance.sol";
 import {BeanstalkERC20} from "contracts/tokens/ERC20/BeanstalkERC20.sol";
+import {LibWeth} from "contracts/beanstalk/migration/L1Libraries/LibWeth.sol";
 
 /**
  * @title Mock Attack Facet
@@ -33,7 +34,7 @@ contract MockAttackFacet is Invariable {
 
     function revert_oneOutFlow() external oneOutFlow(s.sys.tokens.bean) {
         BeanstalkERC20(s.sys.tokens.bean).transfer(msg.sender, 1);
-        IERC20(C.WETH).transfer(msg.sender, 1);
+        IERC20(LibWeth.WETH).transfer(msg.sender, 1);
     }
 
     function revert_supplyChange() external noSupplyChange {
@@ -72,7 +73,7 @@ contract MockAttackFacet is Invariable {
     }
 
     function exploitSop() public {
-        s.sys.sop.plentyPerSopToken[C.WETH] = 100_000_000;
+        s.sys.sop.plentyPerSopToken[LibWeth.WETH] = 100_000_000;
     }
 
     function exploitPodOrderBeans() public {

--- a/protocol/foundry.toml
+++ b/protocol/foundry.toml
@@ -46,6 +46,7 @@ no_storage_caching = false
 [profile.differential]
 match_test = "testDiff"
 no_match_test = "a^"
+no_match_contract = "ReseedStateTest"
 
 [profile.default.rpc_storage_caching]
 chains = 'all'

--- a/protocol/foundry.toml
+++ b/protocol/foundry.toml
@@ -42,6 +42,7 @@ ignored_warnings_from = [
 gas_reports = ['*']
 # Cache to `$HOME/.foundry/cache/<chain id>/<block number>`.
 no_storage_caching = false
+no_match_contract = "Reseed"
 
 [profile.differential]
 match_test = "testDiff"

--- a/protocol/scripts/deploy.js
+++ b/protocol/scripts/deploy.js
@@ -14,6 +14,7 @@ const diamond = require("./diamond.js");
 const {
   impersonateBean,
   impersonateWeth,
+  impersonateL2Weth,
   impersonateUnripe,
   impersonatePrice,
   impersonateChainlinkAggregator,
@@ -427,6 +428,7 @@ async function getFacetData(mock = true) {
  */
 async function impersonateERC20s() {
   await impersonateWeth();
+  await impersonateL2Weth();
 
   // New default ERC20s should be added here.
   tokens = [

--- a/protocol/scripts/impersonate.js
+++ b/protocol/scripts/impersonate.js
@@ -6,6 +6,7 @@ const {
   UNISWAP_V2_ROUTER,
   UNISWAP_V2_PAIR,
   WETH,
+  L2_WETH,
   LUSD,
   UNRIPE_BEAN,
   UNRIPE_LP,
@@ -30,6 +31,16 @@ const { getSigner } = "../utils";
 async function weth() {
   await impersonateContractOnPath("./artifacts/contracts/mocks/MockWETH.sol/MockWETH.json", WETH);
   const weth = await ethers.getContractAt("MockToken", WETH);
+  await weth.setSymbol("WETH");
+  await weth.setDecimals(18);
+}
+
+async function l2Weth() {
+  await impersonateContractOnPath(
+    "./artifacts/contracts/mocks/MockWETH.sol/MockWETH.json",
+    L2_WETH
+  );
+  const weth = await ethers.getContractAt("MockToken", L2_WETH);
   await weth.setSymbol("WETH");
   await weth.setDecimals(18);
 }
@@ -168,6 +179,7 @@ exports.impersonateRouter = router;
 exports.impersonateBean = bean;
 exports.impersonatePool = pool;
 exports.impersonateWeth = weth;
+exports.impersonateL2Weth = l2Weth;
 exports.impersonateUnripe = unripe;
 exports.impersonateToken = token;
 exports.impersonatePrice = price;

--- a/protocol/test/foundry/Invariable.t.sol
+++ b/protocol/test/foundry/Invariable.t.sol
@@ -18,7 +18,7 @@ contract InvariableTest is TestHelper {
 
     function setUp() public {
         initializeBeanstalkTestState(true, true);
-        MockToken(C.WETH).mint(BEANSTALK, 100_000);
+        MockToken(WETH).mint(BEANSTALK, 100_000);
 
         siloUsers = createUsers(3);
         initializeUnripeTokens(siloUsers[0], 100e6, 100e18);

--- a/protocol/test/foundry/farm/AdvancedFarm.t.sol
+++ b/protocol/test/foundry/farm/AdvancedFarm.t.sol
@@ -23,7 +23,7 @@ contract AdvancedFarmTest is TestHelper {
 
     function setUp() public {
         initializeBeanstalkTestState(true, true);
-        MockToken(C.WETH).mint(BEANSTALK, 100_000);
+        MockToken(WETH).mint(BEANSTALK, 100_000);
 
         farmers = createUsers(2);
         mintTokensToUsers(farmers, BEAN, 100_000e6);
@@ -40,7 +40,7 @@ contract AdvancedFarmTest is TestHelper {
      * @notice Wrap eth, add liquidity from weth, deposit LP into Silo.
      */
     function test_farmAddLiquidityDeposit() public {
-        IERC20(C.WETH).approve(BEAN_ETH_WELL, type(uint256).max);
+        IERC20(WETH).approve(BEAN_ETH_WELL, type(uint256).max);
 
         // advancedFarmCall[0], wrap eth.
         IMockFBeanstalk.AdvancedFarmCall memory wrapEth = IMockFBeanstalk.AdvancedFarmCall(
@@ -52,7 +52,7 @@ contract AdvancedFarmTest is TestHelper {
         IMockFBeanstalk.AdvancedFarmCall memory loadDepot = IMockFBeanstalk.AdvancedFarmCall(
             abi.encodeWithSelector(
                 TokenFacet.transferToken.selector,
-                C.WETH,
+                WETH,
                 C.PIPELINE,
                 1e18,
                 LibTransfer.From.INTERNAL,
@@ -103,7 +103,7 @@ contract AdvancedFarmTest is TestHelper {
         // Simplify by setting up approvals.
         deal(farmers[0], 1e18);
         vm.prank(C.PIPELINE);
-        IERC20(C.WETH).approve(BEAN_ETH_WELL, type(uint256).max);
+        IERC20(WETH).approve(BEAN_ETH_WELL, type(uint256).max);
         vm.prank(farmers[0]);
         IERC20(BEAN_ETH_WELL).approve(address(bs), type(uint256).max);
 

--- a/protocol/test/foundry/farm/Farm.t.sol
+++ b/protocol/test/foundry/farm/Farm.t.sol
@@ -21,7 +21,7 @@ contract FarmTest is TestHelper {
 
     function setUp() public {
         initializeBeanstalkTestState(true, true);
-        MockToken(C.WETH).mint(BEANSTALK, 100_000);
+        MockToken(WETH).mint(BEANSTALK, 100_000);
 
         farmers = createUsers(2);
         mintTokensToUsers(farmers, BEAN, 100_000e6);
@@ -96,7 +96,7 @@ contract FarmTest is TestHelper {
 
         farmCalls[1] = abi.encodeWithSelector(
             TokenFacet.transferToken.selector,
-            C.WETH,
+            WETH,
             C.PIPELINE,
             1e18,
             LibTransfer.From.INTERNAL,
@@ -107,7 +107,7 @@ contract FarmTest is TestHelper {
             BEAN_ETH_WELL,
             abi.encodeWithSelector(
                 IWell.swapFrom.selector,
-                C.WETH,
+                WETH,
                 BEAN,
                 1e18,
                 0,
@@ -119,7 +119,7 @@ contract FarmTest is TestHelper {
 
         deal(farmers[0], 1e18);
         vm.prank(C.PIPELINE);
-        IERC20(C.WETH).approve(BEAN_ETH_WELL, type(uint256).max);
+        IERC20(WETH).approve(BEAN_ETH_WELL, type(uint256).max);
 
         vm.prank(farmers[0]);
         bs.farm{value: 1e18}(farmCalls);

--- a/protocol/test/foundry/silo/Oracle.t.sol
+++ b/protocol/test/foundry/silo/Oracle.t.sol
@@ -105,8 +105,8 @@ contract OracleTest is TestHelper {
         mockAddRound(ETH_USD_CHAINLINK_PRICE_AGGREGATOR, 1200e6, 600);
 
         // query price
-        uint256 usdTokenPrice = OracleFacet(BEANSTALK).getUsdTokenTwap(C.WETH, 3600);
-        uint256 tokenUsdPrice = OracleFacet(BEANSTALK).getTokenUsdTwap(C.WETH, 3600);
+        uint256 usdTokenPrice = OracleFacet(BEANSTALK).getUsdTokenTwap(WETH, 3600);
+        uint256 tokenUsdPrice = OracleFacet(BEANSTALK).getTokenUsdTwap(WETH, 3600);
 
         // verify math:
         // 1200 + 1000 + 1100 + 1000 + 900 + 1200 = 6400 / 6 = 1066.666666e6
@@ -125,8 +125,8 @@ contract OracleTest is TestHelper {
         mockAddRound(ETH_USD_CHAINLINK_PRICE_AGGREGATOR, 1200e6, 50);
 
         // query price
-        uint256 usdTokenPrice = OracleFacet(BEANSTALK).getUsdTokenTwap(C.WETH, 3600);
-        uint256 tokenUsdPrice = OracleFacet(BEANSTALK).getTokenUsdTwap(C.WETH, 3600);
+        uint256 usdTokenPrice = OracleFacet(BEANSTALK).getUsdTokenTwap(WETH, 3600);
+        uint256 tokenUsdPrice = OracleFacet(BEANSTALK).getTokenUsdTwap(WETH, 3600);
 
         // verify math:
         // (1200 * 600) + (1000 * 1000) + (1100 * 500) + (1000 * 300) + (900 * 1150) + (1200 * 50) / 3600 = 1018.055555 * 1e6
@@ -263,11 +263,11 @@ contract OracleTest is TestHelper {
         );
 
         // token price is number of dollars per token, i.e. 50000 USD for 1 WBTC
-        uint256 tokenPriceEth = OracleFacet(BEANSTALK).getTokenUsdPrice(C.WETH); // 1000e6
+        uint256 tokenPriceEth = OracleFacet(BEANSTALK).getTokenUsdPrice(WETH); // 1000e6
         assertEq(tokenPriceEth, 1000e6, "getTokenUsdPrice eth");
 
         // number of tokens received per dollar
-        uint256 usdPriceEth = OracleFacet(BEANSTALK).getUsdTokenPrice(C.WETH); // 1e15 which is 1e18 (1 eth in wei) / 1000 (weth price 1000), you get 1/1000th of 1 eth for $1
+        uint256 usdPriceEth = OracleFacet(BEANSTALK).getUsdTokenPrice(WETH); // 1e15 which is 1e18 (1 eth in wei) / 1000 (weth price 1000), you get 1/1000th of 1 eth for $1
         assertEq(usdPriceEth, 1e18 / 1000, "getUsdTokenPrice eth");
 
         uint256 tokenPriceWBTC = OracleFacet(BEANSTALK).getTokenUsdPrice(WBTC); // should be 50000e6
@@ -293,7 +293,7 @@ contract OracleTest is TestHelper {
         );
 
         // WETH price is 1000
-        uint256 priceWETH = OracleFacet(BEANSTALK).getUsdTokenPrice(C.WETH);
+        uint256 priceWETH = OracleFacet(BEANSTALK).getUsdTokenPrice(WETH);
         assertEq(priceWETH, 1e15); //  1e18/1e3 = 1e15
 
         // WBTC price is 50000

--- a/protocol/test/foundry/silo/Oracle.t.sol
+++ b/protocol/test/foundry/silo/Oracle.t.sol
@@ -408,7 +408,7 @@ contract OracleTest is TestHelper {
         // in the case of AAVE/ETH, eth is the token that needs to be looked up against chainlink
         vm.prank(BEANSTALK);
         bs.updateOracleImplementationForToken(
-            WETH,
+            L1_WETH,
             IMockFBeanstalk.Implementation(
                 ETH_USD_CHAINLINK_PRICE_AGGREGATOR, // note this is using eth instead of weth
                 bytes4(0),
@@ -434,7 +434,7 @@ contract OracleTest is TestHelper {
         // in the case of AAVE/ETH, eth is the token that needs to be looked up against chainlink
         vm.prank(BEANSTALK);
         bs.updateOracleImplementationForToken(
-            WETH,
+            L1_WETH,
             IMockFBeanstalk.Implementation(
                 ETH_USD_CHAINLINK_PRICE_AGGREGATOR, // note this is using eth instead of weth
                 bytes4(0),

--- a/protocol/test/foundry/silo/Whitelist.t.sol
+++ b/protocol/test/foundry/silo/Whitelist.t.sol
@@ -16,10 +16,11 @@ import {GaugePointFacet} from "contracts/beanstalk/sun/GaugePoints/GaugePointFac
 import {LiquidityWeightFacet} from "contracts/beanstalk/sun/LiquidityWeightFacet.sol";
 
 contract MockWellToken {
+    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     function tokens() public returns (IERC20[] memory) {
         IERC20[] memory _tokens = new IERC20[](2);
-        _tokens[0] = IERC20(C.WETH);
-        _tokens[1] = IERC20(C.WETH);
+        _tokens[0] = IERC20(WETH);
+        _tokens[1] = IERC20(WETH);
         return _tokens;
     }
 }

--- a/protocol/test/foundry/silo/Whitelist.t.sol
+++ b/protocol/test/foundry/silo/Whitelist.t.sol
@@ -16,7 +16,8 @@ import {GaugePointFacet} from "contracts/beanstalk/sun/GaugePoints/GaugePointFac
 import {LiquidityWeightFacet} from "contracts/beanstalk/sun/LiquidityWeightFacet.sol";
 
 contract MockWellToken {
-    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address constant WETH = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
+
     function tokens() public returns (IERC20[] memory) {
         IERC20[] memory _tokens = new IERC20[](2);
         _tokens[0] = IERC20(WETH);

--- a/protocol/test/foundry/sun/Flood.t.sol
+++ b/protocol/test/foundry/sun/Flood.t.sol
@@ -351,7 +351,7 @@ contract FloodTest is TestHelper {
     }
 
     function testSopsBelowPeg() public {
-        setDeltaBforWell(-1000e6, BEAN_ETH_WELL, C.WETH);
+        setDeltaBforWell(-1000e6, BEAN_ETH_WELL, WETH);
         season.siloSunrise(25);
 
         Season memory s = seasonGetters.time();
@@ -371,7 +371,7 @@ contract FloodTest is TestHelper {
         // getSwapOut for how much Beanstalk will get for swapping this amount of beans
         uint256 amountOut = IWell(sopWell).getSwapOut(
             IERC20(BEAN),
-            IERC20(C.WETH),
+            IERC20(WETH),
             uint256(currentDeltaB)
         );
 
@@ -396,7 +396,7 @@ contract FloodTest is TestHelper {
         emit SeasonOfPlentyWell(
             seasonGetters.time().current + 1, // flood will happen next season
             sopWell,
-            C.WETH,
+            WETH,
             51191151829696906017
         );
 
@@ -407,7 +407,7 @@ contract FloodTest is TestHelper {
         assertEq(s.lastSop, s.rainStart);
         assertEq(s.lastSopSeason, s.current);
         // check weth balance of beanstalk
-        assertEq(IERC20(C.WETH).balanceOf(BEANSTALK), 51191151829696906017);
+        assertEq(IERC20(WETH).balanceOf(BEANSTALK), 51191151829696906017);
         // after the swap, the composition of the pools are
         uint256[] memory balances = IWell(sopWell).getReserves();
         assertEq(balances[0], 1048808848170);
@@ -449,7 +449,7 @@ contract FloodTest is TestHelper {
         vm.prank(users[2]);
         bs.claimPlenty(sopWell, 0);
         assertEq(bs.balanceOfPlenty(users[2], sopWell), 0);
-        assertEq(IERC20(C.WETH).balanceOf(users[2]), userCalcPlenty);
+        assertEq(IERC20(WETH).balanceOf(users[2]), userCalcPlenty);
     }
 
     function testMultipleSop() public {
@@ -473,7 +473,7 @@ contract FloodTest is TestHelper {
         emit SeasonOfPlentyWell(
             seasonGetters.time().current + 2, // flood will happen in two seasons
             sopWell,
-            C.WETH,
+            WETH,
             25900501355272002583
         );
 
@@ -485,7 +485,7 @@ contract FloodTest is TestHelper {
 
         assertEq(s.lastSop, s.rainStart);
         assertEq(s.lastSopSeason, s.current);
-        assertEq(IERC20(C.WETH).balanceOf(BEANSTALK), 77091653184968908600);
+        assertEq(IERC20(WETH).balanceOf(BEANSTALK), 77091653184968908600);
 
         assertEq(reserves[0], 1074099498643);
         assertEq(reserves[1], 1074099498644727997417);
@@ -536,7 +536,7 @@ contract FloodTest is TestHelper {
         emit SeasonOfPlentyWell(
             seasonGetters.time().current + 1, // flood will happen in two seasons
             sopWell,
-            C.WETH,
+            WETH,
             51191151829696906017
         );
 
@@ -549,7 +549,7 @@ contract FloodTest is TestHelper {
 
         assertEq(s.lastSop, s.rainStart);
         assertEq(s.lastSopSeason, s.current);
-        assertEq(IERC20(C.WETH).balanceOf(BEANSTALK), 51191151829696906017);
+        assertEq(IERC20(WETH).balanceOf(BEANSTALK), 51191151829696906017);
 
         assertEq(reserves[0], 1048808848170);
         assertEq(reserves[1], 1048808848170303093983);
@@ -586,7 +586,7 @@ contract FloodTest is TestHelper {
         vm.prank(users[2]);
         bs.claimPlenty(sopWell, 0);
         assertEq(bs.balanceOfPlenty(users[2], sopWell), 0);
-        assertEq(IERC20(C.WETH).balanceOf(users[2]), 25595575914848452999);
+        assertEq(IERC20(WETH).balanceOf(users[2]), 25595575914848452999);
     }
 
     function testSopUsingRealSunrise() public {
@@ -602,7 +602,7 @@ contract FloodTest is TestHelper {
         // getSwapOut for how much Beanstalk will get for swapping this amount of beans
         uint256 amountOut = IWell(sopWell).getSwapOut(
             IERC20(BEAN),
-            IERC20(C.WETH),
+            IERC20(WETH),
             uint256(currentDeltaB)
         );
 
@@ -718,7 +718,7 @@ contract FloodTest is TestHelper {
         // getSwapOut for how much Beanstalk will get for swapping this amount of beans
         uint256 amountOut = IWell(sopWell).getSwapOut(
             IERC20(BEAN),
-            IERC20(C.WETH),
+            IERC20(WETH),
             uint256(currentDeltaB)
         );
 
@@ -736,7 +736,7 @@ contract FloodTest is TestHelper {
         emit SeasonOfPlentyWell(
             seasonGetters.time().current + 1, // flood will happen next season
             sopWell,
-            C.WETH,
+            WETH,
             51191151829696906017
         );
 
@@ -751,7 +751,7 @@ contract FloodTest is TestHelper {
         assertEq(s.lastSop, s.rainStart);
         assertEq(s.lastSopSeason, s.current);
         // check weth balance of beanstalk
-        assertEq(IERC20(C.WETH).balanceOf(BEANSTALK), 51191151829696906017);
+        assertEq(IERC20(WETH).balanceOf(BEANSTALK), 51191151829696906017);
         // after the swap, the composition of the pools are
         uint256[] memory balances = IWell(sopWell).getReserves();
         assertEq(balances[0], 1048808848170);
@@ -802,7 +802,7 @@ contract FloodTest is TestHelper {
             "balance of plenty not cleared after claim"
         );
         assertEq(
-            IERC20(C.WETH).balanceOf(users[2]),
+            IERC20(WETH).balanceOf(users[2]),
             userCalcPlenty,
             "user balance not correct after claim"
         );
@@ -818,7 +818,7 @@ contract FloodTest is TestHelper {
         // getSwapOut for how much Beanstalk will get for swapping this amount of beans
         uint256 amountOut = IWell(sopWell).getSwapOut(
             IERC20(BEAN),
-            IERC20(C.WETH),
+            IERC20(WETH),
             uint256(currentDeltaB)
         );
 
@@ -836,7 +836,7 @@ contract FloodTest is TestHelper {
         emit SeasonOfPlentyWell(
             seasonGetters.time().current + 1, // flood will happen next season
             sopWell,
-            C.WETH,
+            WETH,
             51191151829696906017
         );
 

--- a/protocol/test/foundry/sun/Gauge.t.sol
+++ b/protocol/test/foundry/sun/Gauge.t.sol
@@ -26,7 +26,7 @@ contract GaugeTest is TestHelper {
 
         // deploy gaugePointPrice contract for WETH, with a price threshold of 500 USD,
         // and a gaugePoint of 10.
-        gpP = new GaugePointPrice(BEANSTALK, C.WETH, 500e6, 10e18);
+        gpP = new GaugePointPrice(BEANSTALK, WETH, 500e6, 10e18);
     }
 
     ////////////////////// BEAN TO MAX LP RATIO //////////////////////

--- a/protocol/test/foundry/utils/OracleDeployer.sol
+++ b/protocol/test/foundry/utils/OracleDeployer.sol
@@ -187,6 +187,13 @@ contract OracleDeployer is Utils {
             verbose
         );
 
+        // init L1 ETH:USD oracle
+        updateOracleImplementationForTokenUsingChainlinkAggregator(
+            L1_WETH,
+            ETH_USD_CHAINLINK_PRICE_AGGREGATOR,
+            verbose
+        );
+
         // init wsteth oracle.
         setupLSDChainlinkOracleForToken(
             WSTETH,

--- a/protocol/test/foundry/utils/Utils.sol
+++ b/protocol/test/foundry/utils/Utils.sol
@@ -18,7 +18,8 @@ contract Utils is Test {
     address internal constant BEAN = 0xBEA0000029AD1c77D3d5D23Ba2D8893dB9d1Efab;
     address internal constant UNRIPE_BEAN = 0x1BEA0050E63e05FBb5D8BA2f10cf5800B6224449;
     address internal constant UNRIPE_LP = 0x1BEA3CcD22F4EBd3d37d731BA31Eeca95713716D;
-    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address internal constant L1_WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address internal constant WETH = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
     address internal constant WSTETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
     address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address internal constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;

--- a/protocol/test/hardhat/Token.test.js
+++ b/protocol/test/hardhat/Token.test.js
@@ -1,7 +1,7 @@
 const { to18, to6 } = require("./utils/helpers.js");
 const { EXTERNAL, INTERNAL, INTERNAL_EXTERNAL, INTERNAL_TOLERANT } = require("./utils/balances.js");
-const { WETH, BEANSTALK, MAX_UINT256 } = require("./utils/constants");
-const { getWeth } = require("../../utils/contracts.js");
+const { L2_WETH, BEANSTALK, MAX_UINT256 } = require("./utils/constants");
+const { getL2Weth } = require("../../utils/contracts.js");
 const { expect } = require("chai");
 const { deploy } = require("../../scripts/deploy.js");
 const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot");
@@ -39,7 +39,7 @@ describe("Token", function () {
     await this.token2.connect(this.user).mint(this.user.address, "1000");
     await this.token2.connect(this.user).approve(beanstalk.address, to18("1000000000000000"));
 
-    this.weth = await getWeth();
+    this.weth = await getL2Weth();
     await this.weth.connect(this.user).approve(beanstalk.address, to18("1000000000000000"));
 
     const MockERC1155Token = await ethers.getContractFactory("MockERC1155");
@@ -639,7 +639,7 @@ describe("Token", function () {
         to18("1.001")
       );
       expect(await this.weth.balanceOf(this.user.address)).to.eq(to18("1"));
-      expect(await beanstalk.getInternalBalance(this.user.address, WETH)).to.eq(to18("0"));
+      expect(await beanstalk.getInternalBalance(this.user.address, L2_WETH)).to.eq(to18("0"));
     });
 
     it("deposit WETH to external, not all", async function () {
@@ -650,7 +650,7 @@ describe("Token", function () {
         to18("1.001")
       );
       expect(await this.weth.balanceOf(this.user.address)).to.eq(to18("1"));
-      expect(await beanstalk.getInternalBalance(this.user.address, WETH)).to.eq(to18("0"));
+      expect(await beanstalk.getInternalBalance(this.user.address, L2_WETH)).to.eq(to18("0"));
     });
 
     it("deposit WETH to external, not all, farm", async function () {
@@ -665,7 +665,7 @@ describe("Token", function () {
         to18("1.001")
       );
       expect(await this.weth.balanceOf(this.user.address)).to.eq(to18("1"));
-      expect(await beanstalk.getInternalBalance(this.user.address, WETH)).to.eq(to18("0"));
+      expect(await beanstalk.getInternalBalance(this.user.address, L2_WETH)).to.eq(to18("0"));
     });
 
     it("withdraw WETH from external", async function () {
@@ -677,10 +677,10 @@ describe("Token", function () {
         to18("-0.999")
       );
       expect(await this.weth.balanceOf(this.user.address)).to.eq(to18("0"));
-      expect(await beanstalk.getInternalBalance(this.user.address, WETH)).to.eq(to18("0"));
+      expect(await beanstalk.getInternalBalance(this.user.address, L2_WETH)).to.eq(to18("0"));
     });
 
-    it("deposit WETH to external", async function () {
+    it("deposit WETH to internal", async function () {
       const ethBefore = await ethers.provider.getBalance(this.user.address);
       await beanstalk.connect(this.user).wrapEth(to18("1"), INTERNAL, { value: to18("1") });
       expect(ethBefore.sub(await ethers.provider.getBalance(this.user.address))).to.be.within(
@@ -688,10 +688,10 @@ describe("Token", function () {
         to18("1.001")
       );
       expect(await this.weth.balanceOf(this.user.address)).to.eq(to18("0"));
-      expect(await beanstalk.getInternalBalance(this.user.address, WETH)).to.eq(to18("1"));
+      expect(await beanstalk.getInternalBalance(this.user.address, L2_WETH)).to.eq(to18("1"));
     });
 
-    it("withdraw WETH from exteranl", async function () {
+    it("withdraw WETH from internal", async function () {
       await beanstalk.connect(this.user).wrapEth(to18("1"), INTERNAL, { value: to18("1") });
       const ethBefore = await ethers.provider.getBalance(this.user.address);
       await beanstalk.connect(this.user).unwrapEth(to18("1"), INTERNAL);
@@ -700,7 +700,7 @@ describe("Token", function () {
         to18("-0.999")
       );
       expect(await this.weth.balanceOf(this.user.address)).to.eq(to18("0"));
-      expect(await beanstalk.getInternalBalance(this.user.address, WETH)).to.eq(to18("0"));
+      expect(await beanstalk.getInternalBalance(this.user.address, L2_WETH)).to.eq(to18("0"));
     });
   });
 

--- a/protocol/utils/contracts.js
+++ b/protocol/utils/contracts.js
@@ -7,7 +7,8 @@ const {
   USDC,
   FERTILIZER,
   PRICE,
-  WETH
+  WETH,
+  L2_WETH
 } = require("../test/hardhat/utils/constants");
 
 async function getBeanstalk(contract = BEANSTALK) {
@@ -37,6 +38,10 @@ async function getWeth() {
   return await ethers.getContractAt("contracts/interfaces/IWETH.sol:IWETH", WETH);
 }
 
+async function getL2Weth() {
+  return await ethers.getContractAt("contracts/interfaces/IWETH.sol:IWETH", L2_WETH);
+}
+
 async function getUsdc() {
   return await ethers.getContractAt("IBean", USDC);
 }
@@ -52,6 +57,7 @@ async function getFertilizer() {
 exports.getBeanstalk = getBeanstalk;
 exports.getBean = getBean;
 exports.getWeth = getWeth;
+exports.getL2Weth = getL2Weth;
 exports.getUsdc = getUsdc;
 exports.getPrice = getPrice;
 exports.getBeanstalkAdminControls = getBeanstalkAdminControls;


### PR DESCRIPTION
Currently, WETH is set to the L1 addresses. This PR implements the fix nessecary to wrap ETH on the L2.