### PR TITLE
chore(protocol): sync EBIP-21 deployed source

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jest": "29.2.2",
     "jest-serial-runner": "1.2.1",
     "lint-staged": "13.3.0",
-    "prettier": "3.8.1",
+    "prettier": "3.9.6",
     "ts-jest": "29.1.2",
     "ts-node": "10.9.2",
     "typescript": "5.3.3"
@@ -58,6 +58,6 @@
     "anvil4tests": "anvil --fork-url https://arb-mainnet.g.alchemy.com/v2/Kk7ktCQL5wz4v4AG8bR2Gun8TAASQ-qi  --chain-id 1337 --fork-block-number 18629000"
   },
   "dependencies": {
-    "prettier-plugin-solidity": "2.2.1"
+    "prettier-plugin-solidity": "2.4.1"
   }
 }

--- a/protocol/abi/Beanstalk.json
+++ b/protocol/abi/Beanstalk.json
@@ -179,6 +179,25 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "underlying",
+        "type": "uint256"
+      }
+    ],
+    "name": "RestoreProtectedUnderlying",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "token",
         "type": "address"
       },
@@ -448,6 +467,44 @@
         "type": "address"
       }
     ],
+    "name": "getProtectedUnderlying",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "underlying",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "unripeToken",
+        "type": "address"
+      }
+    ],
+    "name": "getProtectedUnderlyingCustodian",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "custodian",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "unripeToken",
+        "type": "address"
+      }
+    ],
     "name": "getRecapFundedPercent",
     "outputs": [
       {
@@ -583,6 +640,19 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "restoreProtectedUnderlying",
+    "outputs": [],
+    "stateMutability": "payable",
     "type": "function"
   },
   {

--- a/protocol/abi/MockBeanstalk.json
+++ b/protocol/abi/MockBeanstalk.json
@@ -179,6 +179,25 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "underlying",
+        "type": "uint256"
+      }
+    ],
+    "name": "RestoreProtectedUnderlying",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "token",
         "type": "address"
       },
@@ -448,6 +467,44 @@
         "type": "address"
       }
     ],
+    "name": "getProtectedUnderlying",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "underlying",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "unripeToken",
+        "type": "address"
+      }
+    ],
+    "name": "getProtectedUnderlyingCustodian",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "custodian",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "unripeToken",
+        "type": "address"
+      }
+    ],
     "name": "getRecapFundedPercent",
     "outputs": [
       {
@@ -583,6 +640,19 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "restoreProtectedUnderlying",
+    "outputs": [],
+    "stateMutability": "payable",
     "type": "function"
   },
   {

--- a/protocol/contracts/beanstalk/barn/UnripeFacet.sol
+++ b/protocol/contracts/beanstalk/barn/UnripeFacet.sol
@@ -19,6 +19,7 @@ import {ReentrancyGuard} from "contracts/beanstalk/ReentrancyGuard.sol";
 import {LibRedundantMath256} from "contracts/libraries/LibRedundantMath256.sol";
 import {LibLockedUnderlying} from "contracts/libraries/LibLockedUnderlying.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {UnripeSettings} from "contracts/beanstalk/storage/System.sol";
 
 /**
  * @title UnripeFacet
@@ -47,6 +48,11 @@ contract UnripeFacet is Invariable, ReentrancyGuard {
      * @param underlying `amount` that has changed.
      */
     event ChangeUnderlying(address indexed token, int256 underlying);
+
+    /**
+     * @notice Emitted when protected underlying is returned to Beanstalk custody.
+     */
+    event RestoreProtectedUnderlying(address indexed account, uint256 underlying);
 
     /**
      * @notice Emitted when the Ripe Token of an unripe asset changes.
@@ -231,11 +237,8 @@ contract UnripeFacet is Invariable, ReentrancyGuard {
     function getUnderlyingPerUnripeToken(
         address unripeToken
     ) external view returns (uint256 underlyingPerToken) {
-        underlyingPerToken = s
-            .sys
-            .silo
-            .unripeSettings[unripeToken]
-            .balanceOfUnderlying
+        underlyingPerToken = LibUnripe
+            .getTotalUnderlying(unripeToken)
             .mul(LibUnripe.DECIMALS)
             .div(IERC20(unripeToken).totalSupply());
     }
@@ -246,7 +249,53 @@ contract UnripeFacet is Invariable, ReentrancyGuard {
      * @return underlying The total balance of the token.
      */
     function getTotalUnderlying(address unripeToken) external view returns (uint256 underlying) {
-        return s.sys.silo.unripeSettings[unripeToken].balanceOfUnderlying;
+        return LibUnripe.getTotalUnderlying(unripeToken);
+    }
+
+    /**
+     * @notice Returns the amount of underlying backing held in protected external custody.
+     */
+    function getProtectedUnderlying(
+        address unripeToken
+    ) external view returns (uint256 underlying) {
+        return s.sys.silo.unripeSettings[unripeToken].protectedUnderlying;
+    }
+
+    /**
+     * @notice Returns the Safe authorized to restore protected Unripe LP backing.
+     */
+    function getProtectedUnderlyingCustodian(
+        address unripeToken
+    ) external view returns (address custodian) {
+        return s.sys.silo.unripeSettings[unripeToken].protectedUnderlyingCustodian;
+    }
+
+    /**
+     * @notice Returns protected Unripe LP backing to Beanstalk custody without changing total
+     * backing or recapitalization.
+     * @dev The protected custodian must approve Beanstalk to transfer the LP before calling.
+     */
+    function restoreProtectedUnderlying(
+        uint256 amount
+    ) external payable fundsSafu noOutFlow noSupplyChange nonReentrant {
+        require(amount > 0, "Unripe: Protected amount is zero");
+
+        address urLp = s.sys.tokens.urLp;
+        UnripeSettings storage settings = s.sys.silo.unripeSettings[urLp];
+        require(
+            msg.sender == settings.protectedUnderlyingCustodian,
+            "Unripe: Not protected custodian"
+        );
+        require(
+            settings.protectedUnderlying >= amount,
+            "Unripe: Insufficient protected underlying"
+        );
+
+        IERC20(settings.underlyingToken).safeTransferFrom(msg.sender, address(this), amount);
+        settings.protectedUnderlying = settings.protectedUnderlying.sub(amount);
+        settings.balanceOfUnderlying = settings.balanceOfUnderlying.add(amount);
+
+        emit RestoreProtectedUnderlying(msg.sender, amount);
     }
 
     /**
@@ -302,7 +351,7 @@ contract UnripeFacet is Invariable, ReentrancyGuard {
      * @notice Switches the Ripe Token of an Unripe Token.
      * @param unripeToken The Unripe Token to switch the Ripe Token of.
      * @param newUnderlyingToken The new Ripe Token to switch to.
-     * @dev `s.silo.unripeSettings[unripeToken].balanceOfUnderlying` must be 0.
+     * @dev The Unripe Token must have no local or protected underlying.
      */
     function switchUnderlyingToken(
         address unripeToken,
@@ -310,7 +359,7 @@ contract UnripeFacet is Invariable, ReentrancyGuard {
     ) external payable fundsSafu noNetFlow noSupplyChange nonReentrant {
         LibDiamond.enforceIsContractOwner();
         require(
-            s.sys.silo.unripeSettings[unripeToken].balanceOfUnderlying == 0,
+            LibUnripe.getTotalUnderlying(unripeToken) == 0,
             "Unripe: Underlying balance > 0"
         );
         LibUnripe.switchUnderlyingToken(unripeToken, newUnderlyingToken);

--- a/protocol/contracts/beanstalk/init/InitProtectedUnderlying.sol
+++ b/protocol/contracts/beanstalk/init/InitProtectedUnderlying.sol
@@ -1,0 +1,48 @@
+/*
+ SPDX-License-Identifier: MIT
+*/
+
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {AppStorage} from "contracts/beanstalk/storage/AppStorage.sol";
+import {UnripeSettings} from "contracts/beanstalk/storage/System.sol";
+
+/**
+ * @title InitProtectedUnderlying
+ * @notice Moves Unripe LP backing from Beanstalk custody into protected BCM custody without
+ * changing the total backing attributed to Unripe LP holders.
+ */
+contract InitProtectedUnderlying {
+    using SafeERC20 for IERC20;
+
+    AppStorage internal s;
+
+    event ProtectUnderlying(address indexed recipient, uint256 underlying);
+
+    function init(address recipient, uint256 amount) external {
+        require(recipient != address(0), "Init: Protected recipient is zero");
+        require(amount > 0, "Init: Protected amount is zero");
+
+        address urLp = s.sys.tokens.urLp;
+        UnripeSettings storage settings = s.sys.silo.unripeSettings[urLp];
+        require(
+            settings.balanceOfUnderlying >= amount,
+            "Init: Insufficient local underlying"
+        );
+        require(
+            settings.protectedUnderlyingCustodian == address(0) ||
+                settings.protectedUnderlyingCustodian == recipient,
+            "Init: Protected custodian mismatch"
+        );
+
+        settings.protectedUnderlyingCustodian = recipient;
+        settings.balanceOfUnderlying -= amount;
+        settings.protectedUnderlying += amount;
+
+        IERC20(settings.underlyingToken).safeTransfer(recipient, amount);
+
+        emit ProtectUnderlying(recipient, amount);
+    }
+}

--- a/protocol/contracts/beanstalk/silo/EnrootFacet.sol
+++ b/protocol/contracts/beanstalk/silo/EnrootFacet.sol
@@ -168,6 +168,9 @@ contract EnrootFacet is Invariable, ReentrancyGuard {
             s.sys.silo.unripeSettings[token].underlyingToken != address(0),
             "Silo: token not unripe"
         );
+
+        _validateEnrootDeposits(LibTractor._user(), token, stems, amounts);
+
         // First, remove Deposits because every deposit is in a different season,
         // we need to get the total Stalk, not just BDV.
         LibSilo.AssetsRemoved memory ar = LibSilo._removeDepositsFromAccount(
@@ -230,6 +233,37 @@ contract EnrootFacet is Invariable, ReentrancyGuard {
     }
 
     /**
+     * @notice Validates an enroot batch before any Deposit accounting is updated.
+     */
+    function _validateEnrootDeposits(
+        address account,
+        address token,
+        int96[] calldata stems,
+        uint256[] calldata amounts
+    ) private view {
+        require(stems.length == amounts.length, "Silo: Crates, amounts are diff lengths.");
+
+        for (uint256 i; i < amounts.length; ++i) {
+            require(amounts[i] > 0, "Silo: Enroot amount is zero.");
+        }
+
+        int96 stemTip = LibTokenSilo.stemTipForToken(token);
+        for (uint256 i; i < stems.length; ++i) {
+            require(stems[i] <= stemTip, "Silo: Enroot stem exceeds tip.");
+            require(
+                s.accts[account]
+                    .deposits[LibBytes.packAddressAndStem(token, stems[i])]
+                    .amount > 0,
+                "Silo: Enroot deposit does not exist."
+            );
+
+            for (uint256 j; j < i; ++j) {
+                require(stems[i] != stems[j], "Silo: Enroot duplicate stem.");
+            }
+        }
+    }
+
+    /**
      * @notice Gets data needed for enrooting a token.
      * @dev placed outside for stack overflow reasons.
      */
@@ -263,6 +297,8 @@ contract EnrootFacet is Invariable, ReentrancyGuard {
         int96 stemTip,
         uint48 stalkPerBdv
     ) private returns (uint256 stalkAdded) {
+        require(amount > 0 || bdv == 0, "Silo: Invalid enroot deposit.");
+
         LibTokenSilo.addDepositToAccount(
             LibTractor._user(),
             token,

--- a/protocol/contracts/beanstalk/storage/System.sol
+++ b/protocol/contracts/beanstalk/storage/System.sol
@@ -326,9 +326,12 @@ struct AssetSettings {
 /**
  * @notice Describes the settings for each Unripe Token in Beanstalk.
  * @param underlyingToken The address of the Token underlying the Unripe Token.
- * @param balanceOfUnderlying The number of Tokens underlying the Unripe Tokens (redemption pool).
- * @dev An Unripe Token is a vesting Token that is redeemable for a a pro rata share
- * of the `balanceOfUnderlying`, subject to a penalty based on the percent of
+ * @param balanceOfUnderlying The number of underlying Tokens held by Beanstalk.
+ * @param protectedUnderlying The number of underlying Tokens backing Unripe claims from protected
+ * external custody.
+ * @param protectedUnderlyingCustodian The only address authorized to restore protected backing.
+ * @dev An Unripe Token is a vesting Token that is redeemable for a pro rata share of
+ * `balanceOfUnderlying + protectedUnderlying`, subject to a penalty based on the percent of
  * Unfertilized Beans paid back.
  *
  * There were two Unripe Tokens added at Replant:
@@ -342,6 +345,8 @@ struct AssetSettings {
 struct UnripeSettings {
     address underlyingToken;
     uint256 balanceOfUnderlying;
+    uint256 protectedUnderlying;
+    address protectedUnderlyingCustodian;
 }
 
 /**

--- a/protocol/contracts/interfaces/IMockFBeanstalk.sol
+++ b/protocol/contracts/interfaces/IMockFBeanstalk.sol
@@ -412,6 +412,7 @@ interface IMockFBeanstalk {
         uint256 podAmount,
         uint256 costInBeans
     );
+    event PublishData(bytes compressedData);
     event PublishRequisition(Requisition requisition);
     event Receipt(ShipmentRecipient indexed recipient, uint256 receivedAmount, bytes data);
     event ReceiverApproved(address indexed owner, address receiver);
@@ -1232,6 +1233,10 @@ interface IMockFBeanstalk {
 
     function getPenalty(address unripeToken) external view returns (uint256 penalty);
 
+    function getProtectedUnderlying(
+        address unripeToken
+    ) external view returns (uint256 underlying);
+
     function getPercentPenalty(address unripeToken) external view returns (uint256 penalty);
 
     function getPlotIndexesFromAccount(
@@ -1764,6 +1769,8 @@ interface IMockFBeanstalk {
     function resetState() external;
 
     function resetUnderlying(address unripeToken) external;
+
+    function restoreProtectedUnderlying(uint256 amount) external payable;
 
     function revert_netFlow() external;
 

--- a/protocol/contracts/libraries/LibLockedUnderlying.sol
+++ b/protocol/contracts/libraries/LibLockedUnderlying.sol
@@ -27,11 +27,8 @@ library LibLockedUnderlying {
     ) external view returns (uint256 lockedUnderlying) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return
-            s
-                .sys
-                .silo
-                .unripeSettings[unripeToken]
-                .balanceOfUnderlying
+            (s.sys.silo.unripeSettings[unripeToken].balanceOfUnderlying +
+                s.sys.silo.unripeSettings[unripeToken].protectedUnderlying)
                 .mul(getPercentLockedUnderlying(unripeToken, recapPercentPaid))
                 .div(1e18);
     }

--- a/protocol/contracts/libraries/LibUnripe.sol
+++ b/protocol/contracts/libraries/LibUnripe.sol
@@ -32,7 +32,7 @@ library LibUnripe {
     function percentBeansRecapped() internal view returns (uint256 percent) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return
-            s.sys.silo.unripeSettings[s.sys.tokens.urBean].balanceOfUnderlying.mul(DECIMALS).div(
+            getTotalUnderlying(s.sys.tokens.urBean).mul(DECIMALS).div(
                 IERC20(s.sys.tokens.urBean).totalSupply()
             );
     }
@@ -81,6 +81,17 @@ library LibUnripe {
     }
 
     /**
+     * @notice Returns all underlying backing for an Unripe Token, including backing held in
+     * protected external custody.
+     */
+    function getTotalUnderlying(address unripeToken) internal view returns (uint256 underlying) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        underlying = s.sys.silo.unripeSettings[unripeToken].balanceOfUnderlying.add(
+            s.sys.silo.unripeSettings[unripeToken].protectedUnderlying
+        );
+    }
+
+    /**
      * @notice Calculates the amount of Ripe Tokens that underly a given amount of Unripe Tokens.
      * @param unripeToken The address of the Unripe Token
      * @param unripe The amount of Unripe Tokens.
@@ -91,10 +102,7 @@ library LibUnripe {
         uint256 unripe,
         uint256 supply
     ) internal view returns (uint256 underlying) {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-        underlying = s.sys.silo.unripeSettings[unripeToken].balanceOfUnderlying.mul(unripe).div(
-            supply
-        );
+        underlying = getTotalUnderlying(unripeToken).mul(unripe).div(supply);
     }
 
     /**
@@ -107,9 +115,8 @@ library LibUnripe {
         address unripeToken,
         uint256 underlying
     ) internal view returns (uint256 unripe) {
-        AppStorage storage s = LibAppStorage.diamondStorage();
         unripe = IBean(unripeToken).totalSupply().mul(underlying).div(
-            s.sys.silo.unripeSettings[unripeToken].balanceOfUnderlying
+            getTotalUnderlying(unripeToken)
         );
     }
 
@@ -123,7 +130,7 @@ library LibUnripe {
         AppStorage storage s = LibAppStorage.diamondStorage();
         if (token == s.sys.tokens.urLp) {
             uint256 recapped = underlying.mul(s.sys.fert.recapitalized).div(
-                s.sys.silo.unripeSettings[s.sys.tokens.urLp].balanceOfUnderlying
+                getTotalUnderlying(s.sys.tokens.urLp)
             );
             s.sys.fert.recapitalized = s.sys.fert.recapitalized.add(recapped);
         }
@@ -138,9 +145,13 @@ library LibUnripe {
      */
     function removeUnderlying(address token, uint256 underlying) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
+        require(
+            s.sys.silo.unripeSettings[token].balanceOfUnderlying >= underlying,
+            "Unripe: Insufficient local underlying"
+        );
         if (token == s.sys.tokens.urLp) {
             uint256 recapped = underlying.mul(s.sys.fert.recapitalized).div(
-                s.sys.silo.unripeSettings[s.sys.tokens.urLp].balanceOfUnderlying
+                getTotalUnderlying(s.sys.tokens.urLp)
             );
             s.sys.fert.recapitalized = s.sys.fert.recapitalized.sub(recapped);
         }
@@ -149,10 +160,11 @@ library LibUnripe {
 
     /**
      * @dev Switches the underlying token of an unripe token.
-     * Should only be called if `s.silo.unripeSettings[unripeToken].balanceOfUnderlying == 0`.
+     * Should only be called if the Unripe Token has no local or protected underlying.
      */
     function switchUnderlyingToken(address unripeToken, address newUnderlyingToken) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
+        require(getTotalUnderlying(unripeToken) == 0, "Unripe: Underlying balance > 0");
         s.sys.silo.unripeSettings[unripeToken].underlyingToken = newUnderlyingToken;
         emit SwitchUnderlyingToken(unripeToken, newUnderlyingToken);
     }
@@ -180,7 +192,7 @@ library LibUnripe {
         // redeem = totalRipeUnderlying * (usdValueRaised/totalUsdNeeded)^2 * UnripeAmountIn/UnripeSupply;
         // But totalRipeUnderlying = CurrentUnderlying * totalUsdNeeded/usdValueRaised to get the total underlying
         // redeem = currentRipeUnderlying * (usdValueRaised/totalUsdNeeded) * UnripeAmountIn/UnripeSupply
-        uint256 underlyingAmount = s.sys.silo.unripeSettings[unripeToken].balanceOfUnderlying;
+        uint256 underlyingAmount = getTotalUnderlying(unripeToken);
         if (totalUsdNeeded == 0) {
             // when totalUsdNeeded == 0, the barnraise has been fully recapitalized.
             redeem = underlyingAmount.mul(amount).div(supply);
@@ -283,8 +295,7 @@ library LibUnripe {
         uint256 amount,
         uint256 supply
     ) internal view returns (uint256 redeem) {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-        redeem = s.sys.silo.unripeSettings[unripeToken].balanceOfUnderlying.mul(amount).div(supply);
+        redeem = getTotalUnderlying(unripeToken).mul(amount).div(supply);
     }
 
     function _getUnderlyingToken(

--- a/protocol/contracts/mocks/mockFacets/MockUnripeFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockUnripeFacet.sol
@@ -38,6 +38,8 @@ contract MockUnripeFacet is UnripeFacet {
 
     function resetUnderlying(address unripeToken) external {
         s.sys.silo.unripeSettings[unripeToken].balanceOfUnderlying = 0;
+        s.sys.silo.unripeSettings[unripeToken].protectedUnderlying = 0;
+        s.sys.silo.unripeSettings[unripeToken].protectedUnderlyingCustodian = address(0);
     }
 
     function getLegacyLockedUnderlyingBean() public view returns (uint256) {

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -55,6 +55,10 @@ const {
 } = require("./scripts/bips.js");
 const { ebip9, ebip10, ebip11, ebip13, ebip14, ebip15, ebip19, ebip22 } = require("./scripts/ebips.js");
 const { impersonateMockArbitrumSys } = require("./scripts/impersonate.js");
+const {
+  prepareEnrootFacet,
+  prepareProtectedUnderlying
+} = require("./scripts/protectedUnderlying.js");
 
 //////////////////////// UTILITIES ////////////////////////
 
@@ -67,6 +71,43 @@ function getRemappings() {
 }
 
 //////////////////////// TASKS ////////////////////////
+
+task(
+  "prepareProtectedUnderlying",
+  "Preflight and deploy the protected Unripe LP facets, then write Safe-ready Diamond cut calldata"
+)
+  .addParam("amount", "Human-readable Well LP amount to move into protected custody")
+  .addOptionalParam(
+    "custodian",
+    "Safe allowed to restore protected underlying",
+    "0x2B25b6F1c75231E30e89EF670999E2A3B1029CcE"
+  )
+  .addOptionalParam("diamond", "Beanstalk Diamond address", L2_BEANSTALK)
+  .addFlag("confirm", "Deploy contracts after the read-only preflight")
+  .addFlag("fork", "Allow a localhost Arbitrum fork and use its funded deployer signer")
+  .setAction(async (args, hre) =>
+    prepareProtectedUnderlying({ hre, ...args, diamondAddress: args.diamond })
+  );
+
+task(
+  "prepareEnrootFacet",
+  "Deploy only EnrootFacet and append its selectors to an existing Safe-ready Diamond cut"
+)
+  .addParam("base", "Existing protected-underlying Diamond cut JSON")
+  .addOptionalParam("libsilo", "Existing LibSilo deployment")
+  .addOptionalParam("libtokensilo", "Existing LibTokenSilo deployment")
+  .addFlag("confirm", "Deploy EnrootFacet and write the updated Safe transaction")
+  .addFlag("fork", "Allow a localhost Arbitrum fork and use its funded deployer signer")
+  .setAction(async (args, hre) =>
+    prepareEnrootFacet({
+      hre,
+      baseArtifactPath: args.base,
+      libSilo: args.libsilo,
+      libTokenSilo: args.libtokensilo,
+      confirm: args.confirm,
+      fork: args.fork
+    })
+  );
 
 task("ripen")
   .addParam("amount", "The amount of Pods to ripen")

--- a/protocol/scripts/diamond.js
+++ b/protocol/scripts/diamond.js
@@ -632,13 +632,10 @@ async function upgradeWithNewFacets({
           if (linkedLibraries[name].includes(val)) acc[val] = libraries[val];
           return acc;
         }, {});
-        libraryFactory = await ethers.getContractFactory(
-          name,
-          {
-            libraries: linkedLibrary
-          },
-          account
-        );
+        libraryFactory = await ethers.getContractFactory(name, {
+          libraries: linkedLibrary,
+          signer: account
+        });
       } else {
         libraryFactory = await ethers.getContractFactory(name, account);
       }
@@ -664,13 +661,10 @@ async function upgradeWithNewFacets({
         if (facetLibraries[name].includes(val)) acc[val] = libraries[val];
         return acc;
       }, {});
-      facetFactory = await ethers.getContractFactory(
-        name,
-        {
-          libraries: facetLibrary
-        },
-        account
-      );
+      facetFactory = await ethers.getContractFactory(name, {
+        libraries: facetLibrary,
+        signer: account
+      });
     } else facetFactory = await ethers.getContractFactory(name, account);
     undeployed.push([name, facetFactory]);
   }

--- a/protocol/scripts/protectedUnderlying.js
+++ b/protocol/scripts/protectedUnderlying.js
@@ -1,0 +1,406 @@
+const { L2_BEANSTALK } = require("../test/hardhat/utils/constants");
+const { impersonateBeanstalkOwner, mintEth } = require("../utils");
+const { upgradeWithNewFacets } = require("./diamond");
+const fs = require("fs");
+
+const BEGIN_BARN_RAISE_MIGRATION_SELECTOR = "0xe3d4e44c";
+const RFF_SAFE = "0x2B25b6F1c75231E30e89EF670999E2A3B1029CcE";
+const ENROOT_SELECTORS = Object.freeze(["0xe43b44ee", "0x0b58f073", "0x88fcd169"]);
+const ENROOT_LIBRARIES = Object.freeze({
+  LibSilo: "0x7d668415e36e005820b587e77b1d2e99845c136e",
+  LibTokenSilo: "0xdc66303c59a587bbeb08672949fb55612df7200a"
+});
+
+function appendEnrootFacetToArtifact({ baseArtifact, enrootFacet, ethers }) {
+  if (!baseArtifact?.diamondCut?.diamondCut || !Array.isArray(baseArtifact.diamondCut.diamondCut)) {
+    throw new Error("Base artifact does not contain a diamond cut.");
+  }
+  if (!ethers.utils.isAddress(enrootFacet)) {
+    throw new Error("A valid EnrootFacet address is required.");
+  }
+
+  const updated = JSON.parse(JSON.stringify(baseArtifact));
+  const existingSelectors = new Set(
+    updated.diamondCut.diamondCut.flatMap((cut) =>
+      (cut[2] || []).map((selector) => selector.toLowerCase())
+    )
+  );
+  for (const selector of ENROOT_SELECTORS) {
+    if (existingSelectors.has(selector)) {
+      throw new Error(`Enroot selector already exists in base cut: ${selector}`);
+    }
+  }
+
+  updated.diamondCut.diamondCut.push([
+    ethers.utils.getAddress(enrootFacet),
+    1,
+    [...ENROOT_SELECTORS]
+  ]);
+  return updated;
+}
+
+async function prepareEnrootFacet({
+  hre,
+  baseArtifactPath,
+  libSilo = ENROOT_LIBRARIES.LibSilo,
+  libTokenSilo = ENROOT_LIBRARIES.LibTokenSilo,
+  confirm = false,
+  fork = false
+}) {
+  const { ethers } = hre;
+  const network = await ethers.provider.getNetwork();
+  const chainId = Number(network.chainId);
+  if (!fork && chainId !== 42161) {
+    throw new Error(`EnrootFacet deployment requires Arbitrum (42161), got ${chainId}.`);
+  }
+
+  const baseArtifact = JSON.parse(fs.readFileSync(baseArtifactPath, "utf8"));
+  const diamond = ethers.utils.getAddress(
+    baseArtifact.preflight?.diamond || baseArtifact.safeTransaction?.to
+  );
+  const libraries = {
+    LibSilo: ethers.utils.getAddress(libSilo),
+    LibTokenSilo: ethers.utils.getAddress(libTokenSilo)
+  };
+  const [libSiloCode, libTokenSiloCode] = await Promise.all([
+    ethers.provider.getCode(libraries.LibSilo),
+    ethers.provider.getCode(libraries.LibTokenSilo)
+  ]);
+  if (libSiloCode === "0x" || libTokenSiloCode === "0x") {
+    throw new Error("Configured EnrootFacet library address has no deployed code.");
+  }
+
+  const loupe = new ethers.Contract(
+    diamond,
+    ["function facetAddress(bytes4) view returns (address)"],
+    ethers.provider
+  );
+  const currentFacetAddresses = await Promise.all(
+    ENROOT_SELECTORS.map((selector) => loupe.facetAddress(selector))
+  );
+  if (currentFacetAddresses.some((address) => address === ethers.constants.AddressZero)) {
+    throw new Error("An Enroot selector is not currently installed on the Diamond.");
+  }
+  if (currentFacetAddresses[0].toLowerCase() !== currentFacetAddresses[1].toLowerCase()) {
+    throw new Error("Enroot selectors do not currently resolve to the same facet.");
+  }
+
+  const preflight = {
+    chainId,
+    diamond,
+    baseArtifactPath,
+    currentEnrootFacet: ethers.utils.getAddress(currentFacetAddresses[0]),
+    selectors: [...ENROOT_SELECTORS],
+    libraries,
+    deployed: false
+  };
+  console.log("EnrootFacet-only preflight:");
+  console.table(preflight);
+
+  if (!confirm) {
+    console.log("Read-only preflight complete. Re-run with --confirm to deploy EnrootFacet.");
+    return preflight;
+  }
+
+  let account;
+  if (fork) {
+    [account] = await ethers.getSigners();
+  } else {
+    if (!process.env.DIAMOND_DEPLOYER_PK) {
+      throw new Error("DIAMOND_DEPLOYER_PK is required to deploy EnrootFacet.");
+    }
+    account = new ethers.Wallet(process.env.DIAMOND_DEPLOYER_PK, ethers.provider);
+  }
+  const deployer = ethers.utils.getAddress(await account.getAddress());
+  if (
+    baseArtifact.preflight?.deployer &&
+    deployer !== ethers.utils.getAddress(baseArtifact.preflight.deployer)
+  ) {
+    throw new Error("EnrootFacet deployer does not match the base artifact deployer.");
+  }
+
+  const factory = await ethers.getContractFactory("EnrootFacet", {
+    libraries,
+    signer: account
+  });
+  const enrootFacet = await factory.deploy();
+  await enrootFacet.deployed();
+
+  const updated = appendEnrootFacetToArtifact({
+    baseArtifact,
+    enrootFacet: enrootFacet.address,
+    ethers
+  });
+  const diamondCutFacet = await ethers.getContractAt("DiamondCutFacet", diamond);
+  updated.safeTransaction = {
+    to: diamond,
+    value: "0",
+    data: diamondCutFacet.interface.encodeFunctionData("diamondCut", [
+      updated.diamondCut.diamondCut,
+      updated.diamondCut.initFacetAddress,
+      updated.diamondCut.functionCall
+    ]),
+    operation: 0
+  };
+  updated.enrootFacet = {
+    address: ethers.utils.getAddress(enrootFacet.address),
+    deployer,
+    transactionHash: enrootFacet.deployTransaction.hash,
+    selectors: [...ENROOT_SELECTORS],
+    libraries
+  };
+
+  const outputPath = `./diamondCuts/protected-underlying-enroot-${chainId}-${Math.floor(
+    Date.now() / 1000
+  )}.json`;
+  fs.writeFileSync(outputPath, JSON.stringify(updated, null, 2));
+  console.log(`EnrootFacet deployed at ${enrootFacet.address}`);
+  console.log(`Updated Safe-ready Diamond cut written to ${outputPath}`);
+
+  return { ...preflight, deployed: true, deployer, enrootFacet: enrootFacet.address, outputPath };
+}
+
+async function preflightProtectedUnderlying({
+  hre,
+  amount,
+  custodian = RFF_SAFE,
+  diamondAddress = L2_BEANSTALK,
+  fork = false
+}) {
+  const { ethers } = hre;
+  const network = await ethers.provider.getNetwork();
+  const chainId = Number(network.chainId);
+
+  if (!fork && chainId !== 42161) {
+    throw new Error(`Protected underlying deployment requires Arbitrum (42161), got ${chainId}.`);
+  }
+  if (!ethers.utils.isAddress(diamondAddress)) {
+    throw new Error("A valid Beanstalk Diamond address is required.");
+  }
+  if (!ethers.utils.isAddress(custodian) || custodian === ethers.constants.AddressZero) {
+    throw new Error("A non-zero protected custodian address is required.");
+  }
+
+  const diamond = ethers.utils.getAddress(diamondAddress);
+  const protectedCustodian = ethers.utils.getAddress(custodian);
+  const beanstalk = new ethers.Contract(
+    diamond,
+    [
+      "function owner() view returns (address)",
+      "function getBeanstalkTokens() view returns (tuple(address bean,address fertilizer,address urBean,address urLp))",
+      "function getUnderlyingToken(address) view returns (address)",
+      "function getTotalUnderlying(address) view returns (uint256)"
+    ],
+    ethers.provider
+  );
+
+  const unripeLp = (await beanstalk.getBeanstalkTokens()).urLp;
+  const diamondOwner = await beanstalk.owner();
+  const underlyingToken = ethers.utils.getAddress(await beanstalk.getUnderlyingToken(unripeLp));
+  const underlying = new ethers.Contract(
+    underlyingToken,
+    ["function decimals() view returns (uint8)"],
+    ethers.provider
+  );
+  const [decimals, currentLocalUnderlying] = await Promise.all([
+    underlying.decimals(),
+    beanstalk.getTotalUnderlying(unripeLp)
+  ]);
+  const protectedAmount = ethers.utils.parseUnits(amount, decimals);
+
+  if (protectedAmount.isZero()) {
+    throw new Error("Protected underlying amount must be greater than zero.");
+  }
+  if (protectedAmount.gt(currentLocalUnderlying)) {
+    throw new Error("Protected underlying amount exceeds current local backing.");
+  }
+
+  const custodianCode = await ethers.provider.getCode(protectedCustodian);
+  if (custodianCode === "0x") {
+    throw new Error("Protected custodian is not a deployed contract.");
+  }
+  const safe = new ethers.Contract(
+    protectedCustodian,
+    ["function getThreshold() view returns (uint256)"],
+    ethers.provider
+  );
+  const safeThreshold = (await safe.getThreshold()).toString();
+
+  return {
+    chainId,
+    diamond,
+    diamondOwner: ethers.utils.getAddress(diamondOwner),
+    custodian: protectedCustodian,
+    safeThreshold,
+    unripeLp: ethers.utils.getAddress(unripeLp),
+    underlyingToken,
+    underlyingDecimals: Number(decimals),
+    currentLocalUnderlying: currentLocalUnderlying.toString(),
+    protectedAmount: protectedAmount.toString(),
+    remainingLocalUnderlying: currentLocalUnderlying.sub(protectedAmount).toString(),
+    currentLocalFormatted: ethers.utils.formatUnits(currentLocalUnderlying, decimals),
+    protectedFormatted: ethers.utils.formatUnits(protectedAmount, decimals),
+    remainingLocalFormatted: ethers.utils.formatUnits(
+      currentLocalUnderlying.sub(protectedAmount),
+      decimals
+    ),
+    deployed: false
+  };
+}
+
+async function prepareProtectedUnderlying({ hre, confirm = false, ...args }) {
+  const preflight = await preflightProtectedUnderlying({ hre, ...args });
+  console.log("Protected underlying preflight:");
+  console.table({
+    network: preflight.chainId,
+    diamond: preflight.diamond,
+    diamondOwner: preflight.diamondOwner,
+    custodian: preflight.custodian,
+    safeThreshold: preflight.safeThreshold,
+    underlyingToken: preflight.underlyingToken,
+    currentLocal: preflight.currentLocalFormatted,
+    protecting: preflight.protectedFormatted,
+    remainingLocal: preflight.remainingLocalFormatted
+  });
+
+  if (!confirm) {
+    console.log("Read-only preflight complete. Re-run with --confirm to deploy contracts.");
+    return preflight;
+  }
+
+  let account;
+  if (args.fork) {
+    [account] = await hre.ethers.getSigners();
+  } else {
+    if (!process.env.DIAMOND_DEPLOYER_PK) {
+      throw new Error("DIAMOND_DEPLOYER_PK is required to deploy contracts.");
+    }
+    account = new hre.ethers.Wallet(process.env.DIAMOND_DEPLOYER_PK, hre.ethers.provider);
+  }
+
+  const dc = await upgradeProtectedUnderlying({
+    RFF: preflight.custodian,
+    amount: preflight.protectedAmount,
+    diamondAddress: preflight.diamond,
+    account,
+    execute: false,
+    verbose: true
+  });
+  const diamondCutFacet = await hre.ethers.getContractAt(
+    "DiamondCutFacet",
+    preflight.diamond
+  );
+  const encoded = diamondCutFacet.interface.encodeFunctionData("diamondCut", [
+    dc.diamondCut,
+    dc.initFacetAddress,
+    dc.functionCall
+  ]);
+  const output = {
+    preflight: { ...preflight, deployed: true, deployer: await account.getAddress() },
+    diamondCut: dc,
+    safeTransaction: {
+      to: preflight.diamond,
+      value: "0",
+      data: encoded,
+      operation: 0
+    }
+  };
+  const outputPath = `./diamondCuts/protected-underlying-${preflight.chainId}-${Math.floor(
+    Date.now() / 1000
+  )}.json`;
+  fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
+  console.log(`Safe-ready Diamond cut written to ${outputPath}`);
+
+  return { ...preflight, deployed: true, outputPath, diamondCut: dc, encoded };
+}
+
+/**
+ * Builds or executes the diamond cut that moves Unripe LP backing into RFF custody.
+ * By default the cut is generated as an object and is not executed.
+ */
+async function upgradeProtectedUnderlying({
+  RFF,
+  amount,
+  diamondAddress = L2_BEANSTALK,
+  account,
+  execute = false,
+  verbose = true
+}) {
+  if (!ethers.utils.isAddress(RFF) || RFF === ethers.constants.AddressZero) {
+    throw new Error("A non-zero RFF address is required.");
+  }
+
+  const protectedAmount = ethers.BigNumber.from(amount);
+  if (protectedAmount.isZero()) {
+    throw new Error("A non-zero protected underlying amount is required.");
+  }
+
+  if (account === undefined) {
+    account = await impersonateBeanstalkOwner(diamondAddress);
+    await mintEth(account.address);
+  }
+
+  return upgradeWithNewFacets({
+    diamondAddress,
+    facetNames: [
+      "UnripeFacet",
+      "EnrootFacet",
+      "BDVFacet",
+      "ConvertFacet",
+      "SeasonFacet",
+      "SeasonGettersFacet",
+      "GaugeGettersFacet"
+    ],
+    libraryNames: [
+      "LibLockedUnderlying",
+      "LibEvaluate",
+      "LibPipelineConvert",
+      "LibConvert",
+      "LibSilo",
+      "LibTokenSilo",
+      "LibGauge",
+      "LibIncentive",
+      "LibShipping",
+      "LibFlood",
+      "LibGerminate",
+      "LibWellMinting"
+    ],
+    facetLibraries: {
+      UnripeFacet: ["LibLockedUnderlying"],
+      EnrootFacet: ["LibSilo", "LibTokenSilo"],
+      ConvertFacet: ["LibPipelineConvert", "LibConvert", "LibSilo", "LibTokenSilo"],
+      SeasonFacet: [
+        "LibEvaluate",
+        "LibGauge",
+        "LibIncentive",
+        "LibShipping",
+        "LibFlood",
+        "LibGerminate",
+        "LibWellMinting"
+      ],
+      SeasonGettersFacet: ["LibLockedUnderlying", "LibWellMinting"],
+      GaugeGettersFacet: ["LibLockedUnderlying"]
+    },
+    linkedLibraries: {
+      LibEvaluate: ["LibLockedUnderlying"]
+    },
+    selectorsToRemove: [BEGIN_BARN_RAISE_MIGRATION_SELECTOR],
+    initFacetName: "InitProtectedUnderlying",
+    initArgs: [RFF, protectedAmount],
+    bip: false,
+    object: !execute,
+    verbose,
+    account,
+    reportGas: false
+  });
+}
+
+exports.BEGIN_BARN_RAISE_MIGRATION_SELECTOR = BEGIN_BARN_RAISE_MIGRATION_SELECTOR;
+exports.ENROOT_SELECTORS = ENROOT_SELECTORS;
+exports.ENROOT_LIBRARIES = ENROOT_LIBRARIES;
+exports.RFF_SAFE = RFF_SAFE;
+exports.appendEnrootFacetToArtifact = appendEnrootFacetToArtifact;
+exports.prepareEnrootFacet = prepareEnrootFacet;
+exports.preflightProtectedUnderlying = preflightProtectedUnderlying;
+exports.prepareProtectedUnderlying = prepareProtectedUnderlying;
+exports.upgradeProtectedUnderlying = upgradeProtectedUnderlying;

--- a/protocol/test/foundry/ProtectedUnderlying.t.sol
+++ b/protocol/test/foundry/ProtectedUnderlying.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {TestHelper, MockToken} from "test/foundry/utils/TestHelper.sol";
+import {InitProtectedUnderlying} from "contracts/beanstalk/init/InitProtectedUnderlying.sol";
+import {UnripeFacet} from "contracts/beanstalk/barn/UnripeFacet.sol";
+import {IDiamondCut} from "contracts/interfaces/IDiamondCut.sol";
+
+contract ProtectedUnderlyingTest is TestHelper {
+    UnripeFacet internal unripeFacet = UnripeFacet(BEANSTALK);
+    address internal underlyingLp;
+    uint256 internal localUnderlying;
+    uint256 internal protectedUnderlying;
+
+    function setUp() public {
+        initializeBeanstalkTestState(true, false);
+
+        vm.startPrank(users[0]);
+        MockToken(UNRIPE_LP).mint(users[0], 20_000_000e6);
+        underlyingLp = bs.getUnderlyingToken(UNRIPE_LP);
+        localUnderlying = addLiquidityToWell(underlyingLp, 2_000_000e6, 20_000 ether);
+        MockToken(underlyingLp).approve(BEANSTALK, type(uint256).max);
+        bs.addUnderlying(UNRIPE_LP, localUnderlying);
+        vm.stopPrank();
+
+        protectedUnderlying = (localUnderlying * 9) / 10;
+    }
+
+    function test_InitMovesBackingWithoutChangingClaimsOrLockedBeans() public {
+        uint256 lockedBeansBefore = bs.getLockedBeansUnderlyingUnripeLP();
+        uint256 holderUnderlyingBefore = bs.getUnderlying(UNRIPE_LP, 1e6);
+        uint256 holderBdvBefore = bs.unripeLPToBDV(1e6);
+        uint256 custodianBalanceBefore = MockToken(underlyingLp).balanceOf(users[1]);
+
+        _protectUnderlying(protectedUnderlying);
+
+        assertEq(unripeFacet.getProtectedUnderlying(UNRIPE_LP), protectedUnderlying);
+        assertEq(bs.getTotalUnderlying(UNRIPE_LP), localUnderlying);
+        assertEq(MockToken(underlyingLp).balanceOf(BEANSTALK), localUnderlying - protectedUnderlying);
+        assertEq(MockToken(underlyingLp).balanceOf(users[1]), custodianBalanceBefore + protectedUnderlying);
+        assertEq(unripeFacet.getProtectedUnderlyingCustodian(UNRIPE_LP), users[1]);
+        assertEq(bs.getLockedBeansUnderlyingUnripeLP(), lockedBeansBefore);
+        assertEq(bs.getUnderlying(UNRIPE_LP, 1e6), holderUnderlyingBefore);
+        assertEq(bs.unripeLPToBDV(1e6), holderBdvBefore);
+    }
+
+    function test_RestoreMovesBackingToLocalWithoutChangingTotal() public {
+        _protectUnderlying(protectedUnderlying);
+        uint256 restoreAmount = protectedUnderlying / 3;
+
+        vm.startPrank(users[1]);
+        MockToken(underlyingLp).approve(BEANSTALK, restoreAmount);
+        unripeFacet.restoreProtectedUnderlying(restoreAmount);
+        vm.stopPrank();
+
+        assertEq(unripeFacet.getProtectedUnderlying(UNRIPE_LP), protectedUnderlying - restoreAmount);
+        assertEq(bs.getTotalUnderlying(UNRIPE_LP), localUnderlying);
+        assertEq(MockToken(underlyingLp).balanceOf(BEANSTALK), localUnderlying - protectedUnderlying + restoreAmount);
+    }
+
+    function test_RestoreRejectsDiamondOwnerWhenOwnerIsNotCustodian() public {
+        _protectUnderlying(protectedUnderlying);
+
+        vm.prank(users[0]);
+        vm.expectRevert("Unripe: Not protected custodian");
+        unripeFacet.restoreProtectedUnderlying(1);
+    }
+
+    function test_RestoreRejectsOtherNonCustodian() public {
+        _protectUnderlying(protectedUnderlying);
+
+        vm.prank(users[2]);
+        vm.expectRevert("Unripe: Not protected custodian");
+        unripeFacet.restoreProtectedUnderlying(1);
+    }
+
+    function test_InitRejectsCustodianReplacement() public {
+        _protectUnderlying(protectedUnderlying);
+        InitProtectedUnderlying init = new InitProtectedUnderlying();
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](0);
+
+        vm.prank(users[0]);
+        vm.expectRevert("Init: Protected custodian mismatch");
+        IDiamondCut(BEANSTALK)
+            .diamondCut(cut, address(init), abi.encodeCall(init.init, (users[2], 1)));
+    }
+
+    function test_InitRejectsMoreThanLocalBacking() public {
+        InitProtectedUnderlying init = new InitProtectedUnderlying();
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](0);
+
+        vm.prank(users[0]);
+        vm.expectRevert("Init: Insufficient local underlying");
+        IDiamondCut(BEANSTALK)
+            .diamondCut(cut, address(init), abi.encodeCall(init.init, (users[0], localUnderlying + 1)));
+    }
+
+    function testFuzz_ChopValueDependsOnTotalBackingNotCustodySplit(
+        uint256 rawProtectedAmount,
+        uint256 rawChopAmount,
+        uint16 rawRecapBps
+    ) public {
+        uint256 supply = MockToken(UNRIPE_LP).totalSupply();
+        uint256 chopAmount = bound(rawChopAmount, supply / 1_000, supply / 2);
+        uint256 recapBps = bound(uint256(rawRecapBps), 1, 10_000);
+        uint256 totalRecapDollarsNeeded = bs.getTotalRecapDollarsNeeded();
+
+        bs.setPenaltyParams((totalRecapDollarsNeeded * recapBps) / 10_000, 0);
+
+        vm.prank(users[0]);
+        MockToken(UNRIPE_LP).approve(BEANSTALK, type(uint256).max);
+
+        uint256 quoteBefore = bs.getPenalizedUnderlying(UNRIPE_LP, chopAmount);
+        uint256 protectedAmount = bound(rawProtectedAmount, 1, localUnderlying - quoteBefore);
+
+        uint256 snapshot = vm.snapshot();
+        uint256 balanceBefore = MockToken(underlyingLp).balanceOf(users[0]);
+        vm.prank(users[0]);
+        uint256 payoutBefore = bs.chop(UNRIPE_LP, chopAmount, 0, 0);
+        assertEq(payoutBefore, quoteBefore);
+        assertEq(MockToken(underlyingLp).balanceOf(users[0]) - balanceBefore, quoteBefore);
+        vm.revertTo(snapshot);
+
+        _protectUnderlying(protectedAmount);
+
+        uint256 quoteAfter = bs.getPenalizedUnderlying(UNRIPE_LP, chopAmount);
+        assertEq(quoteAfter, quoteBefore);
+
+        balanceBefore = MockToken(underlyingLp).balanceOf(users[0]);
+        vm.prank(users[0]);
+        uint256 payoutAfter = bs.chop(UNRIPE_LP, chopAmount, 0, 0);
+        assertEq(payoutAfter, quoteBefore);
+        assertEq(MockToken(underlyingLp).balanceOf(users[0]) - balanceBefore, quoteBefore);
+    }
+
+    function _protectUnderlying(uint256 amount) internal {
+        InitProtectedUnderlying init = new InitProtectedUnderlying();
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](0);
+
+        vm.prank(users[0]);
+        IDiamondCut(BEANSTALK).diamondCut(cut, address(init), abi.encodeCall(init.init, (users[1], amount)));
+    }
+}

--- a/protocol/test/hardhat/SiloEnroot.test.js
+++ b/protocol/test/hardhat/SiloEnroot.test.js
@@ -117,6 +117,108 @@ describe("Silo Enroot", function () {
       );
     });
 
+    describe("batch validation", async function () {
+      beforeEach(async function () {
+        await mockBeanstalk.deployStemsUpgrade();
+        await mockBeanstalk
+          .connect(owner)
+          .addUnderlying(UNRIPE_BEAN, to6("5000").sub(to6("10000").mul(toBN(pru)).div(to18("1"))));
+
+        this.stem0 = "-2000000";
+        this.stem1 = "0";
+        await mockBeanstalk
+          .connect(user)
+          .depositAtStemAndBdv(UNRIPE_BEAN, to6("5"), this.stem0, "927823", 0);
+        await mockBeanstalk
+          .connect(user)
+          .depositAtStemAndBdv(UNRIPE_BEAN, to6("5"), this.stem1, "927823", 0);
+
+        await mockBeanstalk.setStalkAndRoots(
+          user.address,
+          "18558315646000000",
+          "18558315646000000000000000000"
+        );
+      });
+
+      it("rejects mismatched stems and amounts", async function () {
+        await expect(
+          beanstalk
+            .connect(user)
+            .enrootDeposits(UNRIPE_BEAN, [this.stem0, this.stem1], [to6("5")])
+        ).to.be.revertedWith("Silo: Crates, amounts are diff lengths.");
+      });
+
+      it("rejects a zero-amount row", async function () {
+        await expect(
+          beanstalk
+            .connect(user)
+            .enrootDeposits(UNRIPE_BEAN, [this.stem0, this.stem1], [to6("5"), 0])
+        ).to.be.revertedWith("Silo: Enroot amount is zero.");
+      });
+
+      it("rejects a zero-amount row before later row validation", async function () {
+        await expect(
+          beanstalk
+            .connect(user)
+            .enrootDeposits(
+              UNRIPE_BEAN,
+              [this.stem0, this.stem0, "-1000000"],
+              [1, to6("5").sub(1), 0]
+            )
+        ).to.be.revertedWith("Silo: Enroot amount is zero.");
+      });
+
+      it("rejects a phantom row without a positive deposit", async function () {
+        const phantomStem = "-1000000";
+        await mockBeanstalk
+          .connect(user)
+          .depositAtStemAndBdv(UNRIPE_BEAN, 0, phantomStem, 1, 0);
+
+        await expect(
+          beanstalk.connect(user).enrootDeposits(UNRIPE_BEAN, [phantomStem], [1])
+        ).to.be.revertedWith("Silo: Enroot deposit does not exist.");
+      });
+
+      it("rejects duplicate stems", async function () {
+        await expect(
+          beanstalk
+            .connect(user)
+            .enrootDeposits(UNRIPE_BEAN, [this.stem0, this.stem0], [to6("2"), to6("2")])
+        ).to.be.revertedWith("Silo: Enroot duplicate stem.");
+      });
+
+      it("rejects a stem above the stem tip", async function () {
+        const stemTip = await beanstalk.stemTipForToken(UNRIPE_BEAN);
+        const futureStem = stemTip.add(1);
+        await mockBeanstalk
+          .connect(user)
+          .depositAtStemAndBdv(UNRIPE_BEAN, to6("1"), futureStem, "185564", 0);
+
+        await expect(
+          beanstalk.connect(user).enrootDeposits(UNRIPE_BEAN, [futureStem], [to6("1")])
+        ).to.be.revertedWith("Silo: Enroot stem exceeds tip.");
+      });
+
+      it("enroots valid unique positive rows", async function () {
+        await expect(
+          beanstalk
+            .connect(user)
+            .enrootDeposits(
+              UNRIPE_BEAN,
+              [this.stem0, this.stem1],
+              [to6("5"), to6("5")]
+            )
+        ).to.not.be.reverted;
+
+        expect((await beanstalk.getDeposit(user.address, UNRIPE_BEAN, this.stem0))[0]).to.eq(
+          to6("5")
+        );
+        expect((await beanstalk.getDeposit(user.address, UNRIPE_BEAN, this.stem1))[0]).to.eq(
+          to6("5")
+        );
+      });
+    });
+
     describe("1 deposit, some", async function () {
       beforeEach(async function () {
         await mockBeanstalk.deployStemsUpgrade();

--- a/protocol/test/hardhat/Unripe.test.js
+++ b/protocol/test/hardhat/Unripe.test.js
@@ -1,10 +1,19 @@
 const { expect } = require("chai");
+const fs = require("fs");
+const hre = require("hardhat");
 const { EXTERNAL, INTERNAL, INTERNAL_TOLERANT } = require("./utils/balances.js");
 const { deploy } = require("../../scripts/deploy.js");
 const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot");
 const { BEAN, UNRIPE_BEAN, UNRIPE_LP, USDT, ZERO_BYTES } = require("./utils/constants");
 const { to6 } = require("./utils/helpers.js");
 const { getAllBeanstalkContracts } = require("../../utils/contracts");
+const {
+  BEGIN_BARN_RAISE_MIGRATION_SELECTOR,
+  ENROOT_SELECTORS,
+  appendEnrootFacetToArtifact,
+  prepareProtectedUnderlying,
+  upgradeProtectedUnderlying
+} = require("../../scripts/protectedUnderlying");
 
 let user, user2, owner;
 let userAddress, ownerAddress, user2Address;
@@ -13,6 +22,7 @@ describe("Unripe", function () {
   before(async function () {
     [owner, user, user2] = await ethers.getSigners();
     userAddress = await user.address;
+    user2Address = await user2.address;
 
     const contracts = await deploy((verbose = false), (mock = true), (reset = true));
     ownerAddress = contracts.account;
@@ -60,6 +70,289 @@ describe("Unripe", function () {
     expect(await mockBeanstalk.getPenalizedUnderlying(UNRIPE_BEAN, to6("1"))).to.be.equal("0");
     expect(await mockBeanstalk.getUnderlying(UNRIPE_BEAN, to6("1"))).to.be.equal("0");
     expect(await mockBeanstalk.balanceOfUnderlying(UNRIPE_BEAN, userAddress)).to.be.equal("0");
+  });
+
+  it("executes the protected backing diamond cut", async function () {
+    await this.unripeLP.mint(userAddress, to6("100"));
+    await mockBeanstalk.connect(owner).addUnderlying(UNRIPE_LP, to6("100"));
+
+    await upgradeProtectedUnderlying({
+      RFF: ownerAddress,
+      amount: to6("90"),
+      diamondAddress: this.diamond.address,
+      account: owner,
+      execute: true,
+      verbose: false
+    });
+
+    const unripeFacet = await ethers.getContractAt("UnripeFacet", this.diamond.address);
+    expect(await unripeFacet.getProtectedUnderlying(UNRIPE_LP)).to.equal(to6("90"));
+    expect(await unripeFacet.getTotalUnderlying(UNRIPE_LP)).to.equal(to6("100"));
+
+    const migrationCall = ethers.utils.hexConcat([
+      BEGIN_BARN_RAISE_MIGRATION_SELECTOR,
+      ethers.utils.defaultAbiCoder.encode(["address"], [BEAN])
+    ]);
+    await expect(
+      owner.sendTransaction({ to: this.diamond.address, data: migrationCall })
+    ).to.be.revertedWith("Diamond: Function does not exist");
+  });
+
+  it("threads the RFF custodian into generated initializer calldata", async function () {
+    await this.unripeLP.mint(userAddress, to6("100"));
+    await mockBeanstalk.connect(owner).addUnderlying(UNRIPE_LP, to6("100"));
+    await network.provider.send("hardhat_setCode", [
+      user2Address,
+      "0x600260005260206000f3"
+    ]);
+
+    let prepared;
+    try {
+      prepared = await prepareProtectedUnderlying({
+        hre,
+        amount: "90",
+        custodian: user2Address,
+        diamondAddress: this.diamond.address,
+        fork: true,
+        confirm: true
+      });
+
+      const initFactory = await ethers.getContractFactory("InitProtectedUnderlying");
+      const [recipient, amount] = initFactory.interface.decodeFunctionData(
+        "init",
+        prepared.diamondCut.functionCall
+      );
+      expect(recipient).to.equal(user2Address);
+      expect(amount).to.equal(to6("90"));
+    } finally {
+      if (prepared?.outputPath && fs.existsSync(prepared.outputPath)) {
+        fs.unlinkSync(prepared.outputPath);
+      }
+    }
+  });
+
+  it("appends an isolated EnrootFacet replacement to an existing Safe artifact", async function () {
+    const existingFacet = ethers.Wallet.createRandom().address;
+    const enrootFacet = ethers.Wallet.createRandom().address;
+    const baseArtifact = {
+      preflight: { chainId: 42161, diamond: this.diamond.address },
+      diamondCut: {
+        diamondCut: [[existingFacet, 1, ["0x12345678"]]],
+        initFacetAddress: ownerAddress,
+        functionCall: "0xabcdef"
+      },
+      safeTransaction: { to: this.diamond.address, value: "0", data: "0x", operation: 0 }
+    };
+
+    const updated = appendEnrootFacetToArtifact({
+      baseArtifact,
+      enrootFacet,
+      ethers
+    });
+
+    expect(ENROOT_SELECTORS).to.deep.equal(["0xe43b44ee", "0x0b58f073", "0x88fcd169"]);
+    expect(baseArtifact.diamondCut.diamondCut).to.have.length(1);
+    expect(updated.diamondCut.diamondCut).to.deep.equal([
+      [existingFacet, 1, ["0x12345678"]],
+      [ethers.utils.getAddress(enrootFacet), 1, ENROOT_SELECTORS]
+    ]);
+    expect(updated.diamondCut.initFacetAddress).to.equal(ownerAddress);
+    expect(updated.diamondCut.functionCall).to.equal("0xabcdef");
+  });
+
+  it("rejects an Enroot selector already present in the base cut", async function () {
+    const facet = ethers.Wallet.createRandom().address;
+    const baseArtifact = {
+      preflight: { chainId: 42161, diamond: this.diamond.address },
+      diamondCut: {
+        diamondCut: [[facet, 1, [ENROOT_SELECTORS[0]]]],
+        initFacetAddress: ethers.constants.AddressZero,
+        functionCall: "0x"
+      }
+    };
+
+    expect(() =>
+      appendEnrootFacetToArtifact({ baseArtifact, enrootFacet: facet, ethers })
+    ).to.throw("Enroot selector already exists in base cut");
+  });
+
+  describe("protected Unripe LP backing", function () {
+    const totalUnderlying = to6("100");
+    const protectedUnderlying = to6("90");
+
+    beforeEach(async function () {
+      await this.unripeLP.mint(userAddress, to6("100"));
+      await mockBeanstalk.connect(owner).addUnderlying(UNRIPE_LP, totalUnderlying);
+
+      const totalRecapDollarsNeeded = await mockBeanstalk.getTotalRecapDollarsNeeded();
+      await mockBeanstalk.connect(owner).setPenaltyParams(totalRecapDollarsNeeded, 0);
+
+      const initFactory = await ethers.getContractFactory("InitProtectedUnderlying");
+      this.initProtectedUnderlying = await initFactory.deploy();
+      await this.initProtectedUnderlying.deployed();
+
+      const diamondCut = await ethers.getContractAt("DiamondCutFacet", this.diamond.address);
+      const initData = this.initProtectedUnderlying.interface.encodeFunctionData("init", [
+        user2Address,
+        protectedUnderlying
+      ]);
+      await diamondCut
+        .connect(owner)
+        .diamondCut([], this.initProtectedUnderlying.address, initData);
+
+      this.unripeFacet = await ethers.getContractAt("UnripeFacet", this.diamond.address);
+    });
+
+    it("moves LP to protected custody without changing holder claims", async function () {
+      expect(await this.unripeFacet.getProtectedUnderlying(UNRIPE_LP)).to.equal(
+        protectedUnderlying
+      );
+      expect(await mockBeanstalk.getTotalUnderlying(UNRIPE_LP)).to.equal(totalUnderlying);
+      expect(await mockBeanstalk.getUnderlying(UNRIPE_LP, to6("100"))).to.equal(
+        totalUnderlying
+      );
+      expect(await mockBeanstalk.getUnderlyingPerUnripeToken(UNRIPE_LP)).to.equal(to6("1"));
+      expect(await this.bean.balanceOf(this.diamond.address)).to.equal(to6("10"));
+    });
+
+    it("records the configured protected custodian", async function () {
+      const custodianReader = await ethers.getContractAt(
+        ["function getProtectedUnderlyingCustodian(address) view returns (address)"],
+        this.diamond.address
+      );
+
+      expect(await custodianReader.getProtectedUnderlyingCustodian(UNRIPE_LP)).to.equal(
+        user2Address
+      );
+    });
+
+    it("does not allow a later initializer call to replace the protected custodian", async function () {
+      const diamondCut = await ethers.getContractAt("DiamondCutFacet", this.diamond.address);
+      const initData = this.initProtectedUnderlying.interface.encodeFunctionData("init", [
+        userAddress,
+        to6("1")
+      ]);
+
+      await expect(
+        diamondCut.connect(owner).diamondCut([], this.initProtectedUnderlying.address, initData)
+      ).to.be.reverted;
+      expect(await this.unripeFacet.getProtectedUnderlyingCustodian(UNRIPE_LP)).to.equal(
+        user2Address
+      );
+    });
+
+    it("uses local backing for execution and total backing for chop math", async function () {
+      await mockBeanstalk.connect(user).chop(UNRIPE_LP, to6("5"), EXTERNAL, EXTERNAL);
+
+      expect(await this.bean.balanceOf(userAddress)).to.equal(to6("5"));
+      expect(await this.bean.balanceOf(this.diamond.address)).to.equal(to6("5"));
+      expect(await this.unripeFacet.getProtectedUnderlying(UNRIPE_LP)).to.equal(
+        protectedUnderlying
+      );
+      expect(await mockBeanstalk.getTotalUnderlying(UNRIPE_LP)).to.equal(to6("95"));
+    });
+
+    it("keeps the chop quote and payout constant across local and protected splits", async function () {
+      await this.bean.connect(user2).approve(this.diamond.address, protectedUnderlying);
+      await this.unripeFacet.connect(user2).restoreProtectedUnderlying(protectedUnderlying);
+
+      const totalRecapDollarsNeeded = await mockBeanstalk.getTotalRecapDollarsNeeded();
+      await mockBeanstalk
+        .connect(owner)
+        .setPenaltyParams(totalRecapDollarsNeeded.div(2), 0);
+
+      const chopAmount = to6("10");
+      const splits = [to6("0"), to6("50"), to6("90")];
+      let expectedQuote;
+      let expectedPayout;
+
+      for (const amountProtected of splits) {
+        const splitSnapshotId = await takeSnapshot();
+
+        if (!amountProtected.isZero()) {
+          const diamondCut = await ethers.getContractAt(
+            "DiamondCutFacet",
+            this.diamond.address
+          );
+          const initData = this.initProtectedUnderlying.interface.encodeFunctionData("init", [
+            user2Address,
+            amountProtected
+          ]);
+          await diamondCut
+            .connect(owner)
+            .diamondCut([], this.initProtectedUnderlying.address, initData);
+        }
+
+        const quote = await mockBeanstalk.getPenalizedUnderlying(UNRIPE_LP, chopAmount);
+        const balanceBefore = await this.bean.balanceOf(userAddress);
+        await mockBeanstalk.connect(user).chop(UNRIPE_LP, chopAmount, EXTERNAL, EXTERNAL);
+        const payout = (await this.bean.balanceOf(userAddress)).sub(balanceBefore);
+
+        if (expectedQuote === undefined) {
+          expectedQuote = quote;
+          expectedPayout = payout;
+        } else {
+          expect(quote).to.equal(expectedQuote);
+          expect(payout).to.equal(expectedPayout);
+        }
+        expect(payout).to.equal(quote);
+
+        await revertToSnapshot(splitSnapshotId);
+      }
+    });
+
+    it("reduces recapitalization against total backing instead of only local backing", async function () {
+      const totalRecapDollarsNeeded = await mockBeanstalk.getTotalRecapDollarsNeeded();
+      const recapitalizedBefore = totalRecapDollarsNeeded.div(2);
+      await mockBeanstalk.connect(owner).setPenaltyParams(recapitalizedBefore, 0);
+
+      const expectedPayout = to6("5");
+      const expectedRecapReduction = expectedPayout
+        .mul(recapitalizedBefore)
+        .div(totalUnderlying);
+
+      await mockBeanstalk.connect(user).chop(UNRIPE_LP, to6("10"), EXTERNAL, EXTERNAL);
+
+      expect(await this.bean.balanceOf(userAddress)).to.equal(expectedPayout);
+      expect(await mockBeanstalk.getRecapitalized()).to.equal(
+        recapitalizedBefore.sub(expectedRecapReduction)
+      );
+      expect(await mockBeanstalk.getTotalUnderlying(UNRIPE_LP)).to.equal(to6("95"));
+    });
+
+    it("rejects a chop that exceeds local executable backing", async function () {
+      await expect(
+        mockBeanstalk.connect(user).chop(UNRIPE_LP, to6("11"), EXTERNAL, EXTERNAL)
+      ).to.be.revertedWith("Unripe: Insufficient local underlying");
+    });
+
+    it("restores protected LP to local backing before a larger chop", async function () {
+      await this.bean.connect(user2).approve(this.diamond.address, to6("20"));
+      await this.unripeFacet.connect(user2).restoreProtectedUnderlying(to6("20"));
+
+      expect(await this.unripeFacet.getProtectedUnderlying(UNRIPE_LP)).to.equal(to6("70"));
+      expect(await mockBeanstalk.getTotalUnderlying(UNRIPE_LP)).to.equal(totalUnderlying);
+      expect(await this.bean.balanceOf(this.diamond.address)).to.equal(to6("30"));
+
+      await mockBeanstalk.connect(user).chop(UNRIPE_LP, to6("30"), EXTERNAL, EXTERNAL);
+
+      expect(await this.bean.balanceOf(userAddress)).to.equal(to6("30"));
+      expect(await this.bean.balanceOf(this.diamond.address)).to.equal(0);
+      expect(await this.unripeFacet.getProtectedUnderlying(UNRIPE_LP)).to.equal(to6("70"));
+      expect(await mockBeanstalk.getTotalUnderlying(UNRIPE_LP)).to.equal(to6("70"));
+    });
+
+    it("rejects restoration by the Diamond owner when the owner is not the custodian", async function () {
+      await expect(
+        this.unripeFacet.connect(owner).restoreProtectedUnderlying(to6("1"))
+      ).to.be.revertedWith("Unripe: Not protected custodian");
+    });
+
+    it("rejects restoration by any other non-custodian", async function () {
+      await expect(
+        this.unripeFacet.connect(user).restoreProtectedUnderlying(to6("1"))
+      ).to.be.revertedWith("Unripe: Not protected custodian");
+    });
   });
 
   describe("deposit underlying", async function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2334,10 +2334,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bytecodealliance/preview2-shim@npm:^0.17.2":
-  version: 0.17.8
-  resolution: "@bytecodealliance/preview2-shim@npm:0.17.8"
-  checksum: 10/a528da2a4412847a70ae4c1e420393f30e48b3b39b87ed718490d85bc49063ee78343b710eaa99d6ba9943749f408109d339b8c95aba282467c39a44d3789e24
+"@bytecodealliance/preview2-shim@npm:^0.19.0":
+  version: 0.19.0
+  resolution: "@bytecodealliance/preview2-shim@npm:0.19.0"
+  checksum: 10/f6b9392acd415158ff307af6f0ee0cd58a19567791ae0ab5b1610e2f13ca84b681dbd93811f58efbdd002de0fb059dc92b7fe632dd6e8e6658f07cec2455de9b
   languageName: node
   linkType: hard
 
@@ -7873,12 +7873,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/slang@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@nomicfoundation/slang@npm:1.3.1"
+"@nomicfoundation/slang@npm:1.3.8":
+  version: 1.3.8
+  resolution: "@nomicfoundation/slang@npm:1.3.8"
   dependencies:
-    "@bytecodealliance/preview2-shim": "npm:^0.17.2"
-  checksum: 10/c05e6fbb031616a7c59dfb6d318be139dcd5c3d5391a9d79aa5e9fd04db414727c9ddc4b45b6e0134f154f1d7bde350a99b31611b6513b76bb1099780613eb20
+    "@bytecodealliance/preview2-shim": "npm:^0.19.0"
+  checksum: 10/08a7cbf8f6d12e9b460bea4c7c5def93f7b63d7da41dfa776730ebeb46906e500d8195cece58795042ade2f166439e42d41ac1f23aa3d04dc49268c8e4978044
   languageName: node
   linkType: hard
 
@@ -33935,16 +33935,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-plugin-solidity@npm:2.2.1":
-  version: 2.2.1
-  resolution: "prettier-plugin-solidity@npm:2.2.1"
+"prettier-plugin-solidity@npm:2.4.1":
+  version: 2.4.1
+  resolution: "prettier-plugin-solidity@npm:2.4.1"
   dependencies:
-    "@nomicfoundation/slang": "npm:1.3.1"
+    "@nomicfoundation/slang": "npm:1.3.8"
     "@solidity-parser/parser": "npm:^0.20.2"
-    semver: "npm:^7.7.3"
+    semver: "npm:^7.8.5"
   peerDependencies:
     prettier: ">=3.0.0"
-  checksum: 10/007fa19131366937465ec8ded6e1540264d07892f235c0679929ce08caf5f0081abf3be065984f7476071c3525d4fd67d02bc996a2a94e28c611fcd214fd16e4
+  checksum: 10/cdd944b00b91370c820747d72fa600fa033ff909cecc95a1d86bc26efcde9f9b31599b3ac879e5d5878222fb5b15fa2010532c8c490e30da770cc4086bc6c62a
   languageName: node
   linkType: hard
 
@@ -33957,12 +33957,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.8.1":
-  version: 3.8.1
-  resolution: "prettier@npm:3.8.1"
+"prettier@npm:3.9.6":
+  version: 3.9.6
+  resolution: "prettier@npm:3.9.6"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10/3da1cf8c1ef9bea828aa618553696c312e951f810bee368f6887109b203f18ee869fe88f66e65f9cf60b7cb1f2eae859892c860a300c062ff8ec69c381fc8dbd
+  checksum: 10/1dd1a1e0e40ec3b91cda9d294c4a95022aef61880ca3f441aad99b1252279f58a766c4cece81132c01550dcff1fd445efbd8812ea4a2374313e7fc6c8136f11f
   languageName: node
   linkType: hard
 
@@ -36254,8 +36254,8 @@ __metadata:
     jest: "npm:29.2.2"
     jest-serial-runner: "npm:1.2.1"
     lint-staged: "npm:13.3.0"
-    prettier: "npm:3.8.1"
-    prettier-plugin-solidity: "npm:2.2.1"
+    prettier: "npm:3.9.6"
+    prettier-plugin-solidity: "npm:2.4.1"
     ts-jest: "npm:29.1.2"
     ts-node: "npm:10.9.2"
     typescript: "npm:5.3.3"
@@ -36668,12 +36668,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.7.3":
-  version: 7.7.4
-  resolution: "semver@npm:7.7.4"
+"semver@npm:^7.8.5":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
   bin:
     semver: bin/semver.js
-  checksum: 10/26bdc6d58b29528f4142d29afb8526bc335f4fc04c4a10f2b98b217f277a031c66736bf82d3d3bb354a2f6a3ae50f18fd62b053c4ac3f294a3d10a61f5075b75
+  checksum: 10/9b01d2ff11e6e4a4539b7ca3c5f280c8704cb397a28504469f2ed4f00ad2194748d756647362a9712fff30984d15772ab7f083108c2fb508e2096ae9e708f22c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Publishes the protocol source deployed through EBIP-21:

- accounts for Unripe backing held in protected external custody while preserving holder claims;
- requires underlying paid out by Beanstalk to be locally available;
- allows the designated custodian to restore protected LP to Beanstalk;
- updates dependent locked-liquidity, BDV, Convert, Season and Gauge calculations; and
- hardens batch Enroot validation against zero-amount, nonexistent, duplicate and future-stem Deposit rows.

This is a post-deployment source synchronization. Merging this PR does not perform an additional on-chain upgrade.

Related to #1189.

## Accounting

Total Unripe backing is calculated as:

`balanceOfUnderlying + protectedUnderlying`

The EBIP-21 initializer reclassified LP from local backing to protected backing and transferred it to the designated custodian without changing total holder backing.

Chops and other underlying outflows continue to require sufficient locally held backing. The custodian can restore protected LP through `restoreProtectedUnderlying`.

## Enroot hardening

`enrootDeposits` now validates the full input batch before changing Silo accounting:

- `stems.length == amounts.length`;
- every amount is greater than zero;
- every supplied Deposit exists with a positive balance;
- stems are unique; and
- every stem is at or below the current stem tip.

Invalid zero-amount/positive-BDV Deposit writes are also rejected.

## Deployment artifacts

Generated Diamond-cut JSON and Safe transaction artifacts are intentionally excluded from this PR.

## Testing

- Hardhat compilation: 130 Solidity files compiled
- Hardhat: 69 passing
- Foundry: 7 passing
- Foundry fuzz: 256 runs
- `git diff --check`: clean