### PR TITLE
Update transmit in facet to accept bytes array for asset flexibility

### DIFF
--- a/protocol/contracts/beanstalk/ForkSystem/TransmitInFacet.sol
+++ b/protocol/contracts/beanstalk/ForkSystem/TransmitInFacet.sol
@@ -24,15 +24,17 @@ contract TransmitInFacet is Invariable {
      */
     function transmitIn(
         address user,
-        bytes[] calldata deposits,
-        bytes[] calldata plots,
-        bytes[] calldata fertilizer,
-        bytes calldata // data
+        bytes[][] calldata assets,
+        bytes calldata //data
     ) external fundsSafu {
         require(s.sys.supportedSourceForks[msg.sender], "Unsupported source");
+        require(assets.length >= 2, "Insufficient data provided");
 
-        LibTransmitIn.transmitInDeposits(user, deposits);
-        LibTransmitIn.transmitInPlots(user, plots);
-        LibTransmitIn.transmitInFertilizer(user, fertilizer);
+        LibTransmitIn.transmitInDeposits(user, assets[0]);
+        LibTransmitIn.transmitInPlots(user, assets[1]);
+        if (assets.length > 2) {
+            LibTransmitIn.transmitInFertilizer(user, assets[2]);
+        }
+        // additional assets can be processed here in the future
     }
 }

--- a/protocol/contracts/beanstalk/ForkSystem/TransmitOutFacet.sol
+++ b/protocol/contracts/beanstalk/ForkSystem/TransmitOutFacet.sol
@@ -22,28 +22,31 @@ contract TransmitOutFacet is Invariable {
      */
     function transmitOut(
         address destination,
-        LibTransmitOut.SourceDeposit[] calldata sourceDeposits,
-        LibTransmitOut.SourcePlot[] calldata sourcePlots,
-        LibTransmitOut.SourceFertilizer[] calldata sourceFertilizer,
+        bytes[] calldata assets,
         bytes calldata data
     ) external fundsSafu {
+        require(assets.length >= 3, "Missing asset data");
+
         bytes[] memory deposits = LibTransmitOut.transmitOutDeposits(
             LibTractor._user(),
             destination,
-            sourceDeposits
+            abi.decode(assets[0], (LibTransmitOut.SourceDeposit[]))
         );
-        bytes[] memory plots = LibTransmitOut.transmitOutPlots(LibTractor._user(), sourcePlots);
+        bytes[] memory plots = LibTransmitOut.transmitOutPlots(
+            LibTractor._user(),
+            abi.decode(assets[1], (LibTransmitOut.SourcePlot[]))
+        );
         bytes[] memory fertilizer = LibTransmitOut.transmitOutFertilizer(
             LibTractor._user(),
-            sourceFertilizer
+            abi.decode(assets[2], (LibTransmitOut.SourceFertilizer[]))
         );
 
-        bytes[][] memory assets = new bytes[][](3);
-        assets[0] = deposits;
-        assets[1] = plots;
-        assets[2] = fertilizer;
+        bytes[][] memory processedAssets = new bytes[][](3);
+        processedAssets[0] = deposits;
+        processedAssets[1] = plots;
+        processedAssets[2] = fertilizer;
 
         // Reverts if Destination fails to handle transmitted assets.
-        ITransmitInFacet(destination).transmitIn(LibTractor._user(), assets, data);
+        ITransmitInFacet(destination).transmitIn(LibTractor._user(), processedAssets, data);
     }
 }

