### PR TITLE
fix(ui): make builds resilient to schema outages

### DIFF
--- a/projects/ui/package.json
+++ b/projects/ui/package.json
@@ -147,7 +147,7 @@
     "lint": "eslint --ext ts --ext tsx ./src",
     "generate": "echo '\nUI Generate' && yarn clean && yarn generate:typechain && yarn generate:graphql && echo \"Done generating files.\"",
     "generate:typechain": "echo \"Generating: typechain ethers-v5\" && typechain --target=ethers-v5 --ts-nocheck --out-dir=./src/generated '{./src/constants/abi/**/*.json,../../protocol/abi/Beanstalk.json}'",
-    "generate:graphql": "echo \"Generating: graphql-codegen\" && graphql-codegen --config codegen-individual.yml && graphql-codegen --config codegen.yml",
+    "generate:graphql": "echo \"Generating: graphql-codegen\" && (graphql-codegen --config codegen-individual.yml || echo 'Schema refresh failed; using checked-in schemas.') && graphql-codegen --config codegen.yml",
     "storybook": "start-storybook -p 6006 -s public",
     "postpack": "yarn generate"
   },


### PR DESCRIPTION
## Summary
- continue attempting to refresh remote GraphQL schemas during UI generation
- fall back to the checked-in schemas when graph.bean.money is unavailable
- keep local code generation and the production build running normally

## Why
PR #1190 merged successfully, but its Netlify deployment was blocked by an unrelated graph.bean.money outage during graphql-codegen.

## Verification
- yarn generate passes while the remote schema endpoints are unavailable
- yarn build passes end-to-end under the same outage
- diff is limited to the UI generation script