### PR TITLE
fix(ci): remove hardcoded Alchemy keys

### DIFF
--- a/.github/workflows/ci.protocol.yaml
+++ b/.github/workflows/ci.protocol.yaml
@@ -63,5 +63,5 @@ jobs:
       - name: Run tests
         run: yarn test
         env:
-          FORKING_RPC: ${{ secrets.ANVIL_FORK_URL }}
+          FORKING_RPC: ${{ secrets.ANVIL_ETHEREUM_FORK_URL }}
         working-directory: protocol

--- a/.github/workflows/ci.sdk-core.yaml
+++ b/.github/workflows/ci.sdk-core.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           version: nightly
       - name: Launch Anvil
-        run: anvil --fork-url $ANVIL_ETHEREUM_FORK_URL --chain-id 1337 &
+        run: bash scripts/start-anvil-ci.sh anvil --fork-url $ANVIL_ETHEREUM_FORK_URL --chain-id 1337
         env:
           ANVIL_ETHEREUM_FORK_URL: ${{ secrets.ANVIL_ETHEREUM_FORK_URL }}
       - name: Build All

--- a/.github/workflows/ci.sdk-core.yaml
+++ b/.github/workflows/ci.sdk-core.yaml
@@ -31,9 +31,9 @@ jobs:
         with:
           version: nightly
       - name: Launch Anvil
-        run: anvil --fork-url $ANVIL_FORK_URL --chain-id 1337 &
+        run: anvil --fork-url $ANVIL_ETHEREUM_FORK_URL --chain-id 1337 &
         env:
-          ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
+          ANVIL_ETHEREUM_FORK_URL: ${{ secrets.ANVIL_ETHEREUM_FORK_URL }}
       - name: Build All
         run: yarn build
       - name: Test SDK Core

--- a/.github/workflows/ci.sdk-wells.yaml
+++ b/.github/workflows/ci.sdk-wells.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           version: nightly
       - name: Launch Anvil
-        run: anvil --fork-url $ANVIL_ETHEREUM_FORK_URL --chain-id 1337 &
+        run: bash scripts/start-anvil-ci.sh anvil --fork-url $ANVIL_ETHEREUM_FORK_URL --chain-id 1337
         env:
           ANVIL_ETHEREUM_FORK_URL: ${{ secrets.ANVIL_ETHEREUM_FORK_URL }}
       - name: Build All

--- a/.github/workflows/ci.sdk-wells.yaml
+++ b/.github/workflows/ci.sdk-wells.yaml
@@ -33,11 +33,13 @@ jobs:
         with:
           version: nightly
       - name: Launch Anvil
-        run: anvil --fork-url $ANVIL_FORK_URL --chain-id 1337 &
+        run: anvil --fork-url $ANVIL_ETHEREUM_FORK_URL --chain-id 1337 &
         env:
-          ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
+          ANVIL_ETHEREUM_FORK_URL: ${{ secrets.ANVIL_ETHEREUM_FORK_URL }}
       - name: Build All
         run: yarn build
       - name: Run Tests
         run: yarn sdk-wells:test
+        env:
+          ANVIL_ETHEREUM_FORK_URL: ${{ secrets.ANVIL_ETHEREUM_FORK_URL }}
         working-directory: projects/sdk-wells

--- a/.github/workflows/ci.sdk.yaml
+++ b/.github/workflows/ci.sdk.yaml
@@ -32,7 +32,7 @@ jobs:
           version: nightly
       # TODO: Cache Anvil RPC calls between runs to speed up tests
       - name: Launch Anvil
-        run: yarn anvil4tests &
+        run: bash scripts/start-anvil-ci.sh yarn anvil4tests
         env:
           ANVIL_ARBITRUM_FORK_URL: ${{ secrets.ANVIL_ARBITRUM_FORK_URL }}
       - name: Build All

--- a/.github/workflows/ci.sdk.yaml
+++ b/.github/workflows/ci.sdk.yaml
@@ -33,7 +33,11 @@ jobs:
       # TODO: Cache Anvil RPC calls between runs to speed up tests
       - name: Launch Anvil
         run: yarn anvil4tests &
+        env:
+          ANVIL_ARBITRUM_FORK_URL: ${{ secrets.ANVIL_ARBITRUM_FORK_URL }}
       - name: Build All
         run: yarn build
       - run: yarn sdk:test
+        env:
+          ANVIL_ETHEREUM_FORK_URL: ${{ secrets.ANVIL_ETHEREUM_FORK_URL }}
         working-directory: projects/sdk