--- a/protocol/contracts/beanstalk/ForkSystem/TransmitOutFacet.sol
+++ b/protocol/contracts/beanstalk/ForkSystem/TransmitOutFacet.sol
@@ -19,6 +19,8 @@ contract TransmitOutFacet is Invariable {
     /**
      * @notice Process the outbound migration and transfer necessary assets to destination.
      * @dev Reverts if failure to burn assets or destination fails.
+     * @param assets Contains abi encoded deposits, plots, and fertilizer.
+     * @param data Currently unused but remains available for paramaters such as minimum output requirements.
      */
     function transmitOut(
         address destination,

--- a/protocol/contracts/beanstalk/ForkSystem/TransmitOutFacet.sol
+++ b/protocol/contracts/beanstalk/ForkSystem/TransmitOutFacet.sol
@@ -25,7 +25,7 @@ contract TransmitOutFacet is Invariable {
         LibTransmitOut.SourceDeposit[] calldata sourceDeposits,
         LibTransmitOut.SourcePlot[] calldata sourcePlots,
         LibTransmitOut.SourceFertilizer[] calldata sourceFertilizer,
-        bytes calldata // data
+        bytes calldata data
     ) external fundsSafu {
         bytes[] memory deposits = LibTransmitOut.transmitOutDeposits(
             LibTractor._user(),
@@ -38,13 +38,12 @@ contract TransmitOutFacet is Invariable {
             sourceFertilizer
         );
 
+        bytes[][] memory assets = new bytes[][](3);
+        assets[0] = deposits;
+        assets[1] = plots;
+        assets[2] = fertilizer;
+
         // Reverts if Destination fails to handle transmitted assets.
-        ITransmitInFacet(destination).transmitIn(
-            LibTractor._user(),
-            deposits,
-            plots,
-            fertilizer,
-            abi.encode("")
-        );
+        ITransmitInFacet(destination).transmitIn(LibTractor._user(), assets, data);
     }
 }

--- a/protocol/contracts/interfaces/IMockFBeanstalk.sol
+++ b/protocol/contracts/interfaces/IMockFBeanstalk.sol
@@ -1534,9 +1534,7 @@ interface IMockFBeanstalk {
 
     function transmitOut(
         address destination,
-        SourceDeposit[] calldata sourceDeposits,
-        SourcePlot[] calldata sourcePlots,
-        SourceFertilizer[] calldata sourceFertilizer,
+        bytes[] calldata assets,
         bytes calldata data
     ) external;
 

--- a/protocol/contracts/interfaces/IMockFBeanstalk.sol
+++ b/protocol/contracts/interfaces/IMockFBeanstalk.sol
@@ -2008,11 +2008,15 @@ interface IMockFBeanstalk {
 
     function totalPods(uint256 fieldId) external view returns (uint256);
 
+    function totalProcessed(uint256 fieldId) external view returns (uint256);
+
     function totalRainRoots() external view returns (uint256);
 
     function totalRealSoil() external view returns (uint256);
 
     function totalRoots() external view returns (uint256);
+
+    function totalSlashed(uint256 fieldId) external view returns (uint256);
 
     function totalSoil() external view returns (uint256);
 

--- a/protocol/contracts/interfaces/ITransmitInFacet.sol
+++ b/protocol/contracts/interfaces/ITransmitInFacet.sol
@@ -5,9 +5,7 @@ pragma solidity ^0.8.20;
 interface ITransmitInFacet {
     function transmitIn(
         address user,
-        bytes[] calldata deposits,
-        bytes[] calldata plots,
-        bytes[] calldata fertilizer,
-        bytes calldata data
+        bytes[][] calldata assets,
+        bytes calldata //data
     ) external;
 }

--- a/protocol/contracts/interfaces/ITransmitOutFacet.sol
+++ b/protocol/contracts/interfaces/ITransmitOutFacet.sol
@@ -7,9 +7,7 @@ import {LibTransmitOut} from "contracts/libraries/ForkSystem/LibTransmitOut.sol"
 interface ITransmitOutFacet {
     function transmitOut(
         address destination,
-        LibTransmitOut.SourceDeposit[] calldata sourceDeposits,
-        LibTransmitOut.SourcePlot[] calldata sourcePlots,
-        LibTransmitOut.SourceFertilizer[] calldata sourceFertilizer,
+        bytes[] calldata assets,
         bytes calldata data
     ) external;
 }

--- a/protocol/contracts/libraries/ForkSystem/LibTransmitOut.sol
+++ b/protocol/contracts/libraries/ForkSystem/LibTransmitOut.sol
@@ -18,6 +18,7 @@ import {LibMarket} from "contracts/libraries/LibMarket.sol";
 import {LibField} from "contracts/libraries/LibField.sol";
 import {IBean} from "contracts/interfaces/IBean.sol";
 import {IFertilizer} from "contracts/interfaces/IFertilizer.sol";
+import {LibGerminate} from "contracts/libraries/Silo/LibGerminate.sol";
 
 /**
  * @title LibTransmitOut
@@ -95,6 +96,11 @@ library LibTransmitOut {
                     LibSilo._mow(user, deposits[i].token);
                     break;
                 }
+            }
+
+            // if the deposit is germinating, it cannot be transmitted
+            if (LibGerminate.isGerminating(deposits[i].token, deposits[i].stem)) {
+                revert("Transmit: Cannot transmit germinating deposits");
             }
 
             // Withdraw deposit from Silo.

--- a/protocol/contracts/libraries/Silo/LibGerminate.sol
+++ b/protocol/contracts/libraries/Silo/LibGerminate.sol
@@ -395,6 +395,14 @@ library LibGerminate {
         );
     }
 
+    function isGerminating(address token, int96 stem) internal view returns (bool) {
+        (GerminationSide germinationState, ) = getGerminationState(token, stem);
+        if (germinationState == GerminationSide.NOT_GERMINATING) {
+            return false;
+        }
+        return true;
+    }
+
     /**
      * @notice determines whether a deposit (token + stem) should be germinating or not.
      * If germinating, determines whether the deposit should be set to even or odd.

--- a/protocol/contracts/tokens/Fertilizer/Fertilizer1155.sol
+++ b/protocol/contracts/tokens/Fertilizer/Fertilizer1155.sol
@@ -88,7 +88,12 @@ contract Fertilizer1155 is ERC1155Upgradeable {
         __doSafeTransferAcceptanceCheck(operator, address(0), to, id, amount, data);
     }
 
-    function _safeBurn(address from, uint256 id, uint256 amount, bytes memory data) internal virtual {
+    function _safeBurn(
+        address from,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) internal virtual {
         require(from != address(0), "ERC1155: burn from the zero address");
 
         address operator = _msgSender();

--- a/protocol/test/foundry/forkSystem/TransmitToFork.t.sol
+++ b/protocol/test/foundry/forkSystem/TransmitToFork.t.sol
@@ -86,10 +86,10 @@ contract TransmitToForkTest is TestHelper {
             depositForUser(user, BEAN, beanDepositAmount);
             int96 secondBeanStem = bs.stemTipForToken(BEAN);
 
-            IMockFBeanstalk.SourceDeposit[] memory deposits = new IMockFBeanstalk.SourceDeposit[](
+            IMockFBeanstalk.SourceDeposit[] memory _deposits = new IMockFBeanstalk.SourceDeposit[](
                 1
             );
-            deposits[0] = IMockFBeanstalk.SourceDeposit(
+            _deposits[0] = IMockFBeanstalk.SourceDeposit(
                 BEAN,
                 beanDepositAmount,
                 secondBeanStem,
@@ -102,14 +102,14 @@ contract TransmitToForkTest is TestHelper {
                 0 // populated by source
             );
 
-            bytes[] memory assets = new bytes[](3);
-            assets[0] = abi.encode(deposits);
-            assets[1] = abi.encode(new IMockFBeanstalk.SourcePlot[](0));
-            assets[2] = abi.encode(new IMockFBeanstalk.SourceFertilizer[](0));
+            bytes[] memory _assets = new bytes[](3);
+            _assets[0] = abi.encode(_deposits);
+            _assets[1] = abi.encode(new IMockFBeanstalk.SourcePlot[](0));
+            _assets[2] = abi.encode(new IMockFBeanstalk.SourceFertilizer[](0));
 
             vm.expectRevert("Transmit: Cannot transmit germinating deposits");
             vm.prank(user);
-            bs.transmitOut(newBsAddr, assets, abi.encode(""));
+            bs.transmitOut(newBsAddr, _assets, abi.encode(""));
         }
 
         // Capture Source state.

--- a/protocol/test/foundry/forkSystem/TransmitToFork.t.sol
+++ b/protocol/test/foundry/forkSystem/TransmitToFork.t.sol
@@ -315,6 +315,9 @@ contract TransmitToForkTest is TestHelper {
             vm.prank(farmers[5]);
             bs.harvest(0, plotIndices, 0);
             require(bean.balanceOf(farmers[5]) == initBeanBalance, "Beans received from slashing");
+            // at this point, only slashed plots have been processed, no beans harvested
+            require(bs.totalHarvested(SRC_FIELD) == 0, "total harvested");
+            require(bs.totalSlashed(SRC_FIELD) == bs.totalProcessed(SRC_FIELD), "total slashed");
         }
         // Verify Destination plots by harvesting.
         {

--- a/protocol/test/foundry/forkSystem/TransmitToFork.t.sol
+++ b/protocol/test/foundry/forkSystem/TransmitToFork.t.sol
@@ -114,10 +114,10 @@ contract TransmitToForkTest is TestHelper {
 
         // Capture Source state.
         (, uint256 beanDepositBdv) = bs.getDeposit(user, BEAN, beanStem);
-        require(beanDepositBdv > 0, "Source Bean deposit bdv");
+        assertGt(beanDepositBdv, 0, "Source Bean deposit bdv");
         uint256 lpDepositBdv;
         (lpDepositAmount, lpDepositBdv) = bs.getDeposit(user, BEAN_ETH_WELL, lpStem);
-        require(lpDepositBdv > 0, "Source LP deposit bdv");
+        assertGt(lpDepositBdv, 0, "Source LP deposit bdv");
 
         uint256 migrationAmountLp = lpDepositAmount / 2;
 
@@ -205,42 +205,43 @@ contract TransmitToForkTest is TestHelper {
                 BEAN,
                 beanStem
             );
-            require(sourceDepositAmount == 0, "Source bean deposit amt");
-            require(sourceDepositBdv == 0, "Source bean deposit bdv");
+            assertEq(sourceDepositAmount, 0, "Source bean deposit amt");
+            assertEq(sourceDepositBdv, 0, "Source bean deposit bdv");
             (sourceDepositAmount, sourceDepositBdv) = bs.getDeposit(user, BEAN_ETH_WELL, lpStem);
-            require(
-                sourceDepositAmount == lpDepositAmount - migrationAmountLp,
+            assertEq(
+                sourceDepositAmount,
+                lpDepositAmount - migrationAmountLp,
                 "Source lp deposit amt"
             );
-            require(sourceDepositBdv < lpDepositBdv, "Source lp deposit bdv");
+            assertLt(sourceDepositBdv, lpDepositBdv, "Source lp deposit bdv");
         }
         // Verify Destination deposits.
         {
             uint256[] memory destDepositIds = newBs
                 .getTokenDepositsForAccount(user, BEAN)
                 .depositIds;
-            require(destDepositIds.length == 1, "Dest deposit count");
+            assertEq(destDepositIds.length, 1, "Dest deposit count");
             (address token, int96 stem) = LibBytes.unpackAddressAndStem(destDepositIds[0]);
             (uint256 destinationDepositAmount, uint256 destinationDepositBdv) = newBs.getDeposit(
                 user,
                 BEAN,
                 stem
             );
-            require(stem < newBs.stemTipForToken(token), "Dest Bean deposit stem too high");
-            require(beanDepositAmount == destinationDepositAmount, "Dest Bean deposit amount");
-            require(beanDepositBdv == destinationDepositBdv, "Dest Bean deposit bdv");
+            assertLt(stem, newBs.stemTipForToken(token), "Dest Bean deposit stem too high");
+            assertEq(beanDepositAmount, destinationDepositAmount, "Dest Bean deposit amount");
+            assertEq(beanDepositBdv, destinationDepositBdv, "Dest Bean deposit bdv");
 
             destDepositIds = newBs.getTokenDepositsForAccount(user, BEAN_ETH_WELL).depositIds;
-            require(destDepositIds.length == 1, "Dest deposit count");
+            assertEq(destDepositIds.length, 1, "Dest deposit count");
             (token, stem) = LibBytes.unpackAddressAndStem(destDepositIds[0]);
             (destinationDepositAmount, destinationDepositBdv) = newBs.getDeposit(
                 user,
                 BEAN_ETH_WELL,
                 stem
             );
-            require(stem < newBs.stemTipForToken(BEAN_ETH_WELL), "Dest lp dep stem too high");
-            require(migrationAmountLp == destinationDepositAmount, "Dest lp deposit amount");
-            require(0 < destinationDepositBdv, "Dest lp deposit bdv");
+            assertLt(stem, newBs.stemTipForToken(BEAN_ETH_WELL), "Dest lp dep stem too high");
+            assertEq(migrationAmountLp, destinationDepositAmount, "Dest lp deposit amount");
+            assertLt(0, destinationDepositBdv, "Dest lp deposit bdv");
         }
     }
 
@@ -284,18 +285,18 @@ contract TransmitToForkTest is TestHelper {
 
         // Verify Source plots.
         {
-            require(bs.plot(user, SRC_FIELD, 0) == 0, "1st src amt");
-            require(bs.plot(user, SRC_FIELD, partialAmt) == remainingAmt, "1.5 src amt");
-            require(bs.plot(user, SRC_FIELD, podsPerSow) == 0, "2nd src amt");
-            require(bs.plot(ZERO_ADDR, SRC_FIELD, 0) == partialAmt, "1st src null amt");
-            require(bs.plot(ZERO_ADDR, SRC_FIELD, partialAmt) == 0, "1.5 src null amt");
-            require(bs.plot(ZERO_ADDR, SRC_FIELD, podsPerSow) == podsPerSow, "2nd src null amt");
+            assertEq(bs.plot(user, SRC_FIELD, 0), 0, "1st src amt");
+            assertEq(bs.plot(user, SRC_FIELD, partialAmt), remainingAmt, "1.5 src amt");
+            assertEq(bs.plot(user, SRC_FIELD, podsPerSow), 0, "2nd src amt");
+            assertEq(bs.plot(ZERO_ADDR, SRC_FIELD, 0), partialAmt, "1st src null amt");
+            assertEq(bs.plot(ZERO_ADDR, SRC_FIELD, partialAmt), 0, "1.5 src null amt");
+            assertEq(bs.plot(ZERO_ADDR, SRC_FIELD, podsPerSow), podsPerSow, "2nd src null amt");
         }
         // Verify Destination plots.
         {
-            require(newBs.plot(user, DEST_FIELD, 0) == partialAmt, "1st dest amt");
-            require(newBs.plot(ZERO_ADDR, DEST_FIELD, partialAmt) == remainingAmt, "1.5 dest amt");
-            require(newBs.plot(user, DEST_FIELD, podsPerSow) == podsPerSow, "2nd dest amt");
+            assertEq(newBs.plot(user, DEST_FIELD, 0), partialAmt, "1st dest amt");
+            assertEq(newBs.plot(ZERO_ADDR, DEST_FIELD, partialAmt), remainingAmt, "1.5 dest amt");
+            assertEq(newBs.plot(user, DEST_FIELD, podsPerSow), podsPerSow, "2nd dest amt");
         }
 
         // Migrate a plot that is already harvestable and a plot that is beyond the source init length.
@@ -345,19 +346,19 @@ contract TransmitToForkTest is TestHelper {
             emit IMockFBeanstalk.Harvest(farmers[5], SRC_FIELD, plotIndices, 0);
             vm.prank(farmers[5]);
             bs.harvest(0, plotIndices, 0);
-            require(bean.balanceOf(farmers[5]) == initBeanBalance, "Beans received from slashing");
+            assertEq(bean.balanceOf(farmers[5]), initBeanBalance, "Beans received from slashing");
             // at this point, only slashed plots have been processed, no beans harvested
-            require(bs.totalHarvested(SRC_FIELD) == 0, "total harvested");
-            require(bs.totalSlashed(SRC_FIELD) == bs.totalProcessed(SRC_FIELD), "total slashed");
+            assertEq(bs.totalHarvested(SRC_FIELD), 0, "total harvested");
+            assertEq(bs.totalSlashed(SRC_FIELD), bs.totalProcessed(SRC_FIELD), "total slashed");
         }
         // Verify Destination plots by harvesting.
         {
             newBs.sunSunrise(10_000_000e6, 0);
             uint256[] memory plotIds = newBs.getPlotIndexesFromAccount(user, DEST_FIELD);
             for (uint256 i; i < plotIds.length; i++) {
-                require(plotIds[i] >= SRC_INIT_PODS, "plot not pushed");
+                assertGe(plotIds[i], SRC_INIT_PODS, "plot not pushed");
             }
-            require(plotIds.length == 2, "dest plot count");
+            assertEq(plotIds.length, 2, "dest plot count");
             vm.expectEmit();
             emit IMockFBeanstalk.Harvest(user, DEST_FIELD, plotIds, pods);
             vm.prank(user);
@@ -430,20 +431,20 @@ contract TransmitToForkTest is TestHelper {
 
         // Verify Source fertilizer state.
         {
-            require(bs.totalUnfertilizedBeans() < srcInitUnfert, "Src unfert amt");
-            require(bs.getActiveFertilizer() == srcInitActiveFert - totalTrans, "Src afert amt");
+            assertLt(bs.totalUnfertilizedBeans(), srcInitUnfert, "Src unfert amt");
+            assertEq(bs.getActiveFertilizer(), srcInitActiveFert - totalTrans, "Src afert amt");
         }
         // Verify Destination fertilizer.
         {
-            require(newBs.getFertilizer(id0) == transAmount0, "Dest fert0 amt");
-            require(newBs.getFertilizer(id1) == transAmount1, "Dest fert1 amt");
-            require(newBs.totalUnfertilizedBeans() > totalTrans, "Dest unfert");
-            require(newBs.getActiveFertilizer() == totalTrans, "Dest fert1 amt");
+            assertEq(newBs.getFertilizer(id0), transAmount0, "Dest fert0 amt");
+            assertEq(newBs.getFertilizer(id1), transAmount1, "Dest fert1 amt");
+            assertGt(newBs.totalUnfertilizedBeans(), totalTrans, "Dest unfert");
+            assertEq(newBs.getActiveFertilizer(), totalTrans, "Dest fert1 amt");
         }
         // Balance of Fertilizer is unchanged, since both src and dest use the same Fert contract.
         {
-            require(fertilizer.balanceOf(user, id0) == fertAmount0, "fert0 amt");
-            require(fertilizer.balanceOf(user, id1) == fertAmount1, "fert1 amt");
+            assertEq(fertilizer.balanceOf(user, id0), fertAmount0, "fert0 amt");
+            assertEq(fertilizer.balanceOf(user, id1), fertAmount1, "fert1 amt");
         }
         // Fert is rinsible at destination.
         {

--- a/protocol/test/foundry/forkSystem/TransmitToFork.t.sol
+++ b/protocol/test/foundry/forkSystem/TransmitToFork.t.sol
@@ -110,6 +110,13 @@ contract TransmitToForkTest is TestHelper {
             vm.expectRevert("Transmit: Cannot transmit germinating deposits");
             vm.prank(user);
             bs.transmitOut(newBsAddr, _assets, abi.encode(""));
+
+            // if one season passes, the deposit is still germinating, it should revert
+
+            bs.siloSunrise(0);
+            vm.expectRevert("Transmit: Cannot transmit germinating deposits");
+            vm.prank(user);
+            bs.transmitOut(newBsAddr, _assets, abi.encode(""));
         }
 
         // Capture Source state.

--- a/protocol/test/foundry/forkSystem/TransmitToFork.t.sol
+++ b/protocol/test/foundry/forkSystem/TransmitToFork.t.sol
@@ -159,14 +159,13 @@ contract TransmitToForkTest is TestHelper {
             emit IERC20.Transfer(ZERO_ADDR, newBsAddr, 1); // LP mint
         }
 
+        bytes[] memory assets = new bytes[](3);
+        assets[0] = abi.encode(deposits);
+        assets[1] = abi.encode(new IMockFBeanstalk.SourcePlot[](0));
+        assets[2] = abi.encode(new IMockFBeanstalk.SourceFertilizer[](0));
+
         vm.prank(user);
-        bs.transmitOut(
-            newBsAddr,
-            deposits,
-            new IMockFBeanstalk.SourcePlot[](0),
-            new IMockFBeanstalk.SourceFertilizer[](0),
-            abi.encode("")
-        );
+        bs.transmitOut(newBsAddr, assets, abi.encode(""));
 
         // Verify Source deposits.
         {
@@ -244,14 +243,13 @@ contract TransmitToForkTest is TestHelper {
             );
         }
 
+        bytes[] memory assets = new bytes[](3);
+        assets[0] = abi.encode(new IMockFBeanstalk.SourceDeposit[](0));
+        assets[1] = abi.encode(plots);
+        assets[2] = abi.encode(new IMockFBeanstalk.SourceFertilizer[](0));
+
         vm.prank(user);
-        bs.transmitOut(
-            newBsAddr,
-            new IMockFBeanstalk.SourceDeposit[](0),
-            plots,
-            new IMockFBeanstalk.SourceFertilizer[](0),
-            abi.encode("")
-        );
+        bs.transmitOut(newBsAddr, assets, abi.encode(""));
 
         // Verify Source plots.
         {
@@ -297,14 +295,13 @@ contract TransmitToForkTest is TestHelper {
             );
             pods = pods0 + pods1;
 
+            bytes[] memory assets = new bytes[](3);
+            assets[0] = abi.encode(new IMockFBeanstalk.SourceDeposit[](0));
+            assets[1] = abi.encode(plots);
+            assets[2] = abi.encode(new IMockFBeanstalk.SourceFertilizer[](0));
+
             vm.prank(user);
-            bs.transmitOut(
-                newBsAddr,
-                new IMockFBeanstalk.SourceDeposit[](0),
-                plots,
-                new IMockFBeanstalk.SourceFertilizer[](0),
-                abi.encode("")
-            );
+            bs.transmitOut(newBsAddr, assets, abi.encode(""));
         }
         // Verify source plots slashing.
         {
@@ -385,11 +382,15 @@ contract TransmitToForkTest is TestHelper {
         }
 
         vm.prank(user);
+
+        bytes[] memory assets = new bytes[](3);
+        assets[0] = abi.encode(new IMockFBeanstalk.SourceDeposit[](0));
+        assets[1] = abi.encode(new IMockFBeanstalk.SourcePlot[](0));
+        assets[2] = abi.encode(ferts);
+
         bs.transmitOut(
             newBsAddr, // Transmit into self
-            new IMockFBeanstalk.SourceDeposit[](0),
-            new IMockFBeanstalk.SourcePlot[](0),
-            ferts,
+            assets,
             abi.encode("")
         );
 
@@ -463,8 +464,14 @@ contract TransmitToForkTest is TestHelper {
                 0
             );
             vm.expectRevert();
+
+            bytes[] memory assets = new bytes[](3);
+            assets[0] = abi.encode(deposits);
+            assets[1] = abi.encode(plots);
+            assets[2] = abi.encode(fertilizer);
+
             vm.prank(user);
-            bs.transmitOut(newBsAddr, deposits, plots, fertilizer, abi.encode(""));
+            bs.transmitOut(newBsAddr, assets, abi.encode(""));
 
             // Revert LP amount out too high.
             uint256 lpDepositAmount = 100e18;
@@ -488,8 +495,14 @@ contract TransmitToForkTest is TestHelper {
                 0 // populated by source
             );
             vm.expectRevert(); // 0xd58ad03f // error SlippageOut
+
+            assets = new bytes[](3);
+            assets[0] = abi.encode(deposits);
+            assets[1] = abi.encode(plots);
+            assets[2] = abi.encode(fertilizer);
+
             vm.prank(user);
-            bs.transmitOut(newBsAddr, deposits, plots, fertilizer, abi.encode(""));
+            bs.transmitOut(newBsAddr, assets, abi.encode(""));
         }
 
         // Plot reverts.
@@ -509,8 +522,14 @@ contract TransmitToForkTest is TestHelper {
                 0 // existingIndex
             );
             vm.expectRevert();
+
+            bytes[] memory assets = new bytes[](3);
+            assets[0] = abi.encode(deposits);
+            assets[1] = abi.encode(plots);
+            assets[2] = abi.encode(fertilizer);
+
             vm.prank(user);
-            bs.transmitOut(newBsAddr, deposits, plots, fertilizer, abi.encode(""));
+            bs.transmitOut(newBsAddr, assets, abi.encode(""));
 
             // Revert bad existing index.
             uint256 podsPerSow = sowForUser(user, 1000e6);
@@ -521,8 +540,14 @@ contract TransmitToForkTest is TestHelper {
                 1 // existingIndex
             );
             vm.expectRevert("existingIndex non null");
+
+            assets = new bytes[](3);
+            assets[0] = abi.encode(deposits);
+            assets[1] = abi.encode(plots);
+            assets[2] = abi.encode(fertilizer);
+
             vm.prank(user);
-            bs.transmitOut(newBsAddr, deposits, plots, fertilizer, abi.encode(""));
+            bs.transmitOut(newBsAddr, assets, abi.encode(""));
         }
 
         // Fertilizer Reverts.
@@ -542,8 +567,14 @@ contract TransmitToForkTest is TestHelper {
                 0 // _remainingBpf
             );
             vm.expectRevert();
+
+            bytes[] memory assets = new bytes[](3);
+            assets[0] = abi.encode(deposits);
+            assets[1] = abi.encode(plots);
+            assets[2] = abi.encode(fertilizer);
+
             vm.prank(user);
-            bs.transmitOut(newBsAddr, deposits, plots, fertilizer, abi.encode(""));
+            bs.transmitOut(newBsAddr, assets, abi.encode(""));
         }
     }
 
@@ -594,7 +625,12 @@ contract TransmitToForkTest is TestHelper {
             0 // _remainingBpf
         );
 
+        bytes[] memory assets = new bytes[](3);
+        assets[0] = abi.encode(deposits);
+        assets[1] = abi.encode(plots);
+        assets[2] = abi.encode(fertilizer);
+
         vm.prank(user);
-        bs.transmitOut(newBsAddr, deposits, plots, fertilizer, abi.encode(""));
+        bs.transmitOut(newBsAddr, assets, abi.encode(""));
     }
 }

--- a/protocol/test/foundry/sun/Flood.t.sol
+++ b/protocol/test/foundry/sun/Flood.t.sol
@@ -496,7 +496,6 @@ contract FloodTest is TestHelper {
         uint256 userPlenty = bs.balanceOfPlenty(users[1], sopWell);
         assertEq(userPlenty, 38544532214605630101);
 
-
         // tracks user plenty after update
         bs.mow(users[1], sopWell);
         SiloGettersFacet.AccountSeasonOfPlenty memory userSop = siloGetters.balanceOfSop(users[1]);

--- a/protocol/test/foundry/utils/BeanstalkDeployer.sol
+++ b/protocol/test/foundry/utils/BeanstalkDeployer.sol
@@ -100,7 +100,7 @@ contract BeanstalkDeployer is Utils {
             initialDeployFacetAddresses,
             cutActions
         );
-        d = deployDiamondAtAddress(deployer, BEANSTALK);
+        d = deployDiamondAtAddress(deployer, diamondAddr);
 
         // if mocking, set the diamond address to
         // the canonical beanstalk address.

--- a/protocol/test/foundry/utils/LibAltC.sol
+++ b/protocol/test/foundry/utils/LibAltC.sol
@@ -8,7 +8,6 @@ pragma solidity ^0.8.20;
  *         Only contains address constants that diverge from actual Beanstalk.
  */
 library LibAltC {
-
     address constant BEANSTALK = 0x00F84c1cF4Ca7fa8A8b0Dc923DA91ACA148B865C;
     address internal constant BEAN = 0x006DD9acC7cDf83128C4aDF46847c301f94406ab;
 
@@ -20,5 +19,4 @@ library LibAltC {
 
     // address constant PRICE_DEPLOYER = ;
     // address constant PRICE = ;
-
 }


### PR DESCRIPTION
Updates TransmitInFacet to handle 2d bytes array for asset transmission flexibility.

(This PR will be updated to merge into the main transmission branch once the master merge branch is merged).

This also includes:
- Updates tests from using `require` to `assert`
- Adds test for `totalHarvested` and `totalSlashed`
- Disallows the transfer of germinating deposits
- Fixes TransmitOutFacet to pass through data from it's input param to the TransmitInFacet (bug fix)