### PR TITLE
fix(ui): harden Basin swap route construction

### DIFF
--- a/projects/dex-ui/src/components/Swap/useSwapBuilder.tsx
+++ b/projects/dex-ui/src/components/Swap/useSwapBuilder.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useState } from "react";
 
-import { Token } from "@beanstalk/sdk";
+import type { Token } from "@beanstalk/sdk";
 import { SwapBuilder } from "@beanstalk/sdk-wells";
 
 import useSdk from "src/utils/sdk/useSdk";
 import { useWells } from "src/wells/useWells";
+
+const getTokenKey = (token: Token) => {
+  const address = token.address || `native:${token.symbol.toLowerCase()}`;
+  return `${token.chainId}:${address.toLowerCase()}`;
+};
 
 export const useSwapBuilder = () => {
   const sdk = useSdk();
@@ -14,27 +19,45 @@ export const useSwapBuilder = () => {
 
   useEffect(() => {
     if (!wells) return;
-    const tokenMap: Record<string, Token> = {};
-    const b = sdk.wells.swapBuilder;
+    let cancelled = false;
 
-    for (const well of wells) {
-      // only include wells with reserves
-      if (well.reserves?.[0]?.lte(0) || well.reserves?.[1]?.lte(0)) {
-        continue;
-      }
+    const loadBuilder = async () => {
+      const tokenMap: Record<string, Token> = {};
+      const wellAllowlist = new Set(sdk.pools.getWells().map((well) => well.address.toLowerCase()));
+      const b = new SwapBuilder(sdk.wells, wellAllowlist);
 
-      b.addWell(well);
-      setBuilder(b);
+      for (const well of wells) {
+        if (!wellAllowlist.has(well.address.toLowerCase())) {
+          continue;
+        }
 
-      for (const token of well?.tokens || []) {
-        if (!(token.symbol in tokenMap)) {
-          tokenMap[token.symbol] = token;
+        // only include wells with reserves
+        if (well.reserves?.[0]?.lte(0) || well.reserves?.[1]?.lte(0)) {
+          continue;
+        }
+
+        await b.addWell(well);
+
+        for (const token of well?.tokens || []) {
+          const key = getTokenKey(token);
+          if (!(key in tokenMap)) {
+            tokenMap[key] = token;
+          }
         }
       }
-    }
 
-    setTokens([...Object.values(tokenMap), sdk.tokens.ETH]);
-  }, [wells, sdk.wells.swapBuilder, sdk.signer, sdk.tokens.ETH]);
+      if (!cancelled) {
+        setBuilder(b);
+        setTokens([...Object.values(tokenMap), sdk.tokens.ETH]);
+      }
+    };
+
+    void loadBuilder();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [wells, sdk.pools, sdk.wells, sdk.signer, sdk.tokens.ETH]);
 
   return [builder, tokens] as const;
 };

--- a/projects/sdk-wells/src/lib/routing/Graph.ts
+++ b/projects/sdk-wells/src/lib/routing/Graph.ts
@@ -1,10 +1,9 @@
-import { Token } from "@beanstalk/sdk-core";
+import type { Token } from "@beanstalk/sdk-core";
 import { Graph as GraphLib, alg } from "graphlib";
-import { Well } from "../Well";
+import type { Well } from "../Well";
 
 export class Graph {
   graph: GraphLib;
-  private tokens: Set<Token> = new Set<Token>();
 
   constructor() {
     this.graph = new GraphLib({
@@ -14,22 +13,29 @@ export class Graph {
     });
   }
 
+  getTokenKey(token: Token) {
+    const address = token.address || `native:${token.symbol.toLowerCase()}`;
+    return `${token.chainId}:${address.toLowerCase()}`;
+  }
+
   addNode(token: Token) {
-    if (this.tokens.has(token)) return;
-    this.graph.setNode(token.symbol, { token });
-    this.tokens.add(token);
+    const key = this.getTokenKey(token);
+    if (this.graph.hasNode(key)) return;
+    this.graph.setNode(key, { token });
   }
 
   addEdge(tokenA: Token, tokenB: Token, well?: Well) {
-    this.graph.setEdge(tokenA.symbol, tokenB.symbol, {
+    this.graph.setEdge(this.getTokenKey(tokenA), this.getTokenKey(tokenB), {
       well,
       from: tokenA,
       to: tokenB
     });
   }
 
-  searchGraph(start: string, end: string): string[] {
+  searchGraph(startToken: Token, endToken: Token): string[] {
     const path: string[] = [];
+    const start = this.getTokenKey(startToken);
+    const end = this.getTokenKey(endToken);
     let res = alg.dijkstra(this.graph, start);
 
     // target not found

--- a/projects/sdk-wells/src/lib/routing/Route.ts
+++ b/projects/sdk-wells/src/lib/routing/Route.ts
@@ -1,5 +1,5 @@
-import { Token } from "@beanstalk/sdk-core";
-import { Well } from "../Well";
+import type { Token } from "@beanstalk/sdk-core";
+import type { Well } from "../Well";
 
 export type RouteLeg = {
   from: Token;

--- a/projects/sdk-wells/src/lib/routing/Router.test.ts
+++ b/projects/sdk-wells/src/lib/routing/Router.test.ts
@@ -1,0 +1,74 @@
+import type { Well } from "../Well";
+import type { WellsSDK } from "../WellsSDK";
+import { Router } from "./Router";
+
+type TestToken = {
+  chainId: number;
+  address: string;
+  symbol: string;
+  setSignerOrProvider: jest.Mock;
+  equals: (other: TestToken) => boolean;
+};
+
+const makeToken = (address: string, symbol: string): TestToken => {
+  const token = {
+    chainId: 1,
+    address: address.toLowerCase(),
+    symbol,
+    setSignerOrProvider: jest.fn(),
+    equals(other: TestToken) {
+      return this.chainId === other.chainId && this.address === other.address;
+    }
+  };
+  return token;
+};
+
+const makeWell = (address: string, tokens: TestToken[]) =>
+  ({
+    address,
+    getTokens: jest.fn().mockResolvedValue(tokens)
+  }) as unknown as Well;
+
+describe("Router", () => {
+  it("does not replace an allowlisted route with a later unlisted Well using the same tokens", async () => {
+    const bean = makeToken("0x0000000000000000000000000000000000000001", "BEAN");
+    const weth = makeToken("0x0000000000000000000000000000000000000002", "WETH");
+    const trustedWell = makeWell("0x0000000000000000000000000000000000000010", [bean, weth]);
+    const unlistedWell = makeWell("0x0000000000000000000000000000000000000011", [bean, weth]);
+    const sdk = {
+      providerOrSigner: {},
+      tokens: {
+        ETH: makeToken("", "ETH"),
+        WETH: weth
+      }
+    } as unknown as WellsSDK;
+    const router = new Router(sdk, [trustedWell.address]);
+
+    await router.addWell(trustedWell);
+    await router.addWell(unlistedWell);
+    const route = router.getRoute(bean as any, weth as any);
+
+    expect(route.length).toBe(1);
+    expect(route.getStep(0).well.address).toBe(trustedWell.address);
+  });
+
+  it("does not route through a token that only matches the destination symbol", async () => {
+    const bean = makeToken("0x0000000000000000000000000000000000000001", "BEAN");
+    const realWeth = makeToken("0x0000000000000000000000000000000000000002", "WETH");
+    const fakeWeth = makeToken("0x0000000000000000000000000000000000000003", "WETH");
+    const well = makeWell("0x0000000000000000000000000000000000000010", [bean, fakeWeth]);
+    const sdk = {
+      providerOrSigner: {},
+      tokens: {
+        ETH: makeToken("", "ETH"),
+        WETH: realWeth
+      }
+    } as unknown as WellsSDK;
+    const router = new Router(sdk);
+
+    await router.addWell(well);
+    const route = router.getRoute(bean as any, realWeth as any);
+
+    expect(route.length).toBe(0);
+  });
+});

--- a/projects/sdk-wells/src/lib/routing/Router.ts
+++ b/projects/sdk-wells/src/lib/routing/Router.ts
@@ -1,20 +1,25 @@
-import { Token } from "@beanstalk/sdk-core";
-import { Well } from "../Well";
+import type { Token } from "@beanstalk/sdk-core";
+import type { Well } from "../Well";
 import { Graph } from "./Graph";
 import { Route } from "./Route";
-import { WellsSDK } from "../WellsSDK";
+import type { WellsSDK } from "../WellsSDK";
 
 export class Router {
   private sdk: WellsSDK;
+  private readonly wellAllowlist?: Set<string>;
   public wells = new Set<Well>();
   public graph: Graph;
 
-  constructor(sdk: WellsSDK) {
+  constructor(sdk: WellsSDK, wellAllowlist?: Iterable<string>) {
     this.sdk = sdk;
+    this.wellAllowlist = wellAllowlist
+      ? new Set([...wellAllowlist].map((address) => address.toLowerCase()))
+      : undefined;
     this.graph = new Graph();
   }
 
   async addWell(well: Well) {
+    if (this.wellAllowlist && !this.wellAllowlist.has(well.address.toLowerCase())) return;
     if (this.wells.has(well)) return;
 
     const tokens = await well.getTokens();
@@ -28,7 +33,7 @@ export class Router {
     for (const token of tokens) {
       token.setSignerOrProvider(this.sdk.providerOrSigner);
       this.graph.addNode(token);
-      if (token.symbol === "WETH") WETH = token;
+      if (this.sdk.tokens.WETH && token.equals(this.sdk.tokens.WETH)) WETH = token;
     }
     // Add ETH
     const ETH = this.sdk.tokens.ETH;
@@ -57,7 +62,7 @@ export class Router {
   getRoute(fromToken: Token, toToken: Token) {
     const route = new Route();
 
-    let path = this.graph.searchGraph(fromToken.symbol, toToken.symbol);
+    let path = this.graph.searchGraph(fromToken, toToken);
     /**
      * At this point, path is an array of strings, for ex:
      * [ 'A', 'B', 'C', 'D' ]
@@ -90,7 +95,9 @@ export class Router {
       const edge = this.graph.graph.edge(e.v, e.w);
       const label = edge.label;
       const labelString = label ? ` [label="${label}"]` : "";
-      code += `\t"${e.v}" -> "${e.w}"${labelString}\n`;
+      const from = this.graph.graph.node(e.v)?.token?.symbol ?? e.v;
+      const to = this.graph.graph.node(e.w)?.token?.symbol ?? e.w;
+      code += `\t"${from}" -> "${to}"${labelString}\n`;
     });
     code += "}";
 

--- a/projects/sdk-wells/src/lib/swap/SwapBuilder.ts
+++ b/projects/sdk-wells/src/lib/swap/SwapBuilder.ts
@@ -8,9 +8,9 @@ export class SwapBuilder {
   private readonly sdk: WellsSDK;
   router: Router;
 
-  constructor(sdk: WellsSDK) {
+  constructor(sdk: WellsSDK, wellAllowlist?: Iterable<string>) {
     this.sdk = sdk;
-    this.router = new Router(sdk);
+    this.router = new Router(sdk, wellAllowlist);
   }
 
   async addWell(well: Well) {


### PR DESCRIPTION
## Summary

- build generic swap routes only from canonical Wells in the SDK pool registry
- identify routed assets by chain ID and address, including canonical WETH matching
- rebuild the swap graph per load and cover duplicate-pair and same-symbol routing cases

## Testing

- `yarn sdk-wells:test Router.test.ts`
- `yarn workspace @beanstalk/sdk-wells build`
- `yarn workspace dex-ui tsc --noEmit`
- `yarn workspace dex-ui eslint src/components/Swap/useSwapBuilder.tsx`
- targeted Prettier check for all six changed files
- `git diff --check origin/master...HEAD`

## Notes

The legacy SDK Wells integration suite could not complete because its repository-pinned Alchemy endpoint rejected the required local Anvil fork with HTTP 403 (`Unspecified origin not on whitelist`).