--- a/.github/workflows/ci.security.yaml
+++ b/.github/workflows/ci.security.yaml
@@ -1,0 +1,22 @@
+name: Credential Scan
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  alchemy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - name: Test credential scanner
+        run: node --test scripts/check-no-hardcoded-alchemy-keys.test.mjs
+      - name: Scan tracked files
+        run: node scripts/check-no-hardcoded-alchemy-keys.mjs

--- a/.github/workflows/main.off
+++ b/.github/workflows/main.off
@@ -62,9 +62,9 @@ jobs:
       
       # TODO: Cache Anvil RPC calls between runs to speed up tests
       - name: Launch Anvil
-        run: anvil --fork-url $ANVIL_FORK_URL --fork-block-number $ANVIL_BLOCK_NUMBER &
+        run: anvil --fork-url $ANVIL_ETHEREUM_FORK_URL --fork-block-number $ANVIL_BLOCK_NUMBER &
         env:
-          ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
+          ANVIL_ETHEREUM_FORK_URL: ${{ secrets.ANVIL_ETHEREUM_FORK_URL }}
           ANVIL_BLOCK_NUMBER: 15578840
 
       - name: Test

--- a/.github/workflows/main.off
+++ b/.github/workflows/main.off
@@ -62,7 +62,7 @@ jobs:
       
       # TODO: Cache Anvil RPC calls between runs to speed up tests
       - name: Launch Anvil
-        run: anvil --fork-url $ANVIL_ETHEREUM_FORK_URL --fork-block-number $ANVIL_BLOCK_NUMBER &
+        run: bash scripts/start-anvil-ci.sh anvil --fork-url $ANVIL_ETHEREUM_FORK_URL --fork-block-number $ANVIL_BLOCK_NUMBER
         env:
           ANVIL_ETHEREUM_FORK_URL: ${{ secrets.ANVIL_ETHEREUM_FORK_URL }}
           ANVIL_BLOCK_NUMBER: 15578840

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "all:build": "yarn build",
     "test": "yarn sdk:test",
     "format": "yarn sdk:prettier",
+    "security:check-alchemy": "node scripts/check-no-hardcoded-alchemy-keys.mjs",
     "protocol:generate": "yarn workspace @beanstalk/protocol generate",
     "jest:clearcache": "jest --clearCache",
     "sdk:generate": "yarn workspace @beanstalk/sdk generate",
@@ -54,8 +55,8 @@
     "ex": "yarn workspace @beanstalk/examples x",
     "anvil-arbitrum": "yarn cli:anvil-arbitrum",
     "anvil-eth-mainnet": "yarn cli:anvil-eth-mainnet",
