### PR TITLE
Liquidity calculation fix

### DIFF
--- a/protocol/contracts/ecosystem/price/BeanstalkPrice.sol
+++ b/protocol/contracts/ecosystem/price/BeanstalkPrice.sol
@@ -36,4 +36,13 @@ contract BeanstalkPrice is WellPrice {
         }
         p.price = p.price.div(p.liquidity);
     }
+
+    /**
+     * @notice Returns the non-manipulation resistant on-chain liquidiy, deltaB and price data for
+     * Bean in the specified liquidity pools.
+     * @dev No protocol should use this function to calculate manipulation resistant Bean price data.
+     **/
+    function poolPrice(address pool) public view returns (P.Pool memory p) {
+        return getWell(pool);
+    }
 }

--- a/protocol/contracts/ecosystem/price/P.sol
+++ b/protocol/contracts/ecosystem/price/P.sol
@@ -8,6 +8,8 @@ contract P {
         uint256[2] balances;
         uint256 price;
         uint256 liquidity;
+        uint256 beanLiquidity;
+        uint256 nonBeanLiquidity;
         int256 deltaB;
         uint256 lpUsd;
         uint256 lpBdv;

--- a/protocol/foundry.toml
+++ b/protocol/foundry.toml
@@ -42,6 +42,7 @@ gas_reports = ['*']
 # Cache to `$HOME/.foundry/cache/<chain id>/<block number>`.
 no_storage_caching = false
 no_match_test = "testFork"
+no_match_contract = "Reseed|L1ReceiverFacetForkTest|L1ReceiverFacetTest|ReseedL1ReceiverFacetForkTest|ReseedFunctionalityTest"
 
 [profile.differential]
 match_test = "testDiff"

--- a/protocol/test/foundry/Migration/ReseedState.t.sol
+++ b/protocol/test/foundry/Migration/ReseedState.t.sol
@@ -111,7 +111,8 @@ contract ReseedStateTest is TestHelper {
         IMockFBeanstalk.AssetSettings memory assetSettings = l2Beanstalk.tokenSettings(L2BEAN);
 
         // log milestone stem and season
-        console.log("Milestone stem: ", assetSettings.milestoneStem);
+        console.log("Milestone stem: ");
+        console.logInt(assetSettings.milestoneStem);
         console.log("Milestone season: ", assetSettings.milestoneSeason);
     }
 


### PR DESCRIPTION
-Fixes liquidity calculation for stableswap wells. The new formulate calculates the USD value for the bean and non-bean liquidity independently, and adds them together for the final total USD liquidity.
-Adds tests to verify liquidity calculations are correct, as of block 267500000 on arbitrum
-Adds a view function to the BeanstalkPrice contract so that price data for an individual well can be retrieved, without having to get the data about all whitelist wells.
-Adds bean and non-bean USD valued liquidity to the BeanstalkPrice contract return data.
-Fixes a log in `test_WhitelistingState` which was left in a broken state
-Excludes reseed related tests in the foundry.toml, since they require fork setup to run (this allows all tests to pass in CI)