### PR TITLE
EBIP-22: Remove transferInternalTokenFrom Function

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jest": "29.2.2",
     "jest-serial-runner": "1.2.1",
     "lint-staged": "13.3.0",
-    "prettier": "3.5.3",
+    "prettier": "3.8.1",
     "ts-jest": "29.1.2",
     "ts-node": "10.9.2",
     "typescript": "5.3.3"
@@ -58,6 +58,6 @@
     "anvil4tests": "anvil --fork-url https://arb-mainnet.g.alchemy.com/v2/Kk7ktCQL5wz4v4AG8bR2Gun8TAASQ-qi  --chain-id 1337 --fork-block-number 18629000"
   },
   "dependencies": {
-    "prettier-plugin-solidity": "2.0.0"
+    "prettier-plugin-solidity": "2.2.1"
   }
 }

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -53,7 +53,7 @@ const {
   bipSeedGauge,
   bipMiscellaneousImprovements
 } = require("./scripts/bips.js");
-const { ebip9, ebip10, ebip11, ebip13, ebip14, ebip15, ebip19 } = require("./scripts/ebips.js");
+const { ebip9, ebip10, ebip11, ebip13, ebip14, ebip15, ebip19, ebip22 } = require("./scripts/ebips.js");
 const { impersonateMockArbitrumSys } = require("./scripts/impersonate.js");
 
 //////////////////////// UTILITIES ////////////////////////
