### PR TITLE
fix dex-ui well loader hiding rpc failures and cli setbalance error text

### DIFF
--- a/projects/cli/src/commands/setbalance.ts
+++ b/projects/cli/src/commands/setbalance.ts
@@ -48,9 +48,13 @@ export const setbalance = async (sdk, chain, { account, symbol, amount }) => {
       if (symbol === "BEANUSDC") t = sdk.tokens.BEAN_USDC_WELL_LP;
       if (symbol === "BEANUSDT") t = sdk.tokens.BEAN_USDT_WELL_LP;
     }
-    if (typeof chain[`set${symbol}Balance`] !== "function")
-      throw new Error(`${symbol} is not a valid token or the method ${chalk.bold.whiteBright("")}`);
+    const setterName = `set${symbol}Balance`;
+    if (typeof chain[setterName] !== "function") {
+      throw new Error(
+        `${symbol} has no ${setterName} helper on this chain fork (token may be unknown or anvil hook missing)`
+      );
+    }
 
-    await chain[`set${symbol}Balance`](account, t.amount(amount));
+    await chain[setterName](account, t.amount(amount));
   }
 };

--- a/projects/dex-ui/src/wells/wellLoader.ts
+++ b/projects/dex-ui/src/wells/wellLoader.ts
@@ -77,7 +77,7 @@ const loadFromChain = async (sdk: BeanstalkSDK, aquifer: Aquifer): Promise<WellA
     return addresses;
   } catch (e) {
     console.error("error loading wells from chain: ", e);
-    return [];
+    throw e;
   }
 };
 


### PR DESCRIPTION
hey folks, mooncitydev here, was reading dex-ui well loading and the cli fork helpers and found two rough edges.

first is loadFromChain in wellLoader: any rpc/query/decode failure got caught, logged to console, and then it returned an empty array. that resolves successfully so the Promise.any wrapper never treats it as an error, and callers merge that with sdk pools as if the chain just had no bore events. easy to end up with a weird partial well list and no signal that the node call failed. now it rethrows after the log so the same failure path as the outer catch actually runs.

second is setbalance on the cli: the throw when the dynamic setSymbolBalance hook (set plus symbol plus Balance) is missing used chalk.bold.whiteBright with an empty string, so the error never told you which method name was expected. swapped that for a plain message that includes the setter name and calls out fork/anvil hooks.

cheers