-    "anvil": "anvil --fork-url https://arb-mainnet.g.alchemy.com/v2/5ubn94zT7v7DnB5bNW1VOnoIbX5-AG2N --chain-id 1337",
-    "anvil4tests": "anvil --fork-url https://arb-mainnet.g.alchemy.com/v2/Kk7ktCQL5wz4v4AG8bR2Gun8TAASQ-qi  --chain-id 1337 --fork-block-number 18629000"
+    "anvil": "anvil --fork-url $ANVIL_ARBITRUM_FORK_URL --chain-id 1337",
+    "anvil4tests": "anvil --fork-url $ANVIL_ARBITRUM_FORK_URL --chain-id 1337 --fork-block-number 18629000"
   },
   "dependencies": {
     "prettier-plugin-solidity": "2.4.1"

--- a/projects/sdk-wells/test/TestUtils/BlockchainUtils.env.test.ts
+++ b/projects/sdk-wells/test/TestUtils/BlockchainUtils.env.test.ts
@@ -1,0 +1,48 @@
+import { WellsSDK } from "../../src/lib/WellsSDK";
+import { BlockchainUtils } from "./BlockchainUtils";
+
+describe("BlockchainUtils fork configuration", () => {
+  const originalForkUrl = process.env.ANVIL_ETHEREUM_FORK_URL;
+
+  afterEach(() => {
+    if (originalForkUrl === undefined) {
+      delete process.env.ANVIL_ETHEREUM_FORK_URL;
+    } else {
+      process.env.ANVIL_ETHEREUM_FORK_URL = originalForkUrl;
+    }
+  });
+
+  const makeUtils = () => {
+    let receivedForkUrl: string | undefined;
+    const provider = {
+      send: jest.fn(
+        async (_method: string, params: Array<{ forking?: { jsonRpcUrl?: string } }>) => {
+          receivedForkUrl = params[0]?.forking?.jsonRpcUrl;
+        }
+      )
+    };
+    const sdk = { provider } as unknown as WellsSDK;
+
+    return {
+      getReceivedForkUrl: () => receivedForkUrl,
+      utils: new BlockchainUtils(sdk)
+    };
+  };
+
+  it("refuses to reset when ANVIL_ETHEREUM_FORK_URL is missing", async () => {
+    delete process.env.ANVIL_ETHEREUM_FORK_URL;
+    const { utils } = makeUtils();
+
+    await expect(utils.resetFork()).rejects.toThrow("ANVIL_ETHEREUM_FORK_URL is required");
+  });
+
+  it("uses the runtime-provided Ethereum fork URL", async () => {
+    const expectedForkUrl = "https://eth-mainnet.g.alchemy.com/v2/test-runtime-key";
+    process.env.ANVIL_ETHEREUM_FORK_URL = expectedForkUrl;
+    const { getReceivedForkUrl, utils } = makeUtils();
+
+    await utils.resetFork();
+
+    expect(getReceivedForkUrl() === expectedForkUrl).toBe(true);
+  });
+});

--- a/projects/sdk-wells/test/TestUtils/BlockchainUtils.ts
+++ b/projects/sdk-wells/test/TestUtils/BlockchainUtils.ts
@@ -12,10 +12,15 @@ export class BlockchainUtils {
   }
 
   async resetFork() {
+    const jsonRpcUrl = process.env.ANVIL_ETHEREUM_FORK_URL;
+    if (!jsonRpcUrl) {
+      throw new Error("ANVIL_ETHEREUM_FORK_URL is required to reset the fork");
+    }
+
     await this.sdk.provider.send("anvil_reset", [
       {
         forking: {
-          jsonRpcUrl: "https://eth-mainnet.g.alchemy.com/v2/f6piiDvMBMGRYvCOwLJFMD7cUjIvI1TP"
+          jsonRpcUrl
         }
       }
     ]);
@@ -96,7 +101,11 @@ export class BlockchainUtils {
     if (isTokenReverse) values.reverse();
 
     const index = ethers.utils.solidityKeccak256(["uint256", "uint256"], values);
-    await this.setStorageAt(_token.address, index.toString(), this.toBytes32(balanceAmount).toString());
+    await this.setStorageAt(
+      _token.address,
+      index.toString(),
+      this.toBytes32(balanceAmount).toString()
+    );
   }
 
   private async setStorageAt(address: string, index: string, value: string) {

--- a/projects/sdk/src/utils/TestUtils/BlockchainUtils.env.test.ts
+++ b/projects/sdk/src/utils/TestUtils/BlockchainUtils.env.test.ts
@@ -1,0 +1,48 @@
+import { BeanstalkSDK } from "src/lib/BeanstalkSDK";
+import { BlockchainUtils } from "./BlockchainUtils";
+
+describe("BlockchainUtils fork configuration", () => {
+  const originalForkUrl = process.env.ANVIL_ETHEREUM_FORK_URL;
+
+  afterEach(() => {
+    if (originalForkUrl === undefined) {
+      delete process.env.ANVIL_ETHEREUM_FORK_URL;
+    } else {
+      process.env.ANVIL_ETHEREUM_FORK_URL = originalForkUrl;
+    }
+  });
+
+  const makeUtils = () => {
+    let receivedForkUrl: string | undefined;
+    const provider = {
+      send: jest.fn(
+        async (_method: string, params: Array<{ forking?: { jsonRpcUrl?: string } }>) => {
+          receivedForkUrl = params[0]?.forking?.jsonRpcUrl;
+        }
+      )
+    };
+    const sdk = { provider } as unknown as BeanstalkSDK;
+
+    return {
+      getReceivedForkUrl: () => receivedForkUrl,
+      utils: new BlockchainUtils(sdk)
+    };
+  };
+
+  it("refuses to reset when ANVIL_ETHEREUM_FORK_URL is missing", async () => {
+    delete process.env.ANVIL_ETHEREUM_FORK_URL;
+    const { utils } = makeUtils();
+
+    await expect(utils.resetFork()).rejects.toThrow("ANVIL_ETHEREUM_FORK_URL is required");
+  });
+
+  it("uses the runtime-provided Ethereum fork URL", async () => {
+    const expectedForkUrl = "https://eth-mainnet.g.alchemy.com/v2/test-runtime-key";
+    process.env.ANVIL_ETHEREUM_FORK_URL = expectedForkUrl;
+    const { getReceivedForkUrl, utils } = makeUtils();
+
+    await utils.resetFork();
+
+    expect(getReceivedForkUrl() === expectedForkUrl).toBe(true);
+  });
+});

--- a/projects/sdk/src/utils/TestUtils/BlockchainUtils.ts
+++ b/projects/sdk/src/utils/TestUtils/BlockchainUtils.ts
@@ -85,10 +85,15 @@ export class BlockchainUtils {
   }
 
   async resetFork() {
+    const jsonRpcUrl = process.env.ANVIL_ETHEREUM_FORK_URL;
+    if (!jsonRpcUrl) {
+      throw new Error("ANVIL_ETHEREUM_FORK_URL is required to reset the fork");
+    }
+
     await this.sdk.provider.send("anvil_reset", [
       {
         forking: {
-          jsonRpcUrl: "https://eth-mainnet.g.alchemy.com/v2/f6piiDvMBMGRYvCOwLJFMD7cUjIvI1TP"
+          jsonRpcUrl
         }
       }
     ]);

--- a/projects/ui/.env.development
+++ b/projects/ui/.env.development
@@ -4,7 +4,7 @@
 # @note this Alchemy key will only work with the above domain.
 # -----------------------
 VITE_SHOW_DEV_CHAINS=true
-VITE_ALCHEMY_API_KEY="ds4ljBC_Pq-PaIQ3aHo04t27y2n8qpry"
+VITE_ALCHEMY_API_KEY=
 VITE_THEGRAPH_API_KEY="4c0b9364a121c1f2aa96fe61cb73d705"
 VITE_WALLETCONNECT_PROJECT_ID=2159ea7542f2b547554f8c85eca0cec1
 VITE_SNAPSHOT_API_KEY="83b2ba4f5e943503dad56d4afea4a5205ace935d702cb8c0a1151c995b474f59"

--- a/projects/ui/.env.production
+++ b/projects/ui/.env.production
@@ -3,7 +3,7 @@
 # Prod environment: app.bean.money
 # @note this Alchemy key will only work with the above domain.
 # -----------------------
-VITE_ALCHEMY_API_KEY="iByabvqm_66b_Bkl9M-wJJGdCTuy19R3"
+VITE_ALCHEMY_API_KEY=
 VITE_THEGRAPH_API_KEY="4c0b9364a121c1f2aa96fe61cb73d705"
 VITE_SNAPSHOT_API_KEY="83b2ba4f5e943503dad56d4afea4a5205ace935d702cb8c0a1151c995b474f59"
 VITE_ZERO_X_API_KEY=""

--- a/scripts/check-no-hardcoded-alchemy-keys.mjs
+++ b/scripts/check-no-hardcoded-alchemy-keys.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { lstatSync, readFileSync, readdirSync } from "node:fs";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
+
+const SKIPPED_DIRECTORIES = new Set([".git", ".yarn", "node_modules"]);
+const PATTERNS = [
+  /(?:https?:\/\/)?(?:[a-z0-9-]+\.)?alchemy(?:api)?\.(?:com|io)\/v2\/[A-Za-z0-9_-]{20,}/gi,
+  /^[ \t]*[A-Z0-9_]*ALCHEMY[A-Z0-9_]*KEY[ \t]*=[ \t]*["']?[A-Za-z0-9_-]{20,}/gim
+];
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8"
+}).trim();
+
+function collectFiles(path) {
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink()) return [];
+  if (stat.isFile()) return [path];
+  if (!stat.isDirectory() || SKIPPED_DIRECTORIES.has(basename(path))) return [];
+
+  return readdirSync(path, { withFileTypes: true }).flatMap((entry) =>
+    collectFiles(join(path, entry.name))
+  );
+}
+
+function isRegularFile(path) {
+  try {
+    return lstatSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function trackedFiles() {
+  return execFileSync("git", ["-C", repoRoot, "ls-files", "-z"], {
+    encoding: "utf8"
+  })
+    .split("\0")
+    .filter(Boolean)
+    .map((path) => join(repoRoot, path))
+    .filter(isRegularFile);
+}
+
+function lineNumberAt(content, index) {
+  return content.slice(0, index).split("\n").length;
+}
+
+function scan(path) {
+  const content = readFileSync(path, "utf8");
+  if (content.includes("\0")) return [];
+
+  const lines = new Set();
+  for (const pattern of PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of content.matchAll(pattern)) {
+      lines.add(lineNumberAt(content, match.index));
+    }
+  }
+
+  return [...lines].sort((a, b) => a - b);
+}
+
+const requestedPaths = process.argv.slice(2);
+const files = requestedPaths.length
+  ? requestedPaths.flatMap((path) => collectFiles(isAbsolute(path) ? path : resolve(path)))
+  : trackedFiles();
+
+const findings = files.flatMap((path) =>
+  scan(path).map((line) => ({
+    line,
+    path: relative(requestedPaths.length ? process.cwd() : repoRoot, path)
+  }))
+);
+
+if (findings.length) {
+  for (const finding of findings) {
+    console.error(`${finding.path}:${finding.line}: hardcoded Alchemy credential`);
+  }
+  process.exitCode = 1;
+}

--- a/scripts/check-no-hardcoded-alchemy-keys.test.mjs
+++ b/scripts/check-no-hardcoded-alchemy-keys.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { after, before, test } from "node:test";
+
+const scriptPath = new URL("./check-no-hardcoded-alchemy-keys.mjs", import.meta.url);
+let fixtureRoot;
+let trackedDirectoryRepo;
+
+before(() => {
+  fixtureRoot = mkdtempSync(join(tmpdir(), "beanstalk-alchemy-scan-"));
+  mkdirSync(join(fixtureRoot, "clean"));
+  mkdirSync(join(fixtureRoot, "leaked"));
+  const leakedUrl = [
+    "https://eth-mainnet.g.alchemy.com/v2/",
+    "abcdefghijklmnopqrstuvwxyz123456"
+  ].join("");
+  writeFileSync(
+    join(fixtureRoot, "clean", "config.ts"),
+    "const url = `https://eth-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;\n"
+  );
+  writeFileSync(
+    join(fixtureRoot, "clean", ".env.production"),
+    "VITE_ALCHEMY_API_KEY=\nVITE_THEGRAPH_API_KEY=abcdefghijklmnopqrstuvwxyz123456\n"
+  );
+  writeFileSync(join(fixtureRoot, "leaked", "config.ts"), `const url = '${leakedUrl}';\n`);
+  writeFileSync(
+    join(fixtureRoot, "leaked", ".env.production"),
+    "VITE_ALCHEMY_API_KEY=zyxwvutsrqponmlkjihgfedcba654321\n"
+  );
+
+  trackedDirectoryRepo = join(fixtureRoot, "tracked-directory-repo");
+  mkdirSync(trackedDirectoryRepo);
+  spawnSync("git", ["init", "--quiet"], { cwd: trackedDirectoryRepo });
+  const trackedPath = join(trackedDirectoryRepo, "external");
+  writeFileSync(trackedPath, "tracked as a file\n");
+  spawnSync("git", ["add", "external"], { cwd: trackedDirectoryRepo });
+  rmSync(trackedPath);
+  mkdirSync(trackedPath);
+});
+
+after(() => {
+  rmSync(fixtureRoot, { force: true, recursive: true });
+});
+
+test("accepts runtime-provided Alchemy credentials", () => {
+  const result = spawnSync(process.execPath, [scriptPath.pathname, join(fixtureRoot, "clean")], {
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("reports a hardcoded credential without printing its value", () => {
+  const result = spawnSync(process.execPath, [scriptPath.pathname, join(fixtureRoot, "leaked")], {
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /config\.ts:1: hardcoded Alchemy credential/);
+  assert.match(result.stderr, /\.env\.production:1: hardcoded Alchemy credential/);
+  assert.doesNotMatch(result.stderr, /abcdefghijklmnopqrstuvwxyz123456/);
+  assert.doesNotMatch(result.stderr, /zyxwvutsrqponmlkjihgfedcba654321/);
+});
+
+test("skips indexed paths that are directories in the working tree", () => {
+  const result = spawnSync(process.execPath, [scriptPath.pathname], {
+    cwd: trackedDirectoryRepo,
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+});

--- a/scripts/start-anvil-ci.sh
+++ b/scripts/start-anvil-ci.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -u
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 <anvil command> [arguments...]" >&2
+  exit 2
+fi
+
+healthcheck_url="${ANVIL_HEALTHCHECK_URL:-http://127.0.0.1:8545}"
+startup_attempts="${ANVIL_STARTUP_ATTEMPTS:-30}"
+startup_interval="${ANVIL_STARTUP_INTERVAL:-1}"
+log_directory="${RUNNER_TEMP:-/tmp}"
+log_file="$(mktemp "${log_directory}/beanstalk-anvil.XXXXXX.log")"
+
+"$@" >"${log_file}" 2>&1 &
+anvil_pid=$!
+
+for ((attempt = 1; attempt <= startup_attempts; attempt++)); do
+  if curl --silent --show-error --fail \
+    --header "content-type: application/json" \
+    --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' \
+    "${healthcheck_url}" >/dev/null; then
+    echo "Anvil is ready at ${healthcheck_url}."
+    exit 0
+  fi
+
+  process_state="$(ps -o stat= -p "${anvil_pid}" 2>/dev/null || true)"
+  process_state="${process_state#"${process_state%%[![:space:]]*}"}"
+  if [[ -z "${process_state}" || "${process_state}" == Z* ]]; then
+    wait "${anvil_pid}"
+    launch_status=$?
+    cat "${log_file}" >&2
+    if [[ ${launch_status} -eq 0 ]]; then
+      launch_status=1
+    fi
+    exit "${launch_status}"
+  fi
+
+  sleep "${startup_interval}"
+done
+
+echo "Anvil did not become ready at ${healthcheck_url} after ${startup_attempts} attempts." >&2
+cat "${log_file}" >&2
+kill "${anvil_pid}" 2>/dev/null || true
+exit 1

--- a/scripts/start-anvil-ci.test.mjs
+++ b/scripts/start-anvil-ci.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+const helper = path.join(import.meta.dirname, "start-anvil-ci.sh");
+
+function runHelper(args, env) {
+  return new Promise((resolve) => {
+    const child = spawn("/bin/bash", [helper, ...args], {
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("surfaces the launch process error when Anvil exits before becoming ready", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "anvil-ci-failure-"));
+  const command = path.join(directory, "fail.sh");
+  await writeFile(command, "#!/bin/bash\necho 'synthetic launch failure' >&2\nexit 23\n", {
+    mode: 0o755
+  });
+
+  try {
+    const result = await runHelper([command], {
+      ANVIL_HEALTHCHECK_URL: "http://127.0.0.1:1",
+      ANVIL_STARTUP_ATTEMPTS: "3",
+      ANVIL_STARTUP_INTERVAL: "0.01",
+      RUNNER_TEMP: directory
+    });
+
+    assert.equal(result.code, 23, JSON.stringify(result));
+    assert.match(result.stderr, /synthetic launch failure/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("returns success only after the JSON-RPC endpoint responds", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "anvil-ci-success-"));
+  const command = path.join(directory, "stay-alive.sh");
+  const curl = path.join(directory, "curl");
+  const pidFile = path.join(directory, "pid");
+  await writeFile(
+    command,
+    "#!/bin/bash\necho $$ > \"$ANVIL_TEST_PID_FILE\"\ntrap 'exit 0' TERM INT\nwhile true; do sleep 1; done\n",
+    { mode: 0o755 }
+  );
+  await writeFile(curl, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+
+  try {
+    const result = await runHelper([command], {
+      ANVIL_HEALTHCHECK_URL: "http://127.0.0.1:8545",
+      ANVIL_STARTUP_ATTEMPTS: "3",
+      ANVIL_STARTUP_INTERVAL: "0.01",
+      ANVIL_TEST_PID_FILE: pidFile,
+      PATH: `${directory}:${process.env.PATH}`,
+      RUNNER_TEMP: directory
+    });
+
+    assert.equal(result.code, 0, result.stderr);
+  } finally {
+    try {
+      const pid = Number((await readFile(pidFile, "utf8")).trim());
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // The assertion output is more useful than a cleanup failure.
+    }
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- remove committed Alchemy credentials from package scripts, SDK test helpers, and UI environment files
- inject network-specific fork URLs through GitHub Actions secrets and fail closed when runtime configuration is missing
- add a tracked-file credential scanner, dedicated security workflow, and regression coverage

## Verification
- focused SDK tests: 2 passed
- focused SDK Wells tests: 2 passed
- credential scanner tests: 3 passed
- TypeScript checks passed for SDK and SDK Wells
- Prettier, workflow YAML validation, package JSON validation, git diff checks, and tracked-tree credential scan passed

## Deployment notes
- ANVIL_ARBITRUM_FORK_URL and ANVIL_ETHEREUM_FORK_URL are configured as encrypted repository secrets
- VITE_ALCHEMY_API_KEY is configured as a masked, Builds-only Netlify variable for app.bean.money
- rotate the affected provider keys only after this change is merged and the UI deploy succeeds