@@ -605,6 +605,10 @@ task("ebip11", async function () {
 
 task("ebip10", async function () {
   await ebip10();
+});
+
+task("ebip22", async function () {
+  await ebip22();
 });
 
 task("ebip9", async function () {

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -295,6 +295,22 @@ async function ebip19(mock = true, account = undefined) {
   });
 }
 
+async function ebip22(mock = true, account = undefined) {
+  if (account == undefined) {
+    account = await impersonateBeanstalkOwner();
+    await mintEth(account.address);
+  }
+
+  const dc = {
+    diamondCut: [
+      [ethers.constants.AddressZero, "2", ["0xd3f4ec6f"]]
+    ],
+    initFacetAddress: ethers.constants.AddressZero,
+    functionCall: "0x"
+  };
+  await bipDiamondCut("EBIP-22", dc, account, mock);
+}
+
 async function bipDiamondCut(name, dc, account, mock = true) {
   beanstalk = await getBeanstalk();
   if (mock) {
@@ -330,3 +346,4 @@ exports.ebip15 = ebip15;
 exports.ebip16 = ebip16;
 exports.ebip17 = ebip17;
 exports.ebip19 = ebip19;
+exports.ebip22 = ebip22;

--- a/protocol/test/foundry/Migration/L1SelectorRemoval.t.sol
+++ b/protocol/test/foundry/Migration/L1SelectorRemoval.t.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+
+interface IERC20 {
+    function balanceOf(address account) external view returns (uint256);
+}
+
+interface IDiamondCut {
+    struct FacetCut {
+        address facetAddress;
+        uint8 action;
+        bytes4[] functionSelectors;
+    }
+
+    function diamondCut(
+        FacetCut[] calldata _diamondCut,
+        address _init,
+        bytes calldata _calldata
+    ) external;
+}
+
+interface IDiamondLoupe {
+    function facetAddress(bytes4 _functionSelector) external view returns (address);
+}
+
+interface IBeanstalk {
+    function transferToken(
+        address token,
+        address recipient,
+        uint256 amount,
+        uint8 fromMode,
+        uint8 toMode
+    ) external payable;
+
+    function transferInternalTokenFrom(
+        address token,
+        address sender,
+        address recipient,
+        uint256 amount,
+        uint8 toMode
+    ) external payable;
+
+    function getInternalBalance(address account, address token) external view returns (uint256);
+
+    function owner() external view returns (address);
+}
+
+/**
+ * @notice EBIP-22: Remove transferInternalTokenFrom selector from L1 Diamond.
+ * @dev Run with:
+ *   cd protocol
+ *   ETH_RPC_URL=<ethereum-mainnet-rpc> FOUNDRY_PROFILE=l1fork forge test \
+ *     --match-path test/foundry/Migration/L1SelectorRemoval.t.sol -vv
+ */
+contract L1SelectorRemovalTest is Test {
+    address private constant BEANSTALK = 0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5;
+    address private constant BEAN = 0xBEA0000029AD1c77D3d5D23Ba2D8893dB9d1Efab;
+    uint8 private constant FROM_INTERNAL = 1;
+    uint8 private constant TO_EXTERNAL = 0;
+    uint8 private constant TO_INTERNAL = 1;
+    uint256 private constant FORK_BLOCK = 24_547_453;
+
+    address private constant HOLDER = 0xaa75c70b7ce3A00cdFa1Bf401756bdf5C70889Cc;
+
+    bytes4 private constant SELECTOR_TRANSFER_INTERNAL_TOKEN_FROM = 0xd3f4ec6f;
+
+    function setUp() external {
+        uint256 forkId = vm.createFork(vm.envString("ETH_RPC_URL"), FORK_BLOCK);
+        vm.selectFork(forkId);
+    }
+
+    /**
+     * @notice Execute the EBIP-22 diamond cut: remove transferInternalTokenFrom selector.
+     */
+    function _executeDiamondCut() internal {
+        address owner = IBeanstalk(BEANSTALK).owner();
+
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = SELECTOR_TRANSFER_INTERNAL_TOKEN_FROM;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(0),
+            action: 2, // Remove
+            functionSelectors: selectors
+        });
+
+        vm.prank(owner);
+        IDiamondCut(BEANSTALK).diamondCut(cut, address(0), "");
+    }
+
+    /**
+     * @notice Verify that transferInternalTokenFrom is callable BEFORE the fix
+     *         and reverts AFTER the diamond cut.
+     */
+    function test_TransferInternalTokenFromRevertsAfterFix() external {
+        IBeanstalk beanstalk = IBeanstalk(BEANSTALK);
+
+        uint256 internalBefore = beanstalk.getInternalBalance(HOLDER, BEAN);
+        assertGt(internalBefore, 0, "precondition: HOLDER has no internal BEAN");
+
+        uint256 amount = 1e6;
+        if (amount > internalBefore) amount = internalBefore;
+
+        // Before fix: transferInternalTokenFrom succeeds.
+        vm.prank(HOLDER);
+        beanstalk.transferInternalTokenFrom(BEAN, HOLDER, address(0xBEEF), amount, TO_EXTERNAL);
+        assertEq(IERC20(BEAN).balanceOf(address(0xBEEF)), amount, "before fix: bypass works");
+
+        _executeDiamondCut();
+
+        // After fix: transferInternalTokenFrom reverts (selector removed from Diamond).
+        vm.prank(HOLDER);
+        vm.expectRevert();
+        beanstalk.transferInternalTokenFrom(BEAN, HOLDER, address(0xBEEF), amount, TO_EXTERNAL);
+    }
+
+    /**
+     * @notice Verify that the selector is removed from the Diamond loupe.
+     */
+    function test_SelectorRemovedFromLoupe() external {
+        // Before: selector is mapped to a facet.
+        address facetBefore = IDiamondLoupe(BEANSTALK).facetAddress(SELECTOR_TRANSFER_INTERNAL_TOKEN_FROM);
+        assertTrue(facetBefore != address(0), "precondition: selector should exist");
+
+        _executeDiamondCut();
+
+        // After: selector maps to address(0).
+        address facetAfter = IDiamondLoupe(BEANSTALK).facetAddress(SELECTOR_TRANSFER_INTERNAL_TOKEN_FROM);
+        assertEq(facetAfter, address(0), "selector should be removed");
+    }
+
+    /**
+     * @notice Verify that other L1TokenFacet functions still work after the fix.
+     */
+    function test_OtherFunctionsStillWorkAfterFix() external {
+        IBeanstalk beanstalk = IBeanstalk(BEANSTALK);
+
+        _executeDiamondCut();
+
+        // getInternalBalance should still work.
+        uint256 balance = beanstalk.getInternalBalance(HOLDER, BEAN);
+        assertGt(balance, 0, "getInternalBalance should work");
+
+        // transferToken should still revert with checkBeanAsset for BEAN.
+        vm.prank(HOLDER);
+        vm.expectRevert(bytes("TokenFacet: Beans cannot be transferred."));
+        beanstalk.transferToken(BEAN, HOLDER, 1e6, FROM_INTERNAL, TO_EXTERNAL);
+
+        // owner() should still work.
+        address owner = beanstalk.owner();
+        assertTrue(owner != address(0), "owner should work");
+    }
+}

--- a/protocol/test/foundry/Migration/L1SelectorRemoval.t.sol
+++ b/protocol/test/foundry/Migration/L1SelectorRemoval.t.sol
@@ -26,14 +26,6 @@ interface IDiamondLoupe {
 }
 
 interface IBeanstalk {
-    function transferToken(
-        address token,
-        address recipient,
-        uint256 amount,
-        uint8 fromMode,
-        uint8 toMode
-    ) external payable;
-
     function transferInternalTokenFrom(
         address token,
         address sender,
@@ -57,14 +49,14 @@ interface IBeanstalk {
 contract L1SelectorRemovalTest is Test {
     address private constant BEANSTALK = 0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5;
     address private constant BEAN = 0xBEA0000029AD1c77D3d5D23Ba2D8893dB9d1Efab;
-    uint8 private constant FROM_INTERNAL = 1;
     uint8 private constant TO_EXTERNAL = 0;
-    uint8 private constant TO_INTERNAL = 1;
     uint256 private constant FORK_BLOCK = 24_547_453;
 
     address private constant HOLDER = 0xaa75c70b7ce3A00cdFa1Bf401756bdf5C70889Cc;
+    address private constant RECEIVER = address(0xBEEF);
 
-    bytes4 private constant SELECTOR_TRANSFER_INTERNAL_TOKEN_FROM = 0xd3f4ec6f;
+    bytes4 private constant SELECTOR_TRANSFER_INTERNAL_TOKEN_FROM =
+        IBeanstalk.transferInternalTokenFrom.selector;
 
     function setUp() external {
         uint256 forkId = vm.createFork(vm.envString("ETH_RPC_URL"), FORK_BLOCK);
@@ -106,15 +98,15 @@ contract L1SelectorRemovalTest is Test {
 
         // Before fix: transferInternalTokenFrom succeeds.
         vm.prank(HOLDER);
-        beanstalk.transferInternalTokenFrom(BEAN, HOLDER, address(0xBEEF), amount, TO_EXTERNAL);
-        assertEq(IERC20(BEAN).balanceOf(address(0xBEEF)), amount, "before fix: bypass works");
+        beanstalk.transferInternalTokenFrom(BEAN, HOLDER, RECEIVER, amount, TO_EXTERNAL);
+        assertEq(IERC20(BEAN).balanceOf(RECEIVER), amount, "before fix: bypass works");
 
         _executeDiamondCut();
 
         // After fix: transferInternalTokenFrom reverts (selector removed from Diamond).
         vm.prank(HOLDER);
         vm.expectRevert();
-        beanstalk.transferInternalTokenFrom(BEAN, HOLDER, address(0xBEEF), amount, TO_EXTERNAL);
+        beanstalk.transferInternalTokenFrom(BEAN, HOLDER, RECEIVER, amount, TO_EXTERNAL);
     }
 
     /**
@@ -130,27 +122,5 @@ contract L1SelectorRemovalTest is Test {
         // After: selector maps to address(0).
         address facetAfter = IDiamondLoupe(BEANSTALK).facetAddress(SELECTOR_TRANSFER_INTERNAL_TOKEN_FROM);
         assertEq(facetAfter, address(0), "selector should be removed");
-    }
-
-    /**
-     * @notice Verify that other L1TokenFacet functions still work after the fix.
-     */
-    function test_OtherFunctionsStillWorkAfterFix() external {
-        IBeanstalk beanstalk = IBeanstalk(BEANSTALK);
-
-        _executeDiamondCut();
-
-        // getInternalBalance should still work.
-        uint256 balance = beanstalk.getInternalBalance(HOLDER, BEAN);
-        assertGt(balance, 0, "getInternalBalance should work");
-
-        // transferToken should still revert with checkBeanAsset for BEAN.
-        vm.prank(HOLDER);
-        vm.expectRevert(bytes("TokenFacet: Beans cannot be transferred."));
-        beanstalk.transferToken(BEAN, HOLDER, 1e6, FROM_INTERNAL, TO_EXTERNAL);
-
-        // owner() should still work.
-        address owner = beanstalk.owner();
-        assertTrue(owner != address(0), "owner should work");
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2334,10 +2334,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bytecodealliance/preview2-shim@npm:0.17.2":
-  version: 0.17.2
-  resolution: "@bytecodealliance/preview2-shim@npm:0.17.2"
-  checksum: 10/24bf1698fcf8c1cd25089b46eccbdae2db5585ca1d69ec15e5ad5a095f19d710bb73071bb17ed1a4745bd2707cc68754d0c17ce13800cd1aa465cce3c6aaff88
+"@bytecodealliance/preview2-shim@npm:^0.17.2":
+  version: 0.17.8
+  resolution: "@bytecodealliance/preview2-shim@npm:0.17.8"
+  checksum: 10/a528da2a4412847a70ae4c1e420393f30e48b3b39b87ed718490d85bc49063ee78343b710eaa99d6ba9943749f408109d339b8c95aba282467c39a44d3789e24
   languageName: node
   linkType: hard
 
@@ -7873,12 +7873,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/slang@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@nomicfoundation/slang@npm:1.1.0"
+"@nomicfoundation/slang@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@nomicfoundation/slang@npm:1.3.1"
   dependencies:
-    "@bytecodealliance/preview2-shim": "npm:0.17.2"
-  checksum: 10/7f4f24a03aec625813c6eb87390406869534896e5be90b2473b8b55abadfd48537958345629c75c4896dd38e4ad7aaaeff151be752a9ab468a6290a55e999e34
+    "@bytecodealliance/preview2-shim": "npm:^0.17.2"
+  checksum: 10/c05e6fbb031616a7c59dfb6d318be139dcd5c3d5391a9d79aa5e9fd04db414727c9ddc4b45b6e0134f154f1d7bde350a99b31611b6513b76bb1099780613eb20
   languageName: node
   linkType: hard
 
@@ -10622,10 +10622,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solidity-parser/parser@npm:^0.20.1":
-  version: 0.20.1
-  resolution: "@solidity-parser/parser@npm:0.20.1"
-  checksum: 10/6497d74c67386ad3c91c906fbea4cf46df1b0eb3f597c7c881c5bbf33a5c689b36d22211fedc36e023e59facf8a6d7cff315dc117d3215d38cc5be95ecc106db
+"@solidity-parser/parser@npm:^0.20.2":
+  version: 0.20.2
+  resolution: "@solidity-parser/parser@npm:0.20.2"
+  checksum: 10/405009cd712cc410df60e45510ddd2ca615d208b152903be71cef4b9440720287ffd3792f88a92eb0de375c2ea66b442e84c843cb810612d6b6e45fd51a2b49b
   languageName: node
   linkType: hard
 
@@ -33935,16 +33935,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-plugin-solidity@npm:2.0.0":
-  version: 2.0.0
-  resolution: "prettier-plugin-solidity@npm:2.0.0"
+"prettier-plugin-solidity@npm:2.2.1":
+  version: 2.2.1
+  resolution: "prettier-plugin-solidity@npm:2.2.1"
   dependencies:
-    "@nomicfoundation/slang": "npm:1.1.0"
-    "@solidity-parser/parser": "npm:^0.20.1"
-    semver: "npm:^7.7.1"
+    "@nomicfoundation/slang": "npm:1.3.1"
+    "@solidity-parser/parser": "npm:^0.20.2"
+    semver: "npm:^7.7.3"
   peerDependencies:
     prettier: ">=3.0.0"
-  checksum: 10/b5ef1d64902b181478e3bd557a37d11c5437e9353402e43c1ef0909e596d76f1e72b0fd59726a381564d303a6bcb4f0b6b9a9310caf942b27236dc6913819de1
+  checksum: 10/007fa19131366937465ec8ded6e1540264d07892f235c0679929ce08caf5f0081abf3be065984f7476071c3525d4fd67d02bc996a2a94e28c611fcd214fd16e4
   languageName: node
   linkType: hard
 
@@ -33957,12 +33957,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.5.3":
-  version: 3.5.3
-  resolution: "prettier@npm:3.5.3"
+"prettier@npm:3.8.1":
+  version: 3.8.1
+  resolution: "prettier@npm:3.8.1"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10/7050c08f674d9e49fbd9a4c008291d0715471f64e94cc5e4b01729affce221dfc6875c8de7e66b728c64abc9352eefb7eaae071b5f79d30081be207b53774b78
+  checksum: 10/3da1cf8c1ef9bea828aa618553696c312e951f810bee368f6887109b203f18ee869fe88f66e65f9cf60b7cb1f2eae859892c860a300c062ff8ec69c381fc8dbd
   languageName: node
   linkType: hard
 
@@ -36254,8 +36254,8 @@ __metadata:
     jest: "npm:29.2.2"
     jest-serial-runner: "npm:1.2.1"
     lint-staged: "npm:13.3.0"
-    prettier: "npm:3.5.3"
-    prettier-plugin-solidity: "npm:2.0.0"
+    prettier: "npm:3.8.1"
+    prettier-plugin-solidity: "npm:2.2.1"
     ts-jest: "npm:29.1.2"
     ts-node: "npm:10.9.2"
     typescript: "npm:5.3.3"
@@ -36668,12 +36668,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.7.1":
-  version: 7.7.2
-  resolution: "semver@npm:7.7.2"
+"semver@npm:^7.7.3":
+  version: 7.7.4
+  resolution: "semver@npm:7.7.4"
   bin:
     semver: bin/semver.js
-  checksum: 10/7a24cffcaa13f53c09ce55e05efe25cd41328730b2308678624f8b9f5fc3093fc4d189f47950f0b811ff8f3c3039c24a2c36717ba7961615c682045bf03e1dda
+  checksum: 10/26bdc6d58b29528f4142d29afb8526bc335f4fc04c4a10f2b98b217f277a031c66736bf82d3d3bb354a2f6a3ae50f18fd62b053c4ac3f294a3d10a61f5075b75
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# EBIP-22: Remove transferInternalTokenFrom Function

- [Submitter](#submitter)
- [Emergency Process Note](#emergency-process-note)
- [Links](#links)
- [Problem](#problem)
- [Solution](#solution)
- [Contract Changes](#contract-changes)
- [Beans Minted](#beans-minted)
- [Effective](#effective)

## Submitter

Beanstalk Community Multisig

## Emergency Process Note

Per the process outlined in the [BCM Emergency Response Procedures](https://docs.bean.money/almanac/governance/beanstalk/bcm-process#emergency-response-procedures), the BCM can take swift action to protect Beanstalk in the event of a bug or security vulnerability.

This bug was reported by a whitehat on Immunefi.

## Links

- [Gnosis Transaction](https://app.safe.global/transactions/tx?id=multisig_0xa9bA2C40b263843C04d344727b954A545c81D043_0x4df79e09d681e01a940238774b17c8d433f77008386dd0ccde4be584556601ba&safe=eth:0xa9bA2C40b263843C04d344727b954A545c81D043)
- [Etherscan Transaction](https://etherscan.io/tx/0x76f9f324f6ed1b4549edbfbc16000415ba977236403d5cea5a879a903de9e4d0)

## Problem

During the L2 migration, the `L1TokenFacet` was deployed on L1 Beanstalk to restrict the transfer of certain assets (Bean, Bean:ETH Well LP, Bean:wstETH Well LP and the Bean:3CRV LP token) via a `checkBeanAsset` guard in the `transferToken(...)` function. However, the `transferInternalTokenFrom(...)` function in the same facet was not updated to include this guard.

As a result, any account with a non-zero Farm balance of a restricted token could bypass the transfer restriction by calling `transferInternalTokenFrom(...)` directly, moving their frozen internal balance to an external balance.

## Solution

Remove the `transferInternalTokenFrom(...)` function selector from the L1 Beanstalk Diamond.

## Contract Changes

### L1TokenFacet

The following `L1TokenFacet` is still part of Beanstalk:
* [`0x8F66044a9C95FaE9d38B8Bc30665eE04A2456501`](https://etherscan.io/address/0x8F66044a9C95FaE9d38B8Bc30665eE04A2456501#code)

The following function is **removed** from `L1TokenFacet`:

| Name                               | Selector     |
|:------------------------------------|:-------------|
| `transferInternalTokenFrom(...)`    | `0xd3f4ec6f` |

## Beans Minted

None.

## Effective

Effective immediately upon commitment by the BCM, which has already happened.