### PR TITLE
[codex] Optimize frontend RPC polling and versioning

### DIFF
--- a/projects/ui/public/_headers
+++ b/projects/ui/public/_headers
@@ -1,0 +1,2 @@
+/version.json
+  Cache-Control: no-store, max-age=0, must-revalidate

--- a/projects/ui/src/components/App/Wrapper.tsx
+++ b/projects/ui/src/components/App/Wrapper.tsx
@@ -11,6 +11,7 @@ import theme from '~/components/App/muiTheme';
 import { apolloClient } from '~/graph/client';
 import store from '~/state';
 import { FC } from '~/types';
+import AppVersionGuard from '~/components/AppVersionGuard';
 import SdkProvider from './SdkProvider';
 
 const queryClient = new QueryClient();
@@ -23,7 +24,10 @@ const Wrapper: FC<{}> = ({ children }) => (
           <QueryClientProvider client={queryClient}>
             <ThemeProvider theme={theme}>
               <CssBaseline />
-              <SdkProvider>{children}</SdkProvider>
+              <SdkProvider>
+                {children}
+                <AppVersionGuard />
+              </SdkProvider>
             </ThemeProvider>
           </QueryClientProvider>
         </WagmiProvider>

--- a/projects/ui/src/components/AppVersionGuard.test.tsx
+++ b/projects/ui/src/components/AppVersionGuard.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import toast, { Toaster } from 'react-hot-toast';
+import { vi } from 'vitest';
+
+import { useAppVersionGuard } from './AppVersionGuard';
+
+const originalFetch = globalThis.fetch;
+const originalMatchMedia = window.matchMedia;
+
+const GuardHarness = () => {
+  useAppVersionGuard(true);
+  return null;
+};
+
+describe('AppVersionGuard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      media: '',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ buildId: 'new-deployment' }),
+    });
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    });
+  });
+
+  afterEach(() => {
+    toast.remove();
+    vi.useRealTimers();
+    globalThis.fetch = originalFetch;
+    window.matchMedia = originalMatchMedia;
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+  });
+
+  it('offers an explicit reload instead of reloading a hidden wallet flow', async () => {
+    render(
+      <>
+        <Toaster />
+        <GuardHarness />
+      </>
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.getByText('A new Beanstalk version is available.')
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeTruthy();
+  });
+});

--- a/projects/ui/src/components/AppVersionGuard.tsx
+++ b/projects/ui/src/components/AppVersionGuard.tsx
@@ -1,0 +1,157 @@
+/* global __BEANSTALK_APP_VERSION__ */
+import React, { useEffect, useRef } from 'react';
+import toast from 'react-hot-toast';
+
+const VERSION_URL = '/version.json';
+const INITIAL_CHECK_DELAY_MS = 30_000;
+const CHECK_INTERVAL_MS = 5 * 60_000;
+const FOCUS_CHECK_THROTTLE_MS = 60_000;
+
+type AppVersion = typeof __BEANSTALK_APP_VERSION__;
+
+const fetchLatestVersion = async (): Promise<
+  Partial<AppVersion> | undefined
+> => {
+  const response = await fetch(`${VERSION_URL}?t=${Date.now()}`, {
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    return undefined;
+  }
+
+  return response.json();
+};
+
+const reloadApp = () => {
+  window.location.reload();
+};
+
+export default function AppVersionGuard() {
+  const isCheckingRef = useRef(false);
+  const isStaleRef = useRef(false);
+  const hasNotifiedRef = useRef(false);
+  const lastCheckAtRef = useRef(0);
+
+  useEffect(() => {
+    if (!import.meta.env.PROD) {
+      return;
+    }
+
+    let isDisposed = false;
+
+    const handleStaleVersion = () => {
+      if (isDisposed || isStaleRef.current) {
+        return;
+      }
+
+      isStaleRef.current = true;
+
+      if (document.visibilityState === 'hidden') {
+        reloadApp();
+        return;
+      }
+
+      if (hasNotifiedRef.current) {
+        return;
+      }
+
+      hasNotifiedRef.current = true;
+      toast(
+        <span>
+          A new Beanstalk version is available.
+          <button
+            type="button"
+            onClick={reloadApp}
+            style={{
+              marginLeft: 12,
+              border: 'none',
+              background: 'transparent',
+              color: 'inherit',
+              cursor: 'pointer',
+              fontWeight: 700,
+              textDecoration: 'underline',
+            }}
+          >
+            Reload
+          </button>
+        </span>,
+        { duration: Infinity, id: 'app-version-update' }
+      );
+    };
+
+    const checkForLatestVersion = async (force = false) => {
+      if (isDisposed || isStaleRef.current || isCheckingRef.current) {
+        return;
+      }
+
+      const now = Date.now();
+      if (!force && now - lastCheckAtRef.current < FOCUS_CHECK_THROTTLE_MS) {
+        return;
+      }
+
+      lastCheckAtRef.current = now;
+      isCheckingRef.current = true;
+
+      try {
+        const latestVersion = await fetchLatestVersion();
+        if (
+          latestVersion?.buildId &&
+          latestVersion.buildId !== __BEANSTALK_APP_VERSION__.buildId
+        ) {
+          handleStaleVersion();
+        }
+      } catch {
+        // Version checks are best-effort; temporary network failures should not affect app usage.
+      } finally {
+        isCheckingRef.current = false;
+      }
+    };
+
+    const handleFocus = () => {
+      checkForLatestVersion();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden' && isStaleRef.current) {
+        reloadApp();
+        return;
+      }
+
+      if (document.visibilityState === 'visible') {
+        checkForLatestVersion(true);
+      }
+    };
+
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        checkForLatestVersion(true);
+      }
+    };
+
+    const initialCheckId = window.setTimeout(() => {
+      checkForLatestVersion(true);
+    }, INITIAL_CHECK_DELAY_MS);
+    const intervalId = window.setInterval(() => {
+      checkForLatestVersion();
+    }, CHECK_INTERVAL_MS);
+
+    window.addEventListener('focus', handleFocus);
+    window.addEventListener('pageshow', handlePageShow);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      isDisposed = true;
+      window.clearTimeout(initialCheckId);
+      window.clearInterval(intervalId);
+      window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('pageshow', handlePageShow);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  return null;
+}

--- a/projects/ui/src/components/AppVersionGuard.tsx
+++ b/projects/ui/src/components/AppVersionGuard.tsx
@@ -27,14 +27,14 @@ const reloadApp = () => {
   window.location.reload();
 };
 
-export default function AppVersionGuard() {
+export const useAppVersionGuard = (enabled = import.meta.env.PROD) => {
   const isCheckingRef = useRef(false);
   const isStaleRef = useRef(false);
   const hasNotifiedRef = useRef(false);
   const lastCheckAtRef = useRef(0);
 
   useEffect(() => {
-    if (!import.meta.env.PROD) {
+    if (!enabled) {
       return;
     }
 
@@ -46,11 +46,6 @@ export default function AppVersionGuard() {
       }
 
       isStaleRef.current = true;
-
-      if (document.visibilityState === 'hidden') {
-        reloadApp();
-        return;
-      }
 
       if (hasNotifiedRef.current) {
         return;
@@ -113,11 +108,6 @@ export default function AppVersionGuard() {
     };
 
     const handleVisibilityChange = () => {
-      if (document.visibilityState === 'hidden' && isStaleRef.current) {
-        reloadApp();
-        return;
-      }
-
       if (document.visibilityState === 'visible') {
         checkForLatestVersion(true);
       }
@@ -148,7 +138,11 @@ export default function AppVersionGuard() {
       window.removeEventListener('pageshow', handlePageShow);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, []);
+  }, [enabled]);
+};
+
+export default function AppVersionGuard() {
+  useAppVersionGuard();
 
   return null;
 }

--- a/projects/ui/src/components/AppVersionGuard.tsx
+++ b/projects/ui/src/components/AppVersionGuard.tsx
@@ -1,17 +1,14 @@
 /* global __BEANSTALK_APP_VERSION__ */
 import React, { useEffect, useRef } from 'react';
 import toast from 'react-hot-toast';
+import { getRemoteBuildId } from '~/lib/AppVersion';
 
 const VERSION_URL = '/version.json';
 const INITIAL_CHECK_DELAY_MS = 30_000;
 const CHECK_INTERVAL_MS = 5 * 60_000;
 const FOCUS_CHECK_THROTTLE_MS = 60_000;
 
-type AppVersion = typeof __BEANSTALK_APP_VERSION__;
-
-const fetchLatestVersion = async (): Promise<
-  Partial<AppVersion> | undefined
-> => {
+const fetchLatestVersion = async (): Promise<unknown> => {
   const response = await fetch(`${VERSION_URL}?t=${Date.now()}`, {
     cache: 'no-store',
     headers: {
@@ -97,10 +94,10 @@ export default function AppVersionGuard() {
       isCheckingRef.current = true;
 
       try {
-        const latestVersion = await fetchLatestVersion();
+        const latestBuildId = getRemoteBuildId(await fetchLatestVersion());
         if (
-          latestVersion?.buildId &&
-          latestVersion.buildId !== __BEANSTALK_APP_VERSION__.buildId
+          latestBuildId &&
+          latestBuildId !== __BEANSTALK_APP_VERSION__.buildId
         ) {
           handleStaleVersion();
         }

--- a/projects/ui/src/env.d.ts
+++ b/projects/ui/src/env.d.ts
@@ -37,3 +37,11 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+declare const __BEANSTALK_APP_VERSION__: {
+  buildId: string;
+  commit: string;
+  branch: string;
+  context: string;
+  builtAt: string;
+};

--- a/projects/ui/src/lib/AppVersion.test.ts
+++ b/projects/ui/src/lib/AppVersion.test.ts
@@ -1,0 +1,14 @@
+import { getRemoteBuildId } from './AppVersion';
+
+describe('app version payloads', () => {
+  it('accepts a non-empty remote build id', () => {
+    expect(getRemoteBuildId({ buildId: 'deploy-123' })).toBe('deploy-123');
+  });
+
+  it('ignores malformed version payloads', () => {
+    expect(getRemoteBuildId(null)).toBeUndefined();
+    expect(getRemoteBuildId({})).toBeUndefined();
+    expect(getRemoteBuildId({ buildId: 123 })).toBeUndefined();
+    expect(getRemoteBuildId({ buildId: '   ' })).toBeUndefined();
+  });
+});

--- a/projects/ui/src/lib/AppVersion.test.ts
+++ b/projects/ui/src/lib/AppVersion.test.ts
@@ -3,6 +3,7 @@ import { getRemoteBuildId } from './AppVersion';
 describe('app version payloads', () => {
   it('accepts a non-empty remote build id', () => {
     expect(getRemoteBuildId({ buildId: 'deploy-123' })).toBe('deploy-123');
+    expect(getRemoteBuildId({ buildId: '  deploy-123  ' })).toBe('deploy-123');
   });
 
   it('ignores malformed version payloads', () => {

--- a/projects/ui/src/lib/AppVersion.ts
+++ b/projects/ui/src/lib/AppVersion.ts
@@ -1,0 +1,6 @@
+export const getRemoteBuildId = (value: unknown) => {
+  if (!value || typeof value !== 'object') return undefined;
+
+  const { buildId } = value as { buildId?: unknown };
+  return typeof buildId === 'string' && buildId.trim() ? buildId : undefined;
+};

--- a/projects/ui/src/lib/AppVersion.ts
+++ b/projects/ui/src/lib/AppVersion.ts
@@ -2,5 +2,7 @@ export const getRemoteBuildId = (value: unknown) => {
   if (!value || typeof value !== 'object') return undefined;
 
   const { buildId } = value as { buildId?: unknown };
-  return typeof buildId === 'string' && buildId.trim() ? buildId : undefined;
+  return typeof buildId === 'string' && buildId.trim()
+    ? buildId.trim()
+    : undefined;
 };

--- a/projects/ui/src/lib/L2Migration/events.test.ts
+++ b/projects/ui/src/lib/L2Migration/events.test.ts
@@ -1,0 +1,114 @@
+import { ethers } from 'ethers';
+
+import {
+  findLatestReceiverApproval,
+  fetchMigrationEventState,
+  readCachedMigrationSource,
+} from './events';
+
+const BEANSTALK = '0x000000000000000000000000000000000000BEEF';
+const SOURCE = '0x1111111111111111111111111111111111111111';
+const RECEIVER = '0x2222222222222222222222222222222222222222';
+
+const eventInterface = new ethers.utils.Interface([
+  'event ReceiverApproved(address indexed owner, address receiver)',
+  'event L1DepositsMigrated(address indexed owner, address indexed receiver, uint256[] depositIds, uint256[] amounts, uint256[] bdvs)',
+  'event L1PlotsMigrated(address indexed owner, address indexed receiver, uint256[] index, uint256[] pods)',
+  'event L1InternalBalancesMigrated(address indexed owner, address indexed receiver, address[] tokens, uint256[] amounts)',
+  'event L1FertilizerMigrated(address indexed owner, address indexed receiver, uint256[] fertIds, uint128[] amounts, uint128 lastBpf)',
+]);
+
+const makeLog = (eventName: string, args: unknown[]) => {
+  const encoded = eventInterface.encodeEventLog(
+    eventInterface.getEvent(eventName),
+    args
+  );
+
+  return {
+    address: BEANSTALK,
+    blockHash: `0x${'a'.repeat(64)}`,
+    blockNumber: 4_365_700,
+    data: encoded.data,
+    logIndex: 0,
+    removed: false,
+    topics: encoded.topics,
+    transactionHash: `0x${'b'.repeat(64)}`,
+    transactionIndex: 0,
+  };
+};
+
+describe('L2 migration event reads', () => {
+  it('loads all owner migration statuses with one filtered log request', async () => {
+    const requestedFilters: ethers.providers.Filter[] = [];
+    const logs = [
+      makeLog('ReceiverApproved', [SOURCE, RECEIVER]),
+      makeLog('L1DepositsMigrated', [SOURCE, RECEIVER, [1], [2], [3]]),
+      makeLog('L1PlotsMigrated', [SOURCE, RECEIVER, [4], [5]]),
+    ];
+    const contract = {
+      address: BEANSTALK,
+      interface: eventInterface,
+      provider: {
+        getLogs: async (filter: ethers.providers.Filter) => {
+          requestedFilters.push(filter);
+          return logs;
+        },
+      },
+    };
+
+    const state = await fetchMigrationEventState(contract, SOURCE);
+
+    expect(requestedFilters).toHaveLength(1);
+    expect(requestedFilters[0]).toMatchObject({
+      address: BEANSTALK,
+      fromBlock: 4_365_627,
+      toBlock: 'latest',
+    });
+    expect(requestedFilters[0].topics?.[0]).toHaveLength(5);
+    expect(requestedFilters[0].topics?.[1]).toBe(
+      ethers.utils.hexZeroPad(SOURCE, 32)
+    );
+    expect(state).toEqual({
+      receiver: RECEIVER,
+      depositsClaimed: true,
+      plotsClaimed: true,
+      internalBalancesClaimed: false,
+      fertilizerClaimed: false,
+    });
+  });
+});
+
+describe('L2 migration source resolution', () => {
+  it('uses a cached source when its destination matches the connected account', () => {
+    expect(
+      readCachedMigrationSource(
+        JSON.stringify({ source: SOURCE, destination: RECEIVER.toUpperCase() }),
+        RECEIVER
+      )
+    ).toBe(SOURCE);
+  });
+
+  it('ignores cached migration data for another receiver or malformed JSON', () => {
+    expect(
+      readCachedMigrationSource(
+        JSON.stringify({ source: SOURCE, destination: SOURCE }),
+        RECEIVER
+      )
+    ).toBeUndefined();
+    expect(readCachedMigrationSource('{bad json', RECEIVER)).toBeUndefined();
+  });
+
+  it('selects the latest approval for the connected receiver case-insensitively', () => {
+    const olderSource = '0x3333333333333333333333333333333333333333';
+
+    expect(
+      findLatestReceiverApproval(
+        [
+          { args: { owner: olderSource, receiver: RECEIVER } },
+          { args: { owner: SOURCE, receiver: RECEIVER.toUpperCase() } },
+        ],
+        RECEIVER
+      )
+    ).toBe(SOURCE);
+  });
+});

--- a/projects/ui/src/lib/L2Migration/events.ts
+++ b/projects/ui/src/lib/L2Migration/events.ts
@@ -1,0 +1,125 @@
+import { ethers } from 'ethers';
+
+export const L2_MIGRATION_EVENT_FROM_BLOCK = 4_365_627;
+
+const MIGRATION_EVENT_SIGNATURES = [
+  'ReceiverApproved(address,address)',
+  'L1DepositsMigrated(address,address,uint256[],uint256[],uint256[])',
+  'L1PlotsMigrated(address,address,uint256[],uint256[])',
+  'L1InternalBalancesMigrated(address,address,address[],uint256[])',
+  'L1FertilizerMigrated(address,address,uint256[],uint128[],uint128)',
+] as const;
+
+type MigrationEventContract = {
+  address: string;
+  interface: ethers.utils.Interface;
+  provider: Pick<ethers.providers.Provider, 'getLogs'>;
+};
+
+type ReceiverApprovalLog = {
+  args?: {
+    owner?: unknown;
+    receiver?: unknown;
+  };
+};
+
+export type MigrationEventState = {
+  receiver?: string;
+  depositsClaimed: boolean;
+  plotsClaimed: boolean;
+  internalBalancesClaimed: boolean;
+  fertilizerClaimed: boolean;
+};
+
+const isAddress = (value: unknown): value is string =>
+  typeof value === 'string' && /^0x[0-9a-f]{40}$/i.test(value);
+
+const addressesEqual = (left: unknown, right: unknown) =>
+  isAddress(left) &&
+  isAddress(right) &&
+  left.toLowerCase() === right.toLowerCase();
+
+export const readCachedMigrationSource = (
+  serializedMigration: string | null,
+  receiver?: string
+) => {
+  if (!serializedMigration || !isAddress(receiver)) return undefined;
+
+  try {
+    const migration = JSON.parse(serializedMigration) as {
+      source?: unknown;
+      destination?: unknown;
+    };
+
+    if (
+      isAddress(migration.source) &&
+      addressesEqual(migration.destination, receiver)
+    ) {
+      return migration.source;
+    }
+  } catch {
+    // Invalid or obsolete local migration data should fall back to the chain.
+  }
+
+  return undefined;
+};
+
+export const findLatestReceiverApproval = (
+  logs: ReceiverApprovalLog[],
+  receiver: string
+) => {
+  for (let index = logs.length - 1; index >= 0; index -= 1) {
+    const { owner, receiver: approvedReceiver } = logs[index].args ?? {};
+    if (isAddress(owner) && addressesEqual(approvedReceiver, receiver)) {
+      return owner;
+    }
+  }
+
+  return undefined;
+};
+
+export const fetchMigrationEventState = async (
+  contract: MigrationEventContract,
+  sourceAccount: string
+): Promise<MigrationEventState> => {
+  const topics = MIGRATION_EVENT_SIGNATURES.map((signature) =>
+    contract.interface.getEventTopic(signature)
+  );
+  const logs = await contract.provider.getLogs({
+    address: contract.address,
+    fromBlock: L2_MIGRATION_EVENT_FROM_BLOCK,
+    toBlock: 'latest',
+    topics: [topics, ethers.utils.hexZeroPad(sourceAccount, 32)],
+  });
+  const state: MigrationEventState = {
+    depositsClaimed: false,
+    plotsClaimed: false,
+    internalBalancesClaimed: false,
+    fertilizerClaimed: false,
+  };
+
+  logs.forEach((log) => {
+    const event = contract.interface.parseLog(log);
+    switch (event.name) {
+      case 'ReceiverApproved':
+        state.receiver = event.args.receiver;
+        break;
+      case 'L1DepositsMigrated':
+        state.depositsClaimed = true;
+        break;
+      case 'L1PlotsMigrated':
+        state.plotsClaimed = true;
+        break;
+      case 'L1InternalBalancesMigrated':
+        state.internalBalancesClaimed = true;
+        break;
+      case 'L1FertilizerMigrated':
+        state.fertilizerClaimed = true;
+        break;
+      default:
+        break;
+    }
+  });
+
+  return state;
+};

--- a/projects/ui/src/lib/L2Migration/requests.test.ts
+++ b/projects/ui/src/lib/L2Migration/requests.test.ts
@@ -1,0 +1,52 @@
+import {
+  createRequestScope,
+  fetchL2MigrationData,
+  readStoredMigrationSource,
+} from './requests';
+
+const SOURCE = '0x1111111111111111111111111111111111111111';
+const RECEIVER = '0x2222222222222222222222222222222222222222';
+
+describe('L2 migration request scoping', () => {
+  it('lets a new wallet supersede an in-flight request without being cleared by it', () => {
+    const scope = createRequestScope();
+    const oldRequest = scope.begin('old-wallet');
+    const duplicateOldRequest = scope.begin('old-wallet');
+    const newRequest = scope.begin('new-wallet');
+
+    expect(oldRequest).toBeDefined();
+    expect(duplicateOldRequest).toBeUndefined();
+    expect(newRequest).toBeDefined();
+    expect(scope.isCurrent(oldRequest!)).toBe(false);
+    expect(scope.isCurrent(newRequest!)).toBe(true);
+
+    scope.finish(oldRequest!);
+    expect(scope.isCurrent(newRequest!)).toBe(true);
+
+    scope.finish(newRequest!);
+    expect(scope.begin('new-wallet')).toBeDefined();
+  });
+});
+
+describe('L2 migration request safety', () => {
+  it('falls back to chain discovery when browser storage is unavailable', () => {
+    expect(
+      readStoredMigrationSource(() => {
+        throw new DOMException('blocked', 'SecurityError');
+      }, RECEIVER)
+    ).toBeUndefined();
+  });
+
+  it('rejects non-success migration API responses', async () => {
+    const fetcher = async () =>
+      ({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+      }) as Response;
+
+    await expect(
+      fetchL2MigrationData(SOURCE, undefined, fetcher)
+    ).rejects.toThrow('503');
+  });
+});

--- a/projects/ui/src/lib/L2Migration/requests.ts
+++ b/projects/ui/src/lib/L2Migration/requests.ts
@@ -1,0 +1,71 @@
+import { readCachedMigrationSource } from './events';
+
+type RequestToken = {
+  id: number;
+  key: string;
+};
+
+export const createRequestScope = () => {
+  let activeRequest: RequestToken | undefined;
+  let nextId = 0;
+
+  return {
+    begin(key: string) {
+      if (activeRequest?.key === key) return undefined;
+
+      nextId += 1;
+      activeRequest = { id: nextId, key };
+      return activeRequest;
+    },
+    isCurrent(request: RequestToken) {
+      return activeRequest === request;
+    },
+    finish(request: RequestToken) {
+      if (activeRequest === request) activeRequest = undefined;
+    },
+  };
+};
+
+export const readStoredMigrationSource = (
+  readStorage: () => string | null,
+  receiver?: string
+) => {
+  try {
+    return readCachedMigrationSource(readStorage(), receiver);
+  } catch {
+    return undefined;
+  }
+};
+
+type MigrationFetcher = (
+  input: string,
+  init?: { signal?: AbortSignal }
+) => Promise<{
+  json: () => Promise<unknown>;
+  ok: boolean;
+  status: number;
+}>;
+
+type L2MigrationData = {
+  deposits: unknown;
+  fertilizer: unknown;
+  plots: unknown;
+  farmBalance: unknown;
+};
+
+export const fetchL2MigrationData = async (
+  sourceAccount: string,
+  signal?: AbortSignal,
+  fetcher: MigrationFetcher = fetch
+) => {
+  const response = await fetcher(
+    `/.netlify/functions/l2migration?account=${sourceAccount}`,
+    { signal }
+  );
+
+  if (!response.ok) {
+    throw new Error(`L2 migration API request failed with ${response.status}`);
+  }
+
+  return response.json() as Promise<L2MigrationData>;
+};

--- a/projects/ui/src/pages/l1delegate.tsx
+++ b/projects/ui/src/pages/l1delegate.tsx
@@ -32,6 +32,8 @@ import useBanner from '~/hooks/app/useBanner';
 import useNavHeight from '~/hooks/app/usePageDimensions';
 import useChainState from '~/hooks/chain/useChainState';
 
+const L1_MIGRATION_READ_INTERVAL = 60_000;
+
 export default function L1Delegate() {
 
     const account = useAccount();
@@ -190,7 +192,9 @@ export default function L1Delegate() {
         ],
         query: {
             enabled: Boolean(account),
-            refetchInterval: 10000
+            staleTime: L1_MIGRATION_READ_INTERVAL,
+            refetchInterval: L1_MIGRATION_READ_INTERVAL,
+            refetchIntervalInBackground: false,
         }
     }).data;
 

--- a/projects/ui/src/pages/l1transfer.tsx
+++ b/projects/ui/src/pages/l1transfer.tsx
@@ -52,6 +52,8 @@ import useNavHeight from '~/hooks/app/usePageDimensions';
 import useChainId from '~/hooks/chain/useChainId';
 import useChainState from '~/hooks/chain/useChainState';
 
+const L1_MIGRATION_READ_INTERVAL = 60_000;
+
 /// ---------------------------------------------------------------
 
 type TransferFormValues = {
@@ -523,7 +525,9 @@ const L1Transfer: FC<{}> = () => {
     args: [(account || ''), supportedAddresses],
     query: {
       enabled: Boolean(account),
-      refetchInterval: 10000
+      staleTime: L1_MIGRATION_READ_INTERVAL,
+      refetchInterval: L1_MIGRATION_READ_INTERVAL,
+      refetchIntervalInBackground: false,
     }
   });
 
@@ -549,7 +553,9 @@ const L1Transfer: FC<{}> = () => {
     contracts: allowanceCalls,
     query: {
       enabled: Boolean(account),
-      refetchInterval: 10000
+      staleTime: L1_MIGRATION_READ_INTERVAL,
+      refetchInterval: L1_MIGRATION_READ_INTERVAL,
+      refetchIntervalInBackground: false,
     }
   });
   const tokenAllowancesData = tokenAllowances.data as Array<{ result: bigint, status: string }>

--- a/projects/ui/src/pages/l2claim.tsx
+++ b/projects/ui/src/pages/l2claim.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Button, Card, Link, Typography } from '@mui/material';
 import PageHeader from '~/components/Common/PageHeader';
 import { FontWeight } from '~/components/App/muiTheme';
@@ -11,15 +11,22 @@ import useChainState from '~/hooks/chain/useChainState';
 import { useSwitchChain } from 'wagmi';
 import useBanner from '~/hooks/app/useBanner';
 import useNavHeight from '~/hooks/app/usePageDimensions';
+import {
+    findLatestReceiverApproval,
+    fetchMigrationEventState,
+    L2_MIGRATION_EVENT_FROM_BLOCK,
+    readCachedMigrationSource,
+} from '~/lib/L2Migration/events';
 
 const L2_CLAIM_EVENT_POLL_INTERVAL = 5 * 60_000;
-const L2_MIGRATION_EVENT_FROM_BLOCK = 4_365_627;
 
 export default function L2Claim() {
 
-    const [sourceAccount, setSourceAccount] = useState<string | undefined>(undefined);
+    const [discoveredMigration, setDiscoveredMigration] = useState<{
+        receiver: string;
+        source: string;
+    }>();
 
-    const [needsMigration, setNeedsMigration] = useState<boolean>(false);
     const [deposits, setDeposits] = useState<any>(undefined);
     const [ferts, setFerts] = useState<any>(undefined);
     const [plots, setPlots] = useState<any>(undefined);
@@ -34,9 +41,21 @@ export default function L2Claim() {
 
     const account = useAccount();
     const sdk = useSdk();
+    const cachedSourceAccount = useMemo(
+        () => readCachedMigrationSource(
+            window.localStorage.getItem('internalL2MigrationData'),
+            account
+        ),
+        [account]
+    );
+    const discoveredSourceAccount =
+        account && discoveredMigration?.receiver.toLowerCase() === account.toLowerCase()
+            ? discoveredMigration.source
+            : undefined;
+    const sourceAccount = discoveredSourceAccount ?? cachedSourceAccount;
 
     const { isArbitrum, isTestnet } = useChainState();
-    const { chains, error, isPending, switchChain } = useSwitchChain();
+    const { switchChain } = useSwitchChain();
 
     const hasDeposits = deposits ? Object.keys(deposits).length > 0 : false;
     const hasFert = ferts ? Object.keys(ferts).length > 0 : false;
@@ -53,41 +72,29 @@ export default function L2Claim() {
         isLoadingRef.current = true;
         try {
             if (sourceAccount) {
-                const filter = sdk.contracts.beanstalk.filters['ReceiverApproved(address,address)'](sourceAccount);
-                const logs = await sdk.contracts.beanstalk.queryFilter(filter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
-                if (logs && logs.length > 0) {
-                    setReceiverApproved(true);
-                    setSourceAccount(logs[0].args[0]);
-                } else {
-                    setReceiverApproved(false);
-                }
-
-                const depositsFilter = sdk.contracts.beanstalk.filters['L1DepositsMigrated(address,address,uint256[],uint256[],uint256[])'](sourceAccount);
-                const depositLogs = await sdk.contracts.beanstalk.queryFilter(depositsFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
-                (depositLogs && depositLogs.length > 0) ? setDepositsClaimed(true) : setDepositsClaimed(false);
-
-                const plotsFilter = sdk.contracts.beanstalk.filters['L1PlotsMigrated(address,address,uint256[],uint256[])'](sourceAccount);
-                const plotsLogs = await sdk.contracts.beanstalk.queryFilter(plotsFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
-                (plotsLogs && plotsLogs.length > 0) ? setPlotsClaimed(true) : setPlotsClaimed(false);
-
-                const internalBalancesFilter = sdk.contracts.beanstalk.filters['L1InternalBalancesMigrated(address,address,address[],uint256[])'](sourceAccount);
-                const internalLogs = await sdk.contracts.beanstalk.queryFilter(internalBalancesFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
-                (internalLogs && internalLogs.length > 0) ? setInternalBalancesClaimed(true) : setInternalBalancesClaimed(false);
-
-                const fertilizerFilter = sdk.contracts.beanstalk.filters['L1FertilizerMigrated(address,address,uint256[],uint128[],uint128)'](sourceAccount);
-                const fertilizerLogs = await sdk.contracts.beanstalk.queryFilter(fertilizerFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
-                (fertilizerLogs && fertilizerLogs.length > 0) ? setFertilizerClaimed(true) : setFertilizerClaimed(false);
-
+                const state = await fetchMigrationEventState(
+                    sdk.contracts.beanstalk,
+                    sourceAccount
+                );
+                setReceiverApproved(
+                    state.receiver?.toLowerCase() === account.toLowerCase()
+                );
+                setDepositsClaimed(state.depositsClaimed);
+                setPlotsClaimed(state.plotsClaimed);
+                setInternalBalancesClaimed(state.internalBalancesClaimed);
+                setFertilizerClaimed(state.fertilizerClaimed);
             } else {
                 const receiverFilter = sdk.contracts.beanstalk.filters['ReceiverApproved(address,address)']();
                 const logs = await sdk.contracts.beanstalk.queryFilter(receiverFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
-                for (const log of logs) {
-                    if (log.args.receiver.toLowerCase() === account) {
-                        setSourceAccount(log.args.owner);
-                        setReceiverApproved(true);
-                        return
-                    };
-                };
+                const discoveredSource = findLatestReceiverApproval(logs, account);
+                if (discoveredSource) {
+                    setDiscoveredMigration({
+                        receiver: account,
+                        source: discoveredSource,
+                    });
+                    setReceiverApproved(true);
+                    return;
+                }
                 setReceiverApproved(false);
             }
         } finally {
@@ -97,10 +104,9 @@ export default function L2Claim() {
 
     useEffect(() => {
         async function getMigrationData() {
-            if (!account) return
+            if (!account || !sourceAccount) return
             const migrationData = await fetch(`/.netlify/functions/l2migration?account=${sourceAccount}`)
                 .then((response) => response.json())
-            setNeedsMigration(migrationData.needsManualMigration)
             setDeposits(migrationData.deposits)
             setFerts(migrationData.fertilizer)
             setPlots(migrationData.plots)
@@ -216,7 +222,7 @@ export default function L2Claim() {
                                 flexDirection="row"
                                 gap={1}
                                 alignItems="center"
-                                href={'/'}
+                                href="/"
                             >
                                 <Typography variant="h4">Migrate another address</Typography>
                             </Link>
@@ -224,7 +230,7 @@ export default function L2Claim() {
                         :
                         <>
                             <Typography variant="h4" fontWeight={FontWeight.bold} padding={1}>
-                                {"Receive Delegated Balances from Mainnet"}
+                                Receive Delegated Balances from Mainnet
                             </Typography>
                             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                                 <Box

--- a/projects/ui/src/pages/l2claim.tsx
+++ b/projects/ui/src/pages/l2claim.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Button, Card, Link, Typography } from '@mui/material';
 import PageHeader from '~/components/Common/PageHeader';
 import { FontWeight } from '~/components/App/muiTheme';
@@ -11,6 +11,9 @@ import useChainState from '~/hooks/chain/useChainState';
 import { useSwitchChain } from 'wagmi';
 import useBanner from '~/hooks/app/useBanner';
 import useNavHeight from '~/hooks/app/usePageDimensions';
+
+const L2_CLAIM_EVENT_POLL_INTERVAL = 5 * 60_000;
+const L2_MIGRATION_EVENT_FROM_BLOCK = 4_365_627;
 
 export default function L2Claim() {
 
@@ -27,8 +30,6 @@ export default function L2Claim() {
     const [internalBalancesClaimed, setInternalBalancesClaimed] = useState(false);
     const [fertilizerClaimed, setFertilizerClaimed] = useState(false);
 
-    const [isLoading, setIsLoading] = useState(false);
-
     const [receiverApproved, setReceiverApproved] = useState<boolean>(false);
 
     const account = useAccount();
@@ -41,51 +42,58 @@ export default function L2Claim() {
     const hasFert = ferts ? Object.keys(ferts).length > 0 : false;
     const hasPlots = plots ? Object.keys(plots).length > 0 : false;
     const hasFarmBalance = farmBalance ? Object.keys(farmBalance).length > 0 : false;
+    const claimEnabled = receiverApproved && (hasDeposits || hasFert || hasPlots || hasFarmBalance);
+    const claimComplete = (hasDeposits || hasFert || hasPlots || hasFarmBalance)
+        && ((hasDeposits === depositsClaimed) && (hasFert === fertilizerClaimed) && (hasPlots === plotsClaimed) && (hasFarmBalance === internalBalancesClaimed));
+
+    const isLoadingRef = useRef(false);
 
     const getEvent = useCallback(async () => {
-        if (isLoading) return
-        setIsLoading(true)
-        if (sourceAccount) {
-            const filter = sdk.contracts.beanstalk.filters['ReceiverApproved(address,address)'](sourceAccount);
-            const logs = await sdk.contracts.beanstalk.queryFilter(filter);
-            if (logs && logs.length > 0) {
-                setReceiverApproved(true);
-                setSourceAccount(logs[0].args[0]);
+        if (isLoadingRef.current || claimComplete || !account) return
+        isLoadingRef.current = true;
+        try {
+            if (sourceAccount) {
+                const filter = sdk.contracts.beanstalk.filters['ReceiverApproved(address,address)'](sourceAccount);
+                const logs = await sdk.contracts.beanstalk.queryFilter(filter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
+                if (logs && logs.length > 0) {
+                    setReceiverApproved(true);
+                    setSourceAccount(logs[0].args[0]);
+                } else {
+                    setReceiverApproved(false);
+                }
+
+                const depositsFilter = sdk.contracts.beanstalk.filters['L1DepositsMigrated(address,address,uint256[],uint256[],uint256[])'](sourceAccount);
+                const depositLogs = await sdk.contracts.beanstalk.queryFilter(depositsFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
+                (depositLogs && depositLogs.length > 0) ? setDepositsClaimed(true) : setDepositsClaimed(false);
+
+                const plotsFilter = sdk.contracts.beanstalk.filters['L1PlotsMigrated(address,address,uint256[],uint256[])'](sourceAccount);
+                const plotsLogs = await sdk.contracts.beanstalk.queryFilter(plotsFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
+                (plotsLogs && plotsLogs.length > 0) ? setPlotsClaimed(true) : setPlotsClaimed(false);
+
+                const internalBalancesFilter = sdk.contracts.beanstalk.filters['L1InternalBalancesMigrated(address,address,address[],uint256[])'](sourceAccount);
+                const internalLogs = await sdk.contracts.beanstalk.queryFilter(internalBalancesFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
+                (internalLogs && internalLogs.length > 0) ? setInternalBalancesClaimed(true) : setInternalBalancesClaimed(false);
+
+                const fertilizerFilter = sdk.contracts.beanstalk.filters['L1FertilizerMigrated(address,address,uint256[],uint128[],uint128)'](sourceAccount);
+                const fertilizerLogs = await sdk.contracts.beanstalk.queryFilter(fertilizerFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
+                (fertilizerLogs && fertilizerLogs.length > 0) ? setFertilizerClaimed(true) : setFertilizerClaimed(false);
+
             } else {
+                const receiverFilter = sdk.contracts.beanstalk.filters['ReceiverApproved(address,address)']();
+                const logs = await sdk.contracts.beanstalk.queryFilter(receiverFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
+                for (const log of logs) {
+                    if (log.args.receiver.toLowerCase() === account) {
+                        setSourceAccount(log.args.owner);
+                        setReceiverApproved(true);
+                        return
+                    };
+                };
                 setReceiverApproved(false);
             }
-
-            const depositsFilter = sdk.contracts.beanstalk.filters['L1DepositsMigrated(address,address,uint256[],uint256[],uint256[])'](sourceAccount);
-            const depositLogs = await sdk.contracts.beanstalk.queryFilter(depositsFilter);
-            (depositLogs && depositLogs.length > 0) ? setDepositsClaimed(true) : setDepositsClaimed(false);
-
-            const plotsFilter = sdk.contracts.beanstalk.filters['L1PlotsMigrated(address,address,uint256[],uint256[])'](sourceAccount);
-            const plotsLogs = await sdk.contracts.beanstalk.queryFilter(plotsFilter);
-            (plotsLogs && plotsLogs.length > 0) ? setPlotsClaimed(true) : setPlotsClaimed(false);
-
-            const internalBalancesFilter = sdk.contracts.beanstalk.filters['L1InternalBalancesMigrated(address,address,address[],uint256[])'](sourceAccount);
-            const internalLogs = await sdk.contracts.beanstalk.queryFilter(internalBalancesFilter);
-            (internalLogs && internalLogs.length > 0) ? setInternalBalancesClaimed(true) : setInternalBalancesClaimed(false);
-
-            const fertilizerFilter = sdk.contracts.beanstalk.filters['L1FertilizerMigrated(address,address,uint256[],uint128[],uint128)'](sourceAccount);
-            const fertilizerLogs = await sdk.contracts.beanstalk.queryFilter(fertilizerFilter);
-            (fertilizerLogs && fertilizerLogs.length > 0) ? setFertilizerClaimed(true) : setFertilizerClaimed(false);
-
-        } else {
-            const receiverFilter = sdk.contracts.beanstalk.filters['ReceiverApproved(address,address)']();
-            const logs = await sdk.contracts.beanstalk.queryFilter(receiverFilter);
-            for (const log of logs) {
-                if (log.args.receiver.toLowerCase() === account) {
-                    setSourceAccount(log.args.owner);
-                    setReceiverApproved(true);
-                    setIsLoading(false);
-                    return
-                };
-            };
-            setReceiverApproved(false);
+        } finally {
+            isLoadingRef.current = false;
         }
-        setIsLoading(false);
-    }, [sdk.contracts.beanstalk, sourceAccount, isLoading]);
+    }, [sdk.contracts.beanstalk, sourceAccount, account, claimComplete]);
 
     useEffect(() => {
         async function getMigrationData() {
@@ -102,17 +110,18 @@ export default function L2Claim() {
     }, [account, sourceAccount]);
 
     useEffect(() => {
-        const interval = setInterval(getEvent, 5000);
+        if (claimComplete) return;
+        const interval = setInterval(() => {
+            if (document.visibilityState === 'visible') {
+                getEvent();
+            }
+        }, L2_CLAIM_EVENT_POLL_INTERVAL);
         return () => clearInterval(interval);
-    }, [getEvent]);
+    }, [getEvent, claimComplete]);
 
     useEffect(() => {
         getEvent();
-    }, []);
-
-    const claimEnabled = receiverApproved && (hasDeposits || hasFert || hasPlots || hasFarmBalance);
-    const claimComplete = (hasDeposits || hasFert || hasPlots || hasFarmBalance)
-        && ((hasDeposits === depositsClaimed) && (hasFert === fertilizerClaimed) && (hasPlots === plotsClaimed) && (hasFarmBalance === internalBalancesClaimed));
+    }, [getEvent]);
 
     function onSubmit() {
 
@@ -283,7 +292,7 @@ export default function L2Claim() {
                                     <Typography>{hasFert ? 'Fertilizer' : 'No Fertilizer'}</Typography>
                                 </Box>
                                 <Typography sx={{ padding: 1 }}>
-                                    This page checks Arbitrum One for the arrival of migration data every few seconds. The button below will automatically
+                                    This page checks Arbitrum One for the arrival of migration data every few minutes. The button below will automatically
                                     enable itself when this data becomes available.
                                 </Typography>
                                 <Button

--- a/projects/ui/src/pages/l2claim.tsx
+++ b/projects/ui/src/pages/l2claim.tsx
@@ -15,8 +15,12 @@ import {
     findLatestReceiverApproval,
     fetchMigrationEventState,
     L2_MIGRATION_EVENT_FROM_BLOCK,
-    readCachedMigrationSource,
 } from '~/lib/L2Migration/events';
+import {
+    createRequestScope,
+    fetchL2MigrationData,
+    readStoredMigrationSource,
+} from '~/lib/L2Migration/requests';
 
 const L2_CLAIM_EVENT_POLL_INTERVAL = 5 * 60_000;
 
@@ -42,8 +46,8 @@ export default function L2Claim() {
     const account = useAccount();
     const sdk = useSdk();
     const cachedSourceAccount = useMemo(
-        () => readCachedMigrationSource(
-            window.localStorage.getItem('internalL2MigrationData'),
+        () => readStoredMigrationSource(
+            () => window.localStorage.getItem('internalL2MigrationData'),
             account
         ),
         [account]
@@ -65,17 +69,37 @@ export default function L2Claim() {
     const claimComplete = (hasDeposits || hasFert || hasPlots || hasFarmBalance)
         && ((hasDeposits === depositsClaimed) && (hasFert === fertilizerClaimed) && (hasPlots === plotsClaimed) && (hasFarmBalance === internalBalancesClaimed));
 
-    const isLoadingRef = useRef(false);
+    const eventRequestScopeRef = useRef(createRequestScope());
+
+    useEffect(() => {
+        setDeposits(undefined);
+        setFerts(undefined);
+        setPlots(undefined);
+        setFarmBalance(undefined);
+        setDepositsClaimed(false);
+        setPlotsClaimed(false);
+        setInternalBalancesClaimed(false);
+        setFertilizerClaimed(false);
+        setReceiverApproved(false);
+    }, [account, sourceAccount]);
 
     const getEvent = useCallback(async () => {
-        if (isLoadingRef.current || claimComplete || !account) return
-        isLoadingRef.current = true;
+        if (claimComplete || !account) return
+
+        const requestScope = eventRequestScopeRef.current;
+        const request = requestScope.begin(
+            `${account.toLowerCase()}:${sourceAccount?.toLowerCase() ?? 'discover'}`
+        );
+        if (!request) return;
+
         try {
             if (sourceAccount) {
                 const state = await fetchMigrationEventState(
                     sdk.contracts.beanstalk,
                     sourceAccount
                 );
+                if (!requestScope.isCurrent(request)) return;
+
                 setReceiverApproved(
                     state.receiver?.toLowerCase() === account.toLowerCase()
                 );
@@ -86,6 +110,8 @@ export default function L2Claim() {
             } else {
                 const receiverFilter = sdk.contracts.beanstalk.filters['ReceiverApproved(address,address)']();
                 const logs = await sdk.contracts.beanstalk.queryFilter(receiverFilter, L2_MIGRATION_EVENT_FROM_BLOCK, 'latest');
+                if (!requestScope.isCurrent(request)) return;
+
                 const discoveredSource = findLatestReceiverApproval(logs, account);
                 if (discoveredSource) {
                     setDiscoveredMigration({
@@ -97,22 +123,34 @@ export default function L2Claim() {
                 }
                 setReceiverApproved(false);
             }
+        } catch (error) {
+            if (requestScope.isCurrent(request)) {
+                console.error('[l2claim] Failed to load migration events', error);
+            }
         } finally {
-            isLoadingRef.current = false;
+            requestScope.finish(request);
         }
     }, [sdk.contracts.beanstalk, sourceAccount, account, claimComplete]);
 
     useEffect(() => {
-        async function getMigrationData() {
-            if (!account || !sourceAccount) return
-            const migrationData = await fetch(`/.netlify/functions/l2migration?account=${sourceAccount}`)
-                .then((response) => response.json())
-            setDeposits(migrationData.deposits)
-            setFerts(migrationData.fertilizer)
-            setPlots(migrationData.plots)
-            setFarmBalance(migrationData.farmBalance)
-        };
-        getMigrationData();
+        if (!account || !sourceAccount) return;
+
+        const controller = new AbortController();
+        fetchL2MigrationData(sourceAccount, controller.signal)
+            .then((migrationData) => {
+                if (controller.signal.aborted) return;
+                setDeposits(migrationData.deposits);
+                setFerts(migrationData.fertilizer);
+                setPlots(migrationData.plots);
+                setFarmBalance(migrationData.farmBalance);
+            })
+            .catch((error) => {
+                if (!controller.signal.aborted) {
+                    console.error('[l2claim] Failed to load migration data', error);
+                }
+            });
+
+        return () => controller.abort();
     }, [account, sourceAccount]);
 
     useEffect(() => {

--- a/projects/ui/src/pages/nft.tsx
+++ b/projects/ui/src/pages/nft.tsx
@@ -74,8 +74,9 @@ const NFTPage: FC<{}> = () => {
   const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
   async function getNFTMetadataBatch(nftArray: any[], contractAddress: string) {
-    const nftMetadataBatchBaseURL =
-      'https://eth-mainnet.g.alchemy.com/nft/v3/f6piiDvMBMGRYvCOwLJFMD7cUjIvI1TP/getNFTMetadataBatch';
+    const nftMetadataBatchBaseURL = `https://eth-mainnet.g.alchemy.com/nft/v3/${
+      import.meta.env.VITE_ALCHEMY_API_KEY
+    }/getNFTMetadataBatch`;
 
     const nfts: any[] = [];
     let batchRequest: any[] = [];

--- a/projects/ui/src/state/bean/pools/updater.ts
+++ b/projects/ui/src/state/bean/pools/updater.ts
@@ -12,7 +12,6 @@ import {
   Pool,
 } from '@beanstalk/sdk';
 import { chunkArray } from '~/util/UI';
-import { getExtractMulticallResult } from '~/util/Multicall';
 import { transform } from '~/util/BigNumber';
 import useL2OnlyEffect from '~/hooks/chain/useL2OnlyEffect';
 import { TokenMap } from '~/constants';
@@ -20,8 +19,6 @@ import { resetPools, updateBeanPools, UpdatePoolPayload } from './actions';
 import { updateDeltaB, updatePrice, updateSupply } from '../token/actions';
 
 const pageContext = '[bean/pools/useGetPools]';
-
-const extract = getExtractMulticallResult(pageContext);
 
 export const useFetchPools = () => {
   const dispatch = useDispatch();
@@ -38,13 +35,12 @@ export const useFetchPools = () => {
         const poolsArr = [...whitelistedPools.values()];
         const BEAN = sdk.tokens.BEAN;
 
-        const [priceResult, beanTotalSupply, totalDeltaB, lpResults] =
-          await Promise.all([
-            beanstalkPrice.price(),
-            BEAN.getContract().totalSupply().then(tokenResult(BEAN)),
-            beanstalk.totalDeltaB().then(tokenResult(BEAN)),
-            fetchPoolsData(sdk, poolsArr),
-          ]);
+        const {
+          priceResult,
+          beanTotalSupply,
+          totalDeltaB,
+          lpResults,
+        } = await fetchPoolsData(sdk, poolsArr);
 
         console.debug(`${pageContext} FETCH: `, {
           priceResult,
@@ -150,36 +146,68 @@ const PoolsUpdater = () => {
 export default PoolsUpdater;
 
 async function fetchPoolsData(sdk: BeanstalkSDK, pools: Pool[]) {
-  const { beanstalk } = sdk.contracts;
+  const { beanstalk, beanstalkPrice } = sdk.contracts;
+  const BEAN = sdk.tokens.BEAN;
+  const beanContract = BEAN.getContract();
+  const clipboard = Clipboard.encode([]);
 
-  const calls: AdvancedPipeStruct[] = pools
+  const poolCalls: AdvancedPipeStruct[] = pools
     .map((pool) => {
       const deltaBCall = {
         target: beanstalk.address,
         callData: beanstalk.interface.encodeFunctionData('poolDeltaB', [
           pool.address,
         ]),
-        clipboard: Clipboard.encode([]),
+        clipboard,
       };
       const supplyCall = {
         target: pool.lpToken.address,
         callData: pool.lpToken
           .getContract()
           .interface.encodeFunctionData('totalSupply'),
-        clipboard: Clipboard.encode([]),
+        clipboard,
       };
 
       return [deltaBCall, supplyCall];
     })
     .flat();
 
+  const calls: AdvancedPipeStruct[] = [
+    {
+      target: beanstalkPrice.address,
+      callData: beanstalkPrice.interface.encodeFunctionData('price'),
+      clipboard,
+    },
+    {
+      target: beanContract.address,
+      callData: beanContract.interface.encodeFunctionData('totalSupply'),
+      clipboard,
+    },
+    {
+      target: beanstalk.address,
+      callData: beanstalk.interface.encodeFunctionData('totalDeltaB'),
+      clipboard,
+    },
+    ...poolCalls,
+  ];
+
   const result = await sdk.contracts.beanstalk.callStatic.advancedPipe(
     calls,
     '0'
   );
-  const chunkedByPool = chunkArray(result, 2);
+  const priceResult = beanstalkPrice.interface.decodeFunctionResult(
+    'price',
+    result[0]
+  )[0] as Awaited<ReturnType<typeof beanstalkPrice.price>>;
+  const beanTotalSupply = tokenResult(BEAN)(
+    beanContract.interface.decodeFunctionResult('totalSupply', result[1])[0]
+  );
+  const totalDeltaB = tokenResult(BEAN)(
+    beanstalk.interface.decodeFunctionResult('totalDeltaB', result[2])[0]
+  );
+  const chunkedByPool = chunkArray(result.slice(3), 2);
 
-  const datas = pools.reduce<
+  const lpResults = pools.reduce<
     TokenMap<{
       totalSupply: BigNumber;
       deltaB: BigNumber;
@@ -202,5 +230,10 @@ async function fetchPoolsData(sdk: BeanstalkSDK, pools: Pool[]) {
     return prev;
   }, {});
 
-  return datas;
+  return {
+    priceResult,
+    beanTotalSupply,
+    totalDeltaB,
+    lpResults,
+  };
 }

--- a/projects/ui/src/state/bean/unripe/updater.ts
+++ b/projects/ui/src/state/bean/unripe/updater.ts
@@ -7,8 +7,9 @@ import { UnripeToken } from '~/state/bean/unripe';
 import useUnripeUnderlyingMap from '~/hooks/beanstalk/useUnripeUnderlying';
 import BigNumber from 'bignumber.js';
 import useSdk from '~/hooks/sdk';
-import { ERC20Token } from '@beanstalk/sdk';
+import { AdvancedPipeStruct, Clipboard, ERC20Token } from '@beanstalk/sdk';
 import useL2OnlyEffect from '~/hooks/chain/useL2OnlyEffect';
+import { chunkArray } from '~/util/UI';
 import { resetUnripe, updateUnripe } from './actions';
 
 export const useUnripe = () => {
@@ -23,37 +24,102 @@ export const useUnripe = () => {
     if (beanstalk) {
       try {
         const tokenAddresses = Object.keys(unripeTokens); // ['0x1BEA0', '0x1BEA1']
-        const results = await Promise.all(
-          tokenAddresses.map(async (addr) =>
-            Promise.all([
-              /// NOTE:
-              /// `getPercentPenalty` retrieves the conversion rate between Unripe -> Ripe.
-              /// In the UI, we describe the "penalty" as the % of assets forfeited
-              /// when Chopping. To keep this consistency in variable names, we rename this value
-              /// to the `Chop Rate` and then say `Chop Penalty = (1 - Chop Rate) x 100%`.
-              beanstalk
-                .getPercentPenalty(addr)
-                .then(tokenResult(unripeTokens[addr])),
-              beanstalk
-                .getTotalUnderlying(addr)
-                .then(tokenResult(unripeUnderlyingTokens[addr])),
-              unripeTokens[addr]
-                ?.getTotalSupply()
-                ?.then(tokenResult(unripeTokens[addr])),
-              beanstalk
-                .getRecapPaidPercent()
-                .then(tokenResult(unripeTokens[addr])),
-              beanstalk.getPenalty(addr).then((result) => {
-                if (tokenIshEqual(addr, unripeLP)) {
-                  // handle this case separately b/c urBEAN:ETH LP liquidity was originally
-                  // bean:3crv, which had 18 decimals
-                  return new BigNumber(result.toString()).div(1e18);
-                }
-                return tokenResult(unripeTokens[addr])(result);
-              }),
-            ])
-          )
-        );
+        const clipboard = Clipboard.encode([]);
+        const results = chunkArray(
+          await beanstalk.callStatic.advancedPipe(
+            tokenAddresses
+              .map((addr) => {
+                const token = unripeTokens[addr];
+                const tokenContract = token.getContract();
+                const common = {
+                  target: beanstalk.address,
+                  clipboard,
+                };
+
+                return [
+                  /// NOTE:
+                  /// `getPercentPenalty` retrieves the conversion rate between Unripe -> Ripe.
+                  /// In the UI, we describe the "penalty" as the % of assets forfeited
+                  /// when Chopping. To keep this consistency in variable names, we rename this value
+                  /// to the `Chop Rate` and then say `Chop Penalty = (1 - Chop Rate) x 100%`.
+                  {
+                    ...common,
+                    callData: beanstalk.interface.encodeFunctionData(
+                      'getPercentPenalty',
+                      [addr]
+                    ),
+                  },
+                  {
+                    ...common,
+                    callData: beanstalk.interface.encodeFunctionData(
+                      'getTotalUnderlying',
+                      [addr]
+                    ),
+                  },
+                  {
+                    target: token.address,
+                    callData:
+                      tokenContract.interface.encodeFunctionData('totalSupply'),
+                    clipboard,
+                  },
+                  {
+                    ...common,
+                    callData: beanstalk.interface.encodeFunctionData(
+                      'getRecapPaidPercent'
+                    ),
+                  },
+                  {
+                    ...common,
+                    callData: beanstalk.interface.encodeFunctionData(
+                      'getPenalty',
+                      [addr]
+                    ),
+                  },
+                ];
+              })
+              .flat() as AdvancedPipeStruct[],
+            '0'
+          ),
+          5
+        ).map((resultChunk, index) => {
+          const addr = tokenAddresses[index];
+          const token = unripeTokens[addr];
+          const tokenContract = token.getContract();
+          const penalty = beanstalk.interface.decodeFunctionResult(
+            'getPenalty',
+            resultChunk[4]
+          )[0];
+
+          return [
+            tokenResult(token)(
+              beanstalk.interface.decodeFunctionResult(
+                'getPercentPenalty',
+                resultChunk[0]
+              )[0]
+            ),
+            tokenResult(unripeUnderlyingTokens[addr])(
+              beanstalk.interface.decodeFunctionResult(
+                'getTotalUnderlying',
+                resultChunk[1]
+              )[0]
+            ),
+            tokenResult(token)(
+              tokenContract.interface.decodeFunctionResult(
+                'totalSupply',
+                resultChunk[2]
+              )[0]
+            ),
+            tokenResult(token)(
+              beanstalk.interface.decodeFunctionResult(
+                'getRecapPaidPercent',
+                resultChunk[3]
+              )[0]
+            ),
+            tokenIshEqual(addr, unripeLP)
+              ? new BigNumber(penalty.toString()).div(1e18)
+              : tokenResult(token)(penalty),
+          ];
+        });
 
         const data = tokenAddresses.reduce<AddressMap<UnripeToken>>(
           (prev, key, index) => {

--- a/projects/ui/src/state/beanstalk/barn/updater.ts
+++ b/projects/ui/src/state/beanstalk/barn/updater.ts
@@ -1,9 +1,8 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { useERC20Contract } from '~/hooks/ledger/useContract';
+import { AdvancedPipeStruct, Clipboard } from '@beanstalk/sdk';
 import { tokenResult, bigNumberResult } from '~/util';
-import useChainId from '~/hooks/chain/useChainId';
 import { ZERO_BN } from '~/constants';
 import useSdk from '~/hooks/sdk';
 import useL2OnlyEffect from '~/hooks/chain/useL2OnlyEffect';
@@ -28,35 +27,104 @@ export const useFetchBeanstalkBarn = () => {
   const dispatch = useDispatch();
   const sdk = useSdk();
 
-  // Contracts
-  const beanstalk = sdk.contracts.beanstalk;
-  const fertContract = sdk.contracts.fertilizer;
-  const [usdcContract] = useERC20Contract(sdk.tokens.USDC.address);
-
   // Handlers
   const fetch = useCallback(async () => {
     const { BEAN, UNRIPE_BEAN } = sdk.tokens;
-    if (fertContract && usdcContract) {
+    const beanstalk = sdk.contracts.beanstalk;
+
+    if (beanstalk) {
       console.debug('[beanstalk/fertilizer/updater] FETCH');
-      const [
-        remainingRecapitalization,
-        humidity,
-        currentBpf,
-        endBpf,
-        unfertilized,
-        fertilized,
-        recapFundedPct,
-      ] = await Promise.all([
-        beanstalk.remainingRecapitalization().then(tokenResult(BEAN)),
-        beanstalk.getCurrentHumidity().then(bigNumberResult),
-        beanstalk.beansPerFertilizer().then(bigNumberResult),
-        beanstalk.getEndBpf().then(bigNumberResult),
-        beanstalk.totalUnfertilizedBeans().then(tokenResult(BEAN)),
-        beanstalk.totalFertilizedBeans().then(tokenResult(BEAN)),
-        beanstalk
-          .getRecapFundedPercent(UNRIPE_BEAN.address)
-          .then(tokenResult(UNRIPE_BEAN)),
-      ] as const);
+
+      const common = {
+        target: beanstalk.address,
+        clipboard: Clipboard.encode([]),
+      };
+
+      const calls: AdvancedPipeStruct[] = [
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData(
+            'remainingRecapitalization'
+          ),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData(
+            'getCurrentHumidity'
+          ),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData(
+            'beansPerFertilizer'
+          ),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData('getEndBpf'),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData(
+            'totalUnfertilizedBeans'
+          ),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData(
+            'totalFertilizedBeans'
+          ),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData(
+            'getRecapFundedPercent',
+            [UNRIPE_BEAN.address]
+          ),
+        },
+      ];
+
+      const results = await beanstalk.callStatic.advancedPipe(calls, '0');
+      const remainingRecapitalization = tokenResult(BEAN)(
+        beanstalk.interface.decodeFunctionResult(
+          'remainingRecapitalization',
+          results[0]
+        )[0]
+      );
+      const humidity = bigNumberResult(
+        beanstalk.interface.decodeFunctionResult(
+          'getCurrentHumidity',
+          results[1]
+        )[0]
+      );
+      const currentBpf = bigNumberResult(
+        beanstalk.interface.decodeFunctionResult(
+          'beansPerFertilizer',
+          results[2]
+        )[0]
+      );
+      const endBpf = bigNumberResult(
+        beanstalk.interface.decodeFunctionResult('getEndBpf', results[3])[0]
+      );
+      const unfertilized = tokenResult(BEAN)(
+        beanstalk.interface.decodeFunctionResult(
+          'totalUnfertilizedBeans',
+          results[4]
+        )[0]
+      );
+      const fertilized = tokenResult(BEAN)(
+        beanstalk.interface.decodeFunctionResult(
+          'totalFertilizedBeans',
+          results[5]
+        )[0]
+      );
+      const recapFundedPct = tokenResult(UNRIPE_BEAN)(
+        beanstalk.interface.decodeFunctionResult(
+          'getRecapFundedPercent',
+          results[6]
+        )[0]
+      );
+
       console.debug(
         `[beanstalk/fertilizer/updater] RESULT: remaining = ${remainingRecapitalization.toFixed(
           2
@@ -75,7 +143,7 @@ export const useFetchBeanstalkBarn = () => {
         })
       );
     }
-  }, [sdk.tokens, fertContract, usdcContract, beanstalk, dispatch]);
+  }, [sdk, dispatch]);
   const clear = useCallback(() => {
     dispatch(resetBarn());
   }, [dispatch]);
@@ -85,7 +153,6 @@ export const useFetchBeanstalkBarn = () => {
 
 const BarnUpdater = () => {
   const [fetch, clear] = useFetchBeanstalkBarn();
-  const chainId = useChainId();
 
   useL2OnlyEffect(() => {
     clear();

--- a/projects/ui/src/state/beanstalk/case/updater.ts
+++ b/projects/ui/src/state/beanstalk/case/updater.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
+import { AdvancedPipeStruct, Clipboard } from '@beanstalk/sdk';
 import useSdk from '~/hooks/sdk';
 import { useAppSelector } from '~/state';
 import { ethersBNResult } from '~/util';
@@ -24,12 +25,47 @@ export const useUpdateBeanstalkCaseState = () => {
     }
 
     const bs = sdk.contracts.beanstalk;
-    const [deltaPodDemand, l2sr, podRate, largestLiqWell] = await Promise.all([
-      bs.getDeltaPodDemand().then(ethersBNResult(18)),
-      bs.getLiquidityToSupplyRatio().then(ethersBNResult(18)),
-      bs.getPodRate('0').then(ethersBNResult(18)),
-      bs.getLargestLiqWell(),
-    ]);
+    const common = {
+      target: bs.address,
+      clipboard: Clipboard.encode([]),
+    };
+
+    const calls: AdvancedPipeStruct[] = [
+      {
+        ...common,
+        callData: bs.interface.encodeFunctionData('getDeltaPodDemand'),
+      },
+      {
+        ...common,
+        callData: bs.interface.encodeFunctionData('getLiquidityToSupplyRatio'),
+      },
+      {
+        ...common,
+        callData: bs.interface.encodeFunctionData('getPodRate', ['0']),
+      },
+      {
+        ...common,
+        callData: bs.interface.encodeFunctionData('getLargestLiqWell'),
+      },
+    ];
+
+    const results = await bs.callStatic.advancedPipe(calls, '0');
+    const deltaPodDemand = ethersBNResult(18)(
+      bs.interface.decodeFunctionResult('getDeltaPodDemand', results[0])[0]
+    );
+    const l2sr = ethersBNResult(18)(
+      bs.interface.decodeFunctionResult(
+        'getLiquidityToSupplyRatio',
+        results[1]
+      )[0]
+    );
+    const podRate = ethersBNResult(18)(
+      bs.interface.decodeFunctionResult('getPodRate', results[2])[0]
+    );
+    const largestLiqWell = bs.interface.decodeFunctionResult(
+      'getLargestLiqWell',
+      results[3]
+    )[0];
 
     dispatch(
       updateBeanstalkCaseState({

--- a/projects/ui/src/state/beanstalk/field/updater.ts
+++ b/projects/ui/src/state/beanstalk/field/updater.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
+import { AdvancedPipeStruct, Clipboard } from '@beanstalk/sdk';
 import { bigNumberResult, tokenResult } from '~/util';
 import { BEAN } from '~/constants/tokens';
 import useL2OnlyEffect from '~/hooks/chain/useL2OnlyEffect';
@@ -15,26 +16,77 @@ export const useFetchBeanstalkField = () => {
     if (beanstalk) {
       console.debug('[beanstalk/field/useBeanstalkField] FETCH');
 
-      // TODO: multicall?
-      const [
-        harvestableIndex,
-        podIndex,
-        soil,
-        weather,
-        adjustedTemperature,
-        maxTemperature,
-      ] = await Promise.all([
-        beanstalk.harvestableIndex('0').then(tokenResult(BEAN)), // FIXME
-        beanstalk.podIndex('0').then(tokenResult(BEAN)),
-        beanstalk.totalSoil().then(tokenResult(BEAN)),
-        beanstalk.weather().then((_weather) => ({
-          lastDSoil: tokenResult(BEAN)(_weather.lastDeltaSoil),
-          lastSowTime: bigNumberResult(_weather.lastSowTime),
-          thisSowTime: bigNumberResult(_weather.thisSowTime),
-        })),
-        beanstalk.temperature().then(tokenResult(BEAN)), // FIXME
-        beanstalk.maxTemperature().then(tokenResult(BEAN)), // FIXME
-      ]);
+      const common = {
+        target: beanstalk.address,
+        clipboard: Clipboard.encode([]),
+      };
+
+      const calls: AdvancedPipeStruct[] = [
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData(
+            'harvestableIndex',
+            ['0']
+          ),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData('podIndex', ['0']),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData('totalSoil'),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData('weather'),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData('temperature'),
+        },
+        {
+          ...common,
+          callData: beanstalk.interface.encodeFunctionData('maxTemperature'),
+        },
+      ];
+
+      const results = await beanstalk.callStatic.advancedPipe(calls, '0');
+      const _harvestableIndex = beanstalk.interface.decodeFunctionResult(
+        'harvestableIndex',
+        results[0]
+      )[0];
+      const _podIndex = beanstalk.interface.decodeFunctionResult(
+        'podIndex',
+        results[1]
+      )[0];
+      const _soil = beanstalk.interface.decodeFunctionResult(
+        'totalSoil',
+        results[2]
+      )[0];
+      const _weather = beanstalk.interface.decodeFunctionResult(
+        'weather',
+        results[3]
+      )[0];
+      const _adjustedTemperature = beanstalk.interface.decodeFunctionResult(
+        'temperature',
+        results[4]
+      )[0];
+      const _maxTemperature = beanstalk.interface.decodeFunctionResult(
+        'maxTemperature',
+        results[5]
+      )[0];
+
+      const harvestableIndex = tokenResult(BEAN)(_harvestableIndex);
+      const podIndex = tokenResult(BEAN)(_podIndex);
+      const soil = tokenResult(BEAN)(_soil);
+      const weather = {
+        lastDSoil: tokenResult(BEAN)(_weather.lastDeltaSoil),
+        lastSowTime: bigNumberResult(_weather.lastSowTime),
+        thisSowTime: bigNumberResult(_weather.thisSowTime),
+      };
+      const adjustedTemperature = tokenResult(BEAN)(_adjustedTemperature);
+      const maxTemperature = tokenResult(BEAN)(_maxTemperature);
 
       console.debug('[beanstalk/field/useBeanstalkField] RESULT', {
         harvestableIndex: harvestableIndex.toString(),

--- a/projects/ui/src/state/beanstalk/governance/updater.ts
+++ b/projects/ui/src/state/beanstalk/governance/updater.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import BigNumber from 'bignumber.js';
+import { AdvancedPipeStruct, Clipboard } from '@beanstalk/sdk';
 import { useProposalsLazyQuery } from '~/generated/graphql';
 import { AddressMap, MULTISIGS } from '~/constants';
 import { useBeanstalkContract } from '~/hooks/ledger/useContract';
@@ -31,13 +32,30 @@ export const useFetchBeanstalkGovernance = () => {
   /// Handlers
   const fetch = useCallback(async () => {
     if (beanstalk) {
+      const clipboard = Clipboard.encode([]);
+      const balanceCalls: AdvancedPipeStruct[] = MULTISIGS.map((address) => ({
+        target: beanstalk.address,
+        callData: beanstalk.interface.encodeFunctionData('getBalance', [
+          address,
+          BEAN.address,
+        ]),
+        clipboard,
+      }));
+
       const [proposalsResult, multisigBalances] = await Promise.all([
         getProposals(),
-        Promise.all(
-          MULTISIGS.map((address) =>
-            beanstalk.getBalance(address, BEAN.address).then(tokenResult(BEAN))
+        beanstalk.callStatic
+          .advancedPipe(balanceCalls, '0')
+          .then((results) =>
+            results.map((result) =>
+              tokenResult(BEAN)(
+                beanstalk.interface.decodeFunctionResult(
+                  'getBalance',
+                  result
+                )[0]
+              )
+            )
           )
-        ),
       ]);
 
       // Update proposals

--- a/projects/ui/vite.config.mts
+++ b/projects/ui/vite.config.mts
@@ -1,4 +1,5 @@
 import { defineConfig, splitVendorChunkPlugin } from 'vite';
+import { execSync } from 'node:child_process';
 import path from 'path';
 import { createHtmlPlugin } from 'vite-plugin-html';
 import react from '@vitejs/plugin-react';
@@ -18,11 +19,52 @@ type CSPData = {
   'frame-src': string[];
 };
 
+type AppVersion = {
+  buildId: string;
+  commit: string;
+  branch: string;
+  context: string;
+  builtAt: string;
+};
+
 function buildCSP(data: CSPData) {
   return Object.keys(data)
     .map((key) => `${key} ${data[key].join(' ')}`)
     .join(';');
 }
+
+const getGitCommit = () => {
+  try {
+    return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+};
+
+const getAppVersion = (): AppVersion => {
+  const builtAt = new Date().toISOString();
+  const commit =
+    process.env.COMMIT_REF ||
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.CF_PAGES_COMMIT_SHA ||
+    process.env.GITHUB_SHA ||
+    getGitCommit();
+
+  return {
+    buildId:
+      process.env.VITE_APP_BUILD_ID ||
+      process.env.DEPLOY_ID ||
+      `${commit}-${builtAt}`,
+    commit,
+    branch:
+      process.env.BRANCH ||
+      process.env.VERCEL_GIT_COMMIT_REF ||
+      process.env.GITHUB_REF_NAME ||
+      '',
+    context: process.env.CONTEXT || process.env.VITE_NETLIFY_CONTEXT || '',
+    builtAt,
+  };
+};
 
 const CSP = buildCSP({
   'default-src': ["'self'"],
@@ -74,87 +116,103 @@ const CSP = buildCSP({
   ], // for walletconnect
 });
 
-// @ts-ignore
-export default defineConfig(({ command }) => ({
-  test: {
-    globals: true,
-  },
-  server: {
-    hmr: {
-      overlay: true,
+export default defineConfig(({ command }) => {
+  const appVersion = getAppVersion();
+
+  return {
+    define: {
+      __BEANSTALK_APP_VERSION__: JSON.stringify(appVersion),
     },
-    proxy: {
-      '/rff-api': {
-        target: RFF_STAGING_ORIGIN,
-        changeOrigin: true,
-        rewrite: (requestPath) => requestPath.replace(/^\/rff-api/, ''),
-        configure: (proxy) => {
-          proxy.on('proxyReq', (proxyRequest) => {
-            proxyRequest.setHeader('Origin', RFF_UI_ORIGIN);
-          });
-          proxy.on('proxyRes', (proxyResponse) => {
-            const cookies = proxyResponse.headers['set-cookie'];
-            if (cookies) {
-              proxyResponse.headers['set-cookie'] = cookies.map((cookie) =>
-                cookie.replace('Path=/v1', 'Path=/rff-api/v1')
-              );
-            }
-          });
+    test: {
+      globals: true,
+    },
+    server: {
+      hmr: {
+        overlay: true,
+      },
+      proxy: {
+        '/rff-api': {
+          target: RFF_STAGING_ORIGIN,
+          changeOrigin: true,
+          rewrite: (requestPath) => requestPath.replace(/^\/rff-api/, ''),
+          configure: (proxy) => {
+            proxy.on('proxyReq', (proxyRequest) => {
+              proxyRequest.setHeader('Origin', RFF_UI_ORIGIN);
+            });
+            proxy.on('proxyRes', (proxyResponse) => {
+              const cookies = proxyResponse.headers['set-cookie'];
+              if (cookies) {
+                proxyResponse.headers['set-cookie'] = cookies.map((cookie) =>
+                  cookie.replace('Path=/v1', 'Path=/rff-api/v1')
+                );
+              }
+            });
+          },
         },
       },
     },
-  },
-  plugins: [
-    react({
-      // This definition ensures that the `css` prop from Emotion
-      // works at build time. The one in tsconfig.json ensures that
-      // the IDE doesn't throw errors when using the prop.
-      jsxImportSource: '@emotion/react',
-      babel: {
-        compact: false,
-      },
-    }),
-    createHtmlPlugin({
-      minify: true,
-      inject: {
-        data: {
-          csp:
-            process.env.NODE_ENV === 'production' && !process.env.DISABLE_CSP
-              ? `<meta http-equiv="Content-Security-Policy" content="${CSP}" />`
-              : '',
+    plugins: [
+      react({
+        // This definition ensures that the `css` prop from Emotion
+        // works at build time. The one in tsconfig.json ensures that
+        // the IDE doesn't throw errors when using the prop.
+        jsxImportSource: '@emotion/react',
+        babel: {
+          compact: false,
         },
-      },
-    }),
-    splitVendorChunkPlugin(),
-    process.env.NODE_ENV === 'production' && analyze({ limit: 10 }),
-    process.env.NODE_ENV === 'production' &&
-      // There is a bug with this pluin's ESM imports, need to get the function off of .default
-      // @ts-ignore
-      removeHTMLAttributes.default({
-        include: ['**/*.tsx', '**/*.jsx'],
-        attributes: ['data-cy'],
-        exclude: 'node_modules',
       }),
-  ],
-  resolve: {
-    alias: [
       {
-        find: '~',
-        replacement: path.resolve(__dirname, 'src'),
+        name: 'app-version',
+        generateBundle() {
+          this.emitFile({
+            type: 'asset',
+            fileName: 'version.json',
+            source: `${JSON.stringify(appVersion)}\n`,
+          });
+        },
       },
-    ],
-  },
-  build: {
-    sourcemap: command === 'serve',
-    reportCompressedSize: true,
-    rollupOptions: {
-      plugins: [
+      createHtmlPlugin({
+        minify: true,
+        inject: {
+          data: {
+            csp:
+              process.env.NODE_ENV === 'production' && !process.env.DISABLE_CSP
+                ? `<meta http-equiv="Content-Security-Policy" content="${CSP}" />`
+                : '',
+          },
+        },
+      }),
+      splitVendorChunkPlugin(),
+      process.env.NODE_ENV === 'production' && analyze({ limit: 10 }),
+      process.env.NODE_ENV === 'production' &&
+        // There is a bug with this plugin's ESM imports, need to get the function off of .default
         // @ts-ignore
-        strip({
-          functions: ['console.debug'],
-          include: '**/*.(ts|tsx)',
+        removeHTMLAttributes.default({
+          include: ['**/*.tsx', '**/*.jsx'],
+          attributes: ['data-cy'],
+          exclude: 'node_modules',
         }),
+    ],
+    resolve: {
+      alias: [
+        {
+          find: '~',
+          replacement: path.resolve(__dirname, 'src'),
+        },
       ],
     },
-  },
-}));
+    build: {
+      sourcemap: command === 'serve',
+      reportCompressedSize: true,
+      rollupOptions: {
+        plugins: [
+          // @ts-ignore
+          strip({
+            functions: ['console.debug'],
+            include: '**/*.(ts|tsx)',
+          }),
+        ],
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- add a production app-version manifest and persistent reload prompt so stale clients update without automatically interrupting wallet confirmations
- reduce L1 migration polling from every 10 seconds to every 60 seconds and pause it while the tab is hidden
- reduce L2 claim polling from every 5 seconds to every 5 minutes, pause hidden-tab polling, stop after completion, and bound log scans from the Arbitrum migration deployment block
- fetch all five L2 migration claim statuses in one filtered `eth_getLogs` request and reuse the discovered migration source
- invalidate stale wallet RPC/API responses, abort obsolete migration-data requests, handle provider/API failures, and safely fall back when browser storage is unavailable
- batch Beanstalk Field, Barn, Case, Pools, Unripe, and Governance startup reads with `advancedPipe`
- move the NFT page Alchemy API key out of the hardcoded URL and into `VITE_ALCHEMY_API_KEY`

## RPC impact
- Field/Barn/Case: 17 separate boot-time contract reads -> 3 `advancedPipe` RPC calls
- Pools/Unripe/Governance: 16 separate boot-time contract reads -> 3 `advancedPipe` RPC calls
- Combined startup reads: roughly 33 `eth_call` requests -> 6
- L2 claim status: five separate event queries -> one filtered log request
- L1 migration polling: 6x less frequent; L2 claim polling: 60x less frequent, with hidden/completed pages producing no polling

Alchemy lists `eth_call` at 26 compute units. The bundled startup reads therefore fall from roughly 858 CUs to roughly 156 CUs per startup, assuming each outer `advancedPipe` simulation is billed as one `eth_call`.

## Validation
- `22` UI test files / `68` tests passed
- focused ESLint passed with zero warnings or errors
- TypeScript `--noEmit` passed
- hardcoded Alchemy credential scan passed
- Prettier and `git diff --check` passed
- production Vite build passed and emitted `dist/version.json` plus the no-cache header
- the `advancedPipe` targets, selectors, result ordering, and decoders were independently reviewed
- live Arbitrum `callStatic.advancedPipe` and gas estimates for all six bundles were successful; the largest bundle was approximately 5.7M gas
