### PR TITLE
fix(ui): quote urLP converts from execution result

### DIFF
--- a/projects/ui/src/lib/Txn/FarmSteps/silo/ConvertFarmStep.test.ts
+++ b/projects/ui/src/lib/Txn/FarmSteps/silo/ConvertFarmStep.test.ts
@@ -1,0 +1,142 @@
+import { BeanstalkSDK, Deposit, Token, TokenValue } from '@beanstalk/sdk';
+import { ethers } from 'ethers';
+import { describe, expect, it, vi } from 'vitest';
+import { ConvertFarmStep } from './ConvertFarmStep';
+
+const makeToken = (address: string) =>
+  ({
+    address,
+    amount: (value: string | number) => TokenValue.fromHuman(value, 6),
+    equals: (other: Token) =>
+      address.toLowerCase() === other.address.toLowerCase(),
+    fromBlockchain: (value: string | number | ethers.BigNumber) =>
+      TokenValue.fromBlockchain(value, 6),
+  }) as unknown as Token;
+
+describe('ConvertFarmStep', () => {
+  it('quotes urLP to urBEAN from the convert result instead of getAmountOut', async () => {
+    const tokenIn = makeToken('0x0000000000000000000000000000000000000001');
+    const tokenOut = makeToken('0x0000000000000000000000000000000000000002');
+    const amountIn = tokenIn.amount(1);
+    const quotedAmountOut = tokenOut.amount('2.4');
+    const crate = {
+      stem: ethers.BigNumber.from(123),
+      amount: amountIn,
+    } as unknown as Deposit;
+
+    const calculateConvert = vi.fn().mockReturnValue({
+      amount: amountIn,
+      crates: [crate],
+    });
+    const calculateEncoding = vi.fn().mockReturnValue('0xquote');
+    const getAmountOut = vi
+      .fn()
+      .mockRejectedValue(new Error('stale EBIP-23 getter'));
+    const convert = vi.fn().mockResolvedValue({
+      toAmount: quotedAmountOut.toBlockchain(),
+    });
+    const encodeFunctionData = vi.fn().mockReturnValue('0xfinal');
+
+    const sdk = {
+      contracts: {
+        beanstalk: {
+          callStatic: { convert },
+          getAmountOut,
+          interface: { encodeFunctionData },
+        },
+      },
+      silo: {
+        siloConvert: {
+          calculateConvert,
+          calculateEncoding,
+        },
+      },
+      tokens: {
+        UNRIPE_BEAN_WSTETH: tokenIn,
+        UNRIPE_BEAN: tokenOut,
+      },
+    } as unknown as BeanstalkSDK;
+
+    const result = await ConvertFarmStep._handleConversion(
+      sdk,
+      [crate],
+      tokenIn,
+      tokenOut,
+      amountIn,
+      1,
+      1
+    );
+
+    expect(result.minAmountOut.toHuman()).toBe('2.376');
+    expect(convert).toHaveBeenCalledWith('0xquote', ['123'], ['1000000']);
+    expect(getAmountOut).not.toHaveBeenCalled();
+
+    const quoteMinimum = calculateEncoding.mock.calls[0][3] as TokenValue;
+    expect(quoteMinimum.toBlockchain()).toBe('0');
+
+    expect(result.getEncoded()).toBe('0xfinal');
+    const executionMinimum = calculateEncoding.mock.calls[1][3] as TokenValue;
+    expect(executionMinimum.toBlockchain()).toBe('2376000');
+    expect(encodeFunctionData).toHaveBeenCalledWith('convert', [
+      '0xquote',
+      ['123'],
+      ['1000000'],
+    ]);
+  });
+
+  it('continues to quote other convert routes with getAmountOut', async () => {
+    const unripeLp = makeToken('0x0000000000000000000000000000000000000001');
+    const unripeBean = makeToken('0x0000000000000000000000000000000000000002');
+    const tokenIn = makeToken('0x0000000000000000000000000000000000000003');
+    const tokenOut = makeToken('0x0000000000000000000000000000000000000004');
+    const amountIn = tokenIn.amount(1);
+    const quotedAmountOut = tokenOut.amount('2.4');
+    const crate = {
+      stem: ethers.BigNumber.from(123),
+      amount: amountIn,
+    } as unknown as Deposit;
+
+    const getAmountOut = vi
+      .fn()
+      .mockResolvedValue(quotedAmountOut.toBlockchain());
+    const convert = vi.fn();
+    const sdk = {
+      contracts: {
+        beanstalk: {
+          callStatic: { convert },
+          getAmountOut,
+        },
+      },
+      silo: {
+        siloConvert: {
+          calculateConvert: vi.fn().mockReturnValue({
+            amount: amountIn,
+            crates: [crate],
+          }),
+        },
+      },
+      tokens: {
+        UNRIPE_BEAN_WSTETH: unripeLp,
+        UNRIPE_BEAN: unripeBean,
+      },
+    } as unknown as BeanstalkSDK;
+
+    const result = await ConvertFarmStep._handleConversion(
+      sdk,
+      [crate],
+      tokenIn,
+      tokenOut,
+      amountIn,
+      1,
+      1
+    );
+
+    expect(result.minAmountOut.toHuman()).toBe('2.376');
+    expect(getAmountOut).toHaveBeenCalledWith(
+      tokenIn.address,
+      tokenOut.address,
+      '1000000'
+    );
+    expect(convert).not.toHaveBeenCalled();
+  });
+});

--- a/projects/ui/src/lib/Txn/FarmSteps/silo/ConvertFarmStep.ts
+++ b/projects/ui/src/lib/Txn/FarmSteps/silo/ConvertFarmStep.ts
@@ -6,7 +6,8 @@ import {
   TokenValue,
 } from '@beanstalk/sdk';
 import { ethers } from 'ethers';
-import { FarmStep, PlantAndDoX } from '~/lib/Txn/Interface';
+import FarmStep from '~/lib/Txn/Interface/FarmStep';
+import type PlantAndDoX from '~/lib/Txn/Interface/PlantAndDoX';
 
 export class ConvertFarmStep extends FarmStep {
   constructor(
@@ -54,11 +55,32 @@ export class ConvertFarmStep extends FarmStep {
     );
     console.debug('[ConvertFarmStep][conversion]: ', conversion);
 
-    const amountOutBN = await beanstalk.getAmountOut(
-      _tokenIn.address,
-      _tokenOut.address,
-      conversion.amount.toBlockchain()
-    );
+    const stems = conversion.crates.map((c) => c.stem.toString());
+    const amounts = conversion.crates.map((c) => c.amount.abs().toBlockchain());
+    const isUnripeLpToBean =
+      _tokenIn.equals(sdk.tokens.UNRIPE_BEAN_WSTETH) &&
+      _tokenOut.equals(sdk.tokens.UNRIPE_BEAN);
+
+    // EBIP-23 moved urLP backing into protected storage. The deployed getter
+    // still reads the old storage slot, while convert uses the combined backing.
+    const amountOutBN = isUnripeLpToBean
+      ? (
+          await beanstalk.callStatic.convert(
+            siloConvert.calculateEncoding(
+              _tokenIn,
+              _tokenOut,
+              amountIn,
+              _tokenOut.amount(0)
+            ),
+            stems,
+            amounts
+          )
+        ).toAmount
+      : await beanstalk.getAmountOut(
+          _tokenIn.address,
+          _tokenOut.address,
+          conversion.amount.toBlockchain()
+        );
 
     const amountOut = _tokenOut.fromBlockchain(amountOutBN);
     const minAmountOut = amountOut.pct(100 - slippage);
@@ -72,8 +94,8 @@ export class ConvertFarmStep extends FarmStep {
           amountIn,
           minAmountOut
         ),
-        conversion.crates.map((c) => c.stem.toString()),
-        conversion.crates.map((c) => c.amount.abs().toBlockchain()),
+        stems,
+        amounts,
       ]);
 
     return {


### PR DESCRIPTION
## Summary

- quote urLP to urBEAN by simulating the exact Convert call with a zero minimum
- use the returned `toAmount` to calculate the slippage-protected minimum
- preserve the existing getter path for every other Convert route
- add regression coverage for simulation inputs, final calldata, and the unaffected-route control case

## Context

EBIP-23 moved urLP backing into protected storage. The deployed `getAmountOut` getter still reads the old backing location, while `convert` uses the combined backing.

In [this transaction](https://arbiscan.io/tx/0xe05829d8c4e409bb780d7afc192dcd3f3e51edd500046dc840624c47a3bd91fb), 117,008.212452 urLP converted into 282,054.232585 urBEAN, while the UI-derived minimum was only 28,447.198821 urBEAN. Quoting the real execution path keeps the displayed output and minimum aligned with the Convert transaction.

## Test plan

- `VITE_ALCHEMY_API_KEY=test VITE_WALLETCONNECT_PROJECT_ID=test yarn workspace ui vitest run` (58 tests passed)
- `yarn workspace ui tsc --noEmit`
- `yarn workspace ui eslint src/lib/Txn/FarmSteps/silo/ConvertFarmStep.ts src/lib/Txn/FarmSteps/silo/ConvertFarmStep.test.ts`
- `VITE_ALCHEMY_API_KEY=test VITE_WALLETCONNECT_PROJECT_ID=test yarn workspace ui